### PR TITLE
fix: Prevent iOS native menu from obscuring custom context menu

### DIFF
--- a/frontend/src/components/FileTree.css
+++ b/frontend/src/components/FileTree.css
@@ -80,6 +80,12 @@
   font-size: var(--text-sm);
   color: var(--color-text);
   transition: background-color 0.2s ease, box-shadow 0.3s ease;
+
+  /* Prevent iOS long-press behaviors that conflict with custom context menu */
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+  touch-action: manipulation;
 }
 
 .file-tree__item:hover {


### PR DESCRIPTION
## Summary

- Fixes iOS long press behavior that was causing the native callout menu and text selection to appear alongside the app's custom context menu in FileTree
- Adds CSS properties to `.file-tree__item` to prevent native iOS touch behaviors

## Changes

Added to `frontend/src/components/FileTree.css`:
```css
/* Prevent iOS long-press behaviors that conflict with custom context menu */
-webkit-touch-callout: none;
-webkit-user-select: none;
user-select: none;
touch-action: manipulation;
```

## Test plan

- [ ] On iOS device, long press a file/folder in Browse mode
- [ ] Verify custom context menu appears without native iOS callout menu
- [ ] Verify text is not selected during long press
- [ ] Verify scrolling still works in the file tree
- [ ] Verify tap/click behavior is unchanged

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)