### PR TITLE
fix: Pin header to top with independently scrolling content areas

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -8,9 +8,9 @@
 .app {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  min-height: 100dvh;
-  overflow-x: hidden;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
   background-color: var(--color-background);
   position: relative;
 }

--- a/frontend/src/components/NoteCapture.css
+++ b/frontend/src/components/NoteCapture.css
@@ -9,6 +9,7 @@
   flex-direction: column;
   height: 100%;
   padding: var(--spacing-md);
+  overflow-y: auto;
 }
 
 .note-capture__form {


### PR DESCRIPTION
## Summary
- Changed app container from `min-height: 100vh` to `height: 100vh` with `overflow: hidden`
- Header now stays fixed at the top of the viewport
- Each mode (Note/Chat/View) scrolls independently within its container

## Test plan
- [ ] Verify header stays visible when scrolling in Chat mode with many messages
- [ ] Verify Note mode scrolls when recent notes extend beyond viewport
- [ ] Verify View mode tree and content scroll independently
- [ ] Test on mobile viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)