### PR TITLE
refactor: Unify markdown rendering on react-markdown

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,6 @@
   },
   "dependencies": {
     "@memory-loop/shared": "workspace:*",
-    "dompurify": "^3.3.1",
-    "marked": "^17.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
@@ -24,7 +22,6 @@
     "@happy-dom/global-registrator": "^20.0.11",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.1",
-    "@types/dompurify": "^3.2.0",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-react": "^4.3.4",

--- a/frontend/src/components/__tests__/MarkdownViewer.test.tsx
+++ b/frontend/src/components/__tests__/MarkdownViewer.test.tsx
@@ -375,6 +375,7 @@ describe("MarkdownViewer", () => {
     });
 
     it("sanitizes onclick handlers", () => {
+      // react-markdown escapes raw HTML by default, so the anchor won't render as HTML
       const content = '<a href="#" onclick="alert(\'xss\')">Click</a>';
       const { container } = render(<MarkdownViewer />, {
         wrapper: createTestWrapper({
@@ -383,8 +384,10 @@ describe("MarkdownViewer", () => {
         }),
       });
 
+      // Either no anchor exists (raw HTML escaped) or it has no onclick
       const link = container.querySelector("a");
-      expect(link?.getAttribute("onclick")).toBeNull();
+      const hasNoOnclick = !link || link.getAttribute("onclick") === null;
+      expect(hasNoOnclick).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replace `marked` + `DOMPurify` with `react-markdown` in MarkdownViewer
- Reduces bundle size by removing 2 dependencies
- Ensures consistent rendering between MessageBubble and MarkdownViewer

## Changes

- Rewrite MarkdownViewer to use react-markdown with custom components
- Preserve wiki-link, external link, and image asset handling
- Remove marked, dompurify, and @types/dompurify dependencies
- Update XSS test to match react-markdown's escaping behavior

## Test plan

- [x] All 21 MarkdownViewer tests pass
- [x] Full test suite passes (339 tests)
- [x] Typecheck passes
- [x] Lint passes
- [x] Build succeeds

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)