### PR TITLE
feat: Make goals.md parser more freeform

### DIFF
--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -933,11 +933,11 @@ export class WebSocketHandler {
     }
 
     try {
-      const goals = await getVaultGoals(this.state.currentVault);
-      log.info(`Found ${goals?.length ?? 0} goals`);
+      const sections = await getVaultGoals(this.state.currentVault);
+      log.info(`Found ${sections?.length ?? 0} goal sections`);
       this.send(ws, {
         type: "goals",
-        goals,
+        sections,
       });
     } catch (error) {
       log.error("Failed to get goals", error);

--- a/frontend/src/components/GoalsCard.css
+++ b/frontend/src/components/GoalsCard.css
@@ -1,7 +1,7 @@
 /**
  * GoalsCard Component Styles
  *
- * Displays active goals with glassmorphism styling consistent with HomeView.
+ * Displays goals with glassmorphism styling consistent with HomeView.
  */
 
 .goals-card {
@@ -20,13 +20,21 @@
   }
 }
 
+.goals-card__section {
+  margin-bottom: var(--spacing-md);
+}
+
+.goals-card__section:last-child {
+  margin-bottom: 0;
+}
+
 .goals-card__heading {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-bold);
   color: var(--color-accent-pink);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin: 0 0 var(--spacing-md) 0;
+  margin: 0 0 var(--spacing-sm) 0;
 }
 
 .goals-card__list {
@@ -35,7 +43,7 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-sm);
+  gap: var(--spacing-xs);
 }
 
 .goals-card__item {
@@ -47,27 +55,23 @@
   line-height: var(--line-height-normal);
 }
 
-.goals-card__item--completed {
-  color: var(--color-text-muted);
-}
-
-.goals-card__item--completed .goals-card__text {
-  text-decoration: line-through;
-}
-
-.goals-card__checkbox {
+.goals-card__bullet {
   flex-shrink: 0;
   font-size: var(--text-sm);
-  color: var(--color-accent-pink);
-  line-height: var(--line-height-normal);
-}
-
-.goals-card__item--completed .goals-card__checkbox {
   color: var(--color-text-muted);
+  line-height: var(--line-height-normal);
 }
 
 .goals-card__text {
   flex: 1;
+}
+
+.goals-card__item--more {
+  color: var(--color-text-muted);
+}
+
+.goals-card__text--more {
+  font-style: italic;
 }
 
 /* Mobile adjustments for blur performance */

--- a/frontend/src/components/GoalsCard.tsx
+++ b/frontend/src/components/GoalsCard.tsx
@@ -1,8 +1,8 @@
 /**
  * GoalsCard Component
  *
- * Displays active goals from the vault's goals.md file.
- * Shows a compact card on the Home View with the user's current goals.
+ * Displays goals from the vault's goals.md file.
+ * Shows sections with headers and items parsed from markdown.
  */
 
 import React from "react";
@@ -10,10 +10,11 @@ import { useSession } from "../contexts/SessionContext";
 import "./GoalsCard.css";
 
 /**
- * GoalsCard displays the user's active goals from goals.md.
+ * GoalsCard displays goals from goals.md organized by sections.
  *
  * - Shows goals from the vault's 06_Metadata/memory-loop/goals.md file
- * - Displays incomplete goals first, then completed goals
+ * - Displays sections with their markdown headers as titles
+ * - Shows "..." if a section has more than 9 items
  * - Returns null if no goals file exists in the vault
  */
 export function GoalsCard(): React.ReactNode {
@@ -24,44 +25,42 @@ export function GoalsCard(): React.ReactNode {
     return null;
   }
 
-  // Don't render if there are no goals
+  // Don't render if there are no sections
   if (goals.length === 0) {
     return null;
   }
 
-  // Separate incomplete and completed goals
-  const incompleteGoals = goals.filter((g) => !g.completed);
-  const completedGoals = goals.filter((g) => g.completed);
-
   return (
     <section className="goals-card" aria-label="Goals">
-      <h3 className="goals-card__heading">Goals</h3>
-      <ul className="goals-card__list" role="list">
-        {incompleteGoals.map((goal, index) => (
-          <li
-            key={`incomplete-${index}`}
-            className="goals-card__item"
-            aria-label={`Incomplete: ${goal.text}`}
-          >
-            <span className="goals-card__checkbox" aria-hidden="true">
-              ○
-            </span>
-            <span className="goals-card__text">{goal.text}</span>
-          </li>
-        ))}
-        {completedGoals.map((goal, index) => (
-          <li
-            key={`completed-${index}`}
-            className="goals-card__item goals-card__item--completed"
-            aria-label={`Completed: ${goal.text}`}
-          >
-            <span className="goals-card__checkbox" aria-hidden="true">
-              ●
-            </span>
-            <span className="goals-card__text">{goal.text}</span>
-          </li>
-        ))}
-      </ul>
+      {goals.map((section, sectionIndex) => (
+        <div key={sectionIndex} className="goals-card__section">
+          <h3 className="goals-card__heading">{section.title}</h3>
+          <ul className="goals-card__list" role="list">
+            {section.items.map((item, itemIndex) => (
+              <li
+                key={itemIndex}
+                className="goals-card__item"
+                aria-label={item}
+              >
+                <span className="goals-card__bullet" aria-hidden="true">
+                  •
+                </span>
+                <span className="goals-card__text">{item}</span>
+              </li>
+            ))}
+            {section.hasMore && (
+              <li className="goals-card__item goals-card__item--more">
+                <span className="goals-card__bullet" aria-hidden="true">
+                  &nbsp;
+                </span>
+                <span className="goals-card__text goals-card__text--more">
+                  ...
+                </span>
+              </li>
+            )}
+          </ul>
+        </div>
+      ))}
     </section>
   );
 }

--- a/frontend/src/components/HomeView.tsx
+++ b/frontend/src/components/HomeView.tsx
@@ -113,7 +113,7 @@ export function HomeView({ onModeChange }: HomeViewProps): React.ReactNode {
   // Handle goals response
   useEffect(() => {
     if (lastMessage?.type === "goals") {
-      setGoals(lastMessage.goals);
+      setGoals(lastMessage.sections);
     }
   }, [lastMessage, setGoals]);
 

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -14,7 +14,7 @@ import React, {
   useRef,
   type ReactNode,
 } from "react";
-import type { VaultInfo, ServerMessage, FileEntry, RecentNoteEntry, RecentDiscussionEntry, ConversationMessageProtocol, GoalItem } from "@memory-loop/shared";
+import type { VaultInfo, ServerMessage, FileEntry, RecentNoteEntry, RecentDiscussionEntry, ConversationMessageProtocol, GoalSection } from "@memory-loop/shared";
 
 /**
  * Application mode: home, note capture, discussion, or browse.
@@ -80,7 +80,7 @@ export interface SessionState {
   /** Recent discussion sessions for note mode */
   recentDiscussions: RecentDiscussionEntry[];
   /** Goals from vault's goals.md file (null if no goals file exists) */
-  goals: GoalItem[] | null;
+  goals: GoalSection[] | null;
 }
 
 /**
@@ -130,7 +130,7 @@ export interface SessionActions {
   /** Set recent discussions */
   setRecentDiscussions: (discussions: RecentDiscussionEntry[]) => void;
   /** Set goals from vault's goals.md file */
-  setGoals: (goals: GoalItem[] | null) => void;
+  setGoals: (goals: GoalSection[] | null) => void;
 }
 
 /**
@@ -177,7 +177,7 @@ type SessionAction =
   | { type: "PIN_FOLDER"; path: string }
   | { type: "UNPIN_FOLDER"; path: string }
   | { type: "SET_PINNED_FOLDERS"; paths: string[] }
-  | { type: "SET_GOALS"; goals: GoalItem[] | null };
+  | { type: "SET_GOALS"; goals: GoalSection[] | null };
 
 /**
  * Generates a unique message ID.
@@ -550,7 +550,7 @@ export interface SessionProviderProps {
   /** Optional initial recent discussions (for testing) */
   initialRecentDiscussions?: RecentDiscussionEntry[];
   /** Optional initial goals (for testing) */
-  initialGoals?: GoalItem[] | null;
+  initialGoals?: GoalSection[] | null;
 }
 
 /**
@@ -729,7 +729,7 @@ export function SessionProvider({
     dispatch({ type: "SET_RECENT_DISCUSSIONS", discussions });
   }, []);
 
-  const setGoals = useCallback((goals: GoalItem[] | null) => {
+  const setGoals = useCallback((goals: GoalSection[] | null) => {
     dispatch({ type: "SET_GOALS", goals });
   }, []);
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -24,7 +24,7 @@ export {
   // Recent discussion schemas
   RecentDiscussionEntrySchema,
   // Goals schemas
-  GoalItemSchema,
+  GoalSectionSchema,
   // Client -> Server schemas
   SelectVaultMessageSchema,
   CaptureNoteMessageSchema,
@@ -75,7 +75,7 @@ export type {
   // Recent discussion types
   RecentDiscussionEntry,
   // Goal types
-  GoalItem,
+  GoalSection,
   // Client message types
   SelectVaultMessage,
   CaptureNoteMessage,

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -341,20 +341,22 @@ export const RecentActivityMessageSchema = z.object({
 });
 
 /**
- * Schema for a single goal item parsed from goals.md
+ * Schema for a section of goals parsed from goals.md
+ * Sections are created from markdown headers at any level
  */
-export const GoalItemSchema = z.object({
-  text: z.string(),
-  completed: z.boolean(),
+export const GoalSectionSchema = z.object({
+  title: z.string(),
+  items: z.array(z.string()),
+  hasMore: z.boolean(),
 });
 
 /**
  * Server sends goals from the vault's goals.md file
- * Returns null for goals if the file doesn't exist
+ * Returns null for sections if the file doesn't exist
  */
 export const GoalsMessageSchema = z.object({
   type: z.literal("goals"),
-  goals: z.array(GoalItemSchema).nullable(),
+  sections: z.array(GoalSectionSchema).nullable(),
 });
 
 /**
@@ -426,7 +428,7 @@ export type DirectoryListingMessage = z.infer<typeof DirectoryListingMessageSche
 export type FileContentMessage = z.infer<typeof FileContentMessageSchema>;
 export type RecentNotesMessage = z.infer<typeof RecentNotesMessageSchema>;
 export type RecentActivityMessage = z.infer<typeof RecentActivityMessageSchema>;
-export type GoalItem = z.infer<typeof GoalItemSchema>;
+export type GoalSection = z.infer<typeof GoalSectionSchema>;
 export type GoalsMessage = z.infer<typeof GoalsMessageSchema>;
 export type ServerMessage = z.infer<typeof ServerMessageSchema>;
 


### PR DESCRIPTION
## Summary

- Changed goals.md parser to accept any markdown header level (#, ##, ###) as section titles
- Each non-blank line under a header is treated as an item (strips list prefixes like `-`, `- [ ]`, `- [x]`)
- Limits display to 9 items per section with "..." indicator when more exist
- Content before the first header goes into a default "Goals" section

This allows goals.md to be written in any markdown format rather than requiring the specific `## Active` header with checkbox items. Makes it easier to create goals through Discussion mode.

## Test plan

- [x] Backend parser tests updated and passing (78 tests)
- [x] Frontend GoalsCard tests updated and passing
- [x] TypeScript type checking passes
- [x] ESLint passes
- [ ] Manual test: Create goals.md with various header levels and item formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)