### PR TITLE
feat: Expand chat input on focus for verbose typing

### DIFF
--- a/frontend/src/components/Discussion.css
+++ b/frontend/src/components/Discussion.css
@@ -110,7 +110,7 @@
   font-size: var(--text-base);
   line-height: 1.5;
   resize: none;
-  transition: border-color 0.2s ease, box-shadow 0.3s ease;
+  transition: border-color 0.2s ease, box-shadow 0.3s ease, min-height 0.2s ease, max-height 0.2s ease;
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.05),
     inset 0 -1px 0 rgba(0, 0, 0, 0.2);
@@ -216,4 +216,11 @@
     width: 48px;
     height: 48px;
   }
+}
+
+/* Expanded state when focused - approximately 10 lines of text.
+   Must come after media queries to override tablet min-height. */
+.discussion__input--expanded {
+  min-height: 240px;
+  max-height: 240px;
 }

--- a/frontend/src/components/Discussion.tsx
+++ b/frontend/src/components/Discussion.tsx
@@ -35,6 +35,7 @@ export interface DiscussionProps {
 export function Discussion({ onToolUse }: DiscussionProps): React.ReactNode {
   const [input, setInput] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -227,6 +228,9 @@ export function Discussion({ onToolUse }: DiscussionProps): React.ReactNode {
     setInput("");
     localStorage.removeItem(STORAGE_KEY);
     setIsSubmitting(true);
+
+    // Blur input to collapse it back to single row
+    inputRef.current?.blur();
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -271,10 +275,12 @@ export function Discussion({ onToolUse }: DiscussionProps): React.ReactNode {
         <div className="discussion__input-row">
           <textarea
             ref={inputRef}
-            className="discussion__input"
+            className={`discussion__input${isFocused ? " discussion__input--expanded" : ""}`}
             value={input}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
             placeholder="Explore. Challenge. Refine. Your vault awaits..."
             disabled={isSubmitting}
             rows={1}


### PR DESCRIPTION
## Summary
- Chat input expands to ~10 lines (240px) when focused, providing more space for longer messages
- Collapses back to single row on blur or after sending a message
- Smooth CSS transition (0.2s ease) for a polished feel

## Test plan
- [x] Focus on chat input → should expand to ~10 lines
- [x] Click outside input → should collapse back
- [x] Type a message and press Enter → should collapse after send
- [x] Verify on mobile viewport (no visual issues)
- [x] Verify on tablet/desktop viewport (overrides tablet min-height)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)