### PR TITLE
fix: Prevent streaming response from corrupting user message

### DIFF
--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -275,6 +275,14 @@ function sessionReducer(
       if (state.messages.length === 0) return state;
       const messages = [...state.messages];
       const lastMessage = messages[messages.length - 1];
+      // Only update streaming assistant messages to prevent race condition
+      // where response_chunk arrives before response_start is committed to state
+      if (lastMessage.role !== "assistant") {
+        console.warn(
+          "[SessionContext] UPDATE_LAST_MESSAGE ignored: last message is not an assistant message"
+        );
+        return state;
+      }
       messages[messages.length - 1] = {
         ...lastMessage,
         content: lastMessage.content + action.content,


### PR DESCRIPTION
## Summary

- Fixes race condition where first streaming reply gets added to user's message bubble instead of a new assistant bubble
- Adds guard clause to `UPDATE_LAST_MESSAGE` reducer to only update assistant messages
- Adds test coverage for the race condition scenario

Closes #53

## Root Cause

When the user sends the first message in an empty discussion window, `response_chunk` messages from the server can arrive before the `response_start` message's React state update is committed. The `updateLastMessage` function was blindly appending to whatever the last message was, which could be the user's message.

## Solution

Modified the `UPDATE_LAST_MESSAGE` reducer to check if the last message has `role: "assistant"` before appending. If not, the update is ignored with a console warning for debugging.

## Test plan

- [x] New test: `updateLastMessage does not corrupt user message (race condition fix)`
- [x] New test: `updateLastMessage only updates assistant messages`
- [x] All 252 frontend tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)