### PR TITLE
fix: Auto-resume session on page refresh (#50)

### DIFF
--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -151,7 +151,7 @@ const SessionContext = createContext<SessionContextValue | null>(null);
  * localStorage keys for persisting state.
  * Note: Session messages are NOT persisted locally - server is source of truth.
  */
-const STORAGE_KEY_VAULT = "memory-loop:vaultId";
+export const STORAGE_KEY_VAULT = "memory-loop:vaultId";
 const STORAGE_KEY_BROWSER_PATH = "memory-loop:browserPath";
 const STORAGE_KEY_PINNED_FOLDERS_PREFIX = "memory-loop:pinnedFolders:";
 


### PR DESCRIPTION
## Summary

- Fixes issue where Home page always showed 0 messages and 0 session time after browser refresh
- On page refresh, the vault ID was persisted in localStorage but VaultSelect required user to click the vault again to trigger session resume
- Added auto-resume effect that checks localStorage when vaults load and WebSocket connects, then automatically resumes or creates the session

Closes #50

## Test plan

- [x] Typecheck passes
- [x] All 256 tests pass (4 new tests added)
- [x] Manual verification: refresh page with existing session, should auto-resume and show correct message count/session time

🤖 Generated with [Claude Code](https://claude.com/claude-code)