### PR TITLE
fix: Mobile file tree appearing under header

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -37,7 +37,7 @@
 /* Ensure all content sits above background */
 .app > * {
   position: relative;
-  z-index: 1;
+  z-index: auto;
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary
- Fixed mobile file tree panel (`browse-mode__mobile-tree`) appearing behind the sticky header
- Root cause: `z-index: 1` on `.app > *` created a stacking context that limited the mobile tree's z-index
- Changed to `z-index: auto` to allow proper z-index stacking across sibling elements

## Test plan
- [ ] Open app on mobile (or narrow browser window)
- [ ] Switch to Browse mode
- [ ] Tap the menu button to open the file tree panel
- [ ] Verify the panel appears above the header, not behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)