### PR TITLE
feat: Add vault change button to return to vault selection

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -103,12 +103,46 @@
   }
 }
 
-.app-vault-name {
+.app-vault-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin-top: var(--spacing-xs);
   font-size: var(--text-xs);
   color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.2s ease;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  max-width: 100%;
+}
+
+.app-vault-btn::before {
+  content: "\2190";
+  font-size: var(--text-sm);
+  opacity: 0;
+  margin-left: -1em;
+  transition: all 0.2s ease;
+}
+
+.app-vault-btn:hover {
+  color: var(--color-text);
+  border-color: var(--color-border);
+  background-color: var(--color-bg-secondary);
+}
+
+.app-vault-btn:hover::before {
+  opacity: 1;
+  margin-left: 0;
+}
+
+.app-vault-btn:active {
+  transform: scale(0.98);
 }
 
 .app-header__center {

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -80,6 +80,8 @@ export interface SessionState {
 export interface SessionActions {
   /** Select a vault */
   selectVault: (vault: VaultInfo) => void;
+  /** Clear the current vault (return to vault selection) */
+  clearVault: () => void;
   /** Set the session ID */
   setSessionId: (sessionId: string) => void;
   /** Set the application mode */
@@ -134,6 +136,7 @@ const STORAGE_KEY_BROWSER_PATH = "memory-loop:browserPath";
  */
 type SessionAction =
   | { type: "SELECT_VAULT"; vault: VaultInfo }
+  | { type: "CLEAR_VAULT" }
   | { type: "SET_SESSION_ID"; sessionId: string }
   | { type: "SET_MODE"; mode: AppMode }
   | { type: "ADD_MESSAGE"; message: ConversationMessage }
@@ -190,6 +193,16 @@ function sessionReducer(
         // Clear browser state when switching vaults (REQ-F-23)
         browser: createInitialBrowserState(),
         // Clear recent notes when switching vaults
+        recentNotes: [],
+      };
+
+    case "CLEAR_VAULT":
+      return {
+        ...state,
+        vault: null,
+        sessionId: null,
+        messages: [],
+        browser: createInitialBrowserState(),
         recentNotes: [],
       };
 
@@ -461,6 +474,11 @@ export function SessionProvider({
     dispatch({ type: "SELECT_VAULT", vault });
   }, []);
 
+  const clearVault = useCallback(() => {
+    dispatch({ type: "CLEAR_VAULT" });
+    persistVaultId(null);
+  }, []);
+
   const setSessionId = useCallback((sessionId: string) => {
     dispatch({ type: "SET_SESSION_ID", sessionId });
   }, []);
@@ -541,6 +559,7 @@ export function SessionProvider({
   const value: SessionContextValue = {
     ...state,
     selectVault,
+    clearVault,
     setSessionId,
     setMode,
     addMessage,

--- a/frontend/src/contexts/__tests__/SessionContext.test.tsx
+++ b/frontend/src/contexts/__tests__/SessionContext.test.tsx
@@ -309,6 +309,110 @@ describe("SessionContext", () => {
 
   });
 
+  describe("clearVault", () => {
+    it("clears the current vault", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.selectVault(testVault);
+      });
+
+      expect(result.current.vault).toEqual(testVault);
+
+      act(() => {
+        result.current.clearVault();
+      });
+
+      expect(result.current.vault).toBeNull();
+    });
+
+    it("clears session ID and messages", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.selectVault(testVault);
+        result.current.setSessionId("session-123");
+        result.current.addMessage({ role: "user", content: "Hello" });
+      });
+
+      expect(result.current.sessionId).toBe("session-123");
+      expect(result.current.messages.length).toBe(1);
+
+      act(() => {
+        result.current.clearVault();
+      });
+
+      expect(result.current.vault).toBeNull();
+      expect(result.current.sessionId).toBeNull();
+      expect(result.current.messages).toEqual([]);
+    });
+
+    it("clears browser state", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.selectVault(testVault);
+        result.current.setCurrentPath("folder");
+        result.current.toggleDirectory("folder");
+        result.current.cacheDirectory("folder", [{ name: "file.md", type: "file" as const, path: "folder/file.md" }]);
+      });
+
+      act(() => {
+        result.current.clearVault();
+      });
+
+      expect(result.current.browser.currentPath).toBe("");
+      expect(result.current.browser.expandedDirs.size).toBe(0);
+      expect(result.current.browser.directoryCache.size).toBe(0);
+    });
+
+    it("clears recent notes", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.selectVault(testVault);
+        result.current.setRecentNotes([
+          { id: "note-1", text: "Note 1", time: "12:00", date: "2025-01-01" },
+          { id: "note-2", text: "Note 2", time: "12:01", date: "2025-01-01" },
+        ]);
+      });
+
+      expect(result.current.recentNotes.length).toBe(2);
+
+      act(() => {
+        result.current.clearVault();
+      });
+
+      expect(result.current.recentNotes).toEqual([]);
+    });
+
+    it("removes vault ID from localStorage", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.selectVault(testVault);
+      });
+
+      expect(localStorage.getItem("memory-loop:vaultId")).toBe("test-vault");
+
+      act(() => {
+        result.current.clearVault();
+      });
+
+      expect(localStorage.getItem("memory-loop:vaultId")).toBeNull();
+    });
+  });
+
   describe("persistence (writing)", () => {
     // Note: Session messages are no longer persisted to localStorage.
     // The server is the source of truth for session data.


### PR DESCRIPTION
## Summary

- Add ability to change vaults without refreshing the page
- Convert vault name in header to clickable button with hover arrow effect
- Show confirmation dialog before changing vault
- Add `clearVault` action to SessionContext with full state cleanup

## Changes

| File | Description |
|------|-------------|
| `SessionContext.tsx` | Add `clearVault` action that clears vault, session, messages, browser state, recent notes, and localStorage |
| `App.tsx` | Make ConfirmDialog generic, add vault change button with confirmation |
| `App.css` | Add `.app-vault-btn` styles with hover effect |
| `SessionContext.test.tsx` | Add 5 tests for `clearVault` functionality |

## Test plan

- [x] Lint passes
- [x] TypeScript passes
- [x] All 344 tests pass (5 new tests added)
- [ ] Manual: Click vault name → confirmation dialog appears
- [ ] Manual: Confirm → returns to vault selection
- [ ] Manual: Cancel → stays on current vault

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)