### PR TITLE
fix: Prevent duplicate text from streaming responses (#47)

### DIFF
--- a/backend/src/__tests__/websocket-handler.test.ts
+++ b/backend/src/__tests__/websocket-handler.test.ts
@@ -860,14 +860,14 @@ describe("WebSocket Handler", () => {
       const vault = createMockVault();
       mockGetVaultById.mockResolvedValue(vault);
 
-      // Create mock events
+      // Create mock events using stream_event (not assistant, which doesn't send chunks)
       const events = [
         { type: "system", subtype: "init", session_id: "new-session" },
         {
-          type: "assistant",
-          session_id: "new-session",
-          message: {
-            content: [{ type: "text", text: "Hello there!" }],
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: "Hello there!" },
           },
         },
       ];


### PR DESCRIPTION
## Summary

- Fix double-render bug where streaming content appeared twice after completion
- The SDK emits both `stream_event` deltas (incremental) and `assistant` event (full content)
- We were processing both, causing text to be sent twice and persisted doubled
- Now only process `stream_event` deltas, which are the correct streaming source

Closes #47

## Test plan

- [x] All 64 backend tests pass
- [x] Lint passes
- [x] Type checking passes
- [ ] Manual test: Send a message and verify content is not doubled
- [ ] Manual test: Refresh page and verify persisted message is not doubled

🤖 Generated with [Claude Code](https://claude.com/claude-code)