### PR TITLE
feat: Move New button into Chat tab

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -157,30 +157,6 @@
   align-items: center;
 }
 
-.app-new-session-btn {
-  min-height: 36px;
-  padding: var(--spacing-xs) var(--spacing-sm);
-  background-color: transparent;
-  color: var(--color-text-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  cursor: pointer;
-  transition: all 0.2s ease;
-  white-space: nowrap;
-}
-
-.app-new-session-btn:hover {
-  background-color: var(--color-bg-secondary);
-  color: var(--color-text);
-  border-color: var(--color-text-secondary);
-}
-
-.app-new-session-btn:active {
-  transform: scale(0.98);
-}
-
 /* Tablet and up - horizontal header layout */
 @media (min-width: 768px) {
   .app-header {
@@ -208,11 +184,6 @@
 
   .app-title {
     font-size: var(--font-size-3xl);
-  }
-
-  .app-new-session-btn {
-    min-height: 40px;
-    padding: var(--spacing-sm) var(--spacing-md);
   }
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -94,26 +94,17 @@ function ConfirmDialog({
 /**
  * Dialog types for confirmation.
  */
-type DialogType = "newSession" | "changeVault" | null;
+type DialogType = "changeVault" | null;
 
 /**
  * Main app content when a vault is selected.
  */
 function MainContent(): React.ReactNode {
-  const { mode, vault, startNewSession, clearVault } = useSession();
+  const { mode, vault, clearVault } = useSession();
   const [activeDialog, setActiveDialog] = useState<DialogType>(null);
-
-  function handleNewSession() {
-    setActiveDialog("newSession");
-  }
 
   function handleChangeVault() {
     setActiveDialog("changeVault");
-  }
-
-  function handleConfirmNewSession() {
-    startNewSession();
-    setActiveDialog(null);
   }
 
   function handleConfirmChangeVault() {
@@ -148,14 +139,7 @@ function MainContent(): React.ReactNode {
           <ModeToggle />
         </div>
         <div className="app-header__right">
-          <button
-            type="button"
-            className="app-new-session-btn"
-            onClick={handleNewSession}
-            aria-label="Start new session"
-          >
-            New
-          </button>
+          {/* New session button moved to Discussion component */}
         </div>
       </header>
 
@@ -165,15 +149,6 @@ function MainContent(): React.ReactNode {
         {mode === "discussion" && <Discussion />}
         {mode === "browse" && <BrowseMode />}
       </main>
-
-      <ConfirmDialog
-        isOpen={activeDialog === "newSession"}
-        title="Start New Session?"
-        message="This will clear the current conversation. Your notes are already saved to the vault."
-        confirmLabel="New"
-        onConfirm={handleConfirmNewSession}
-        onCancel={handleCancelDialog}
-      />
 
       <ConfirmDialog
         isOpen={activeDialog === "changeVault"}

--- a/frontend/src/components/Discussion.css
+++ b/frontend/src/components/Discussion.css
@@ -224,3 +224,142 @@
   min-height: 240px;
   max-height: 240px;
 }
+
+/* ============================================
+   New Session Button
+   ============================================ */
+
+.discussion__header {
+  display: flex;
+  align-items: center;
+  padding: var(--spacing-xs) var(--spacing-md);
+  flex-shrink: 0;
+}
+
+.discussion__new-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-normal);
+  line-height: 1;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.discussion__new-btn:hover {
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text);
+  border-color: var(--color-text-secondary);
+}
+
+.discussion__new-btn:active {
+  transform: scale(0.95);
+}
+
+/* ============================================
+   New Session Confirmation Dialog
+   ============================================ */
+
+.discussion__dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-md);
+  background-color: rgba(0, 0, 0, 0.5);
+  animation: discussion-fade-in 0.2s ease;
+}
+
+@keyframes discussion-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.discussion__dialog {
+  width: 100%;
+  max-width: 400px;
+  padding: var(--spacing-lg);
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border-hover);
+  border-radius: var(--radius-xl);
+  box-shadow:
+    0 8px 40px rgba(0, 0, 0, 0.5),
+    0 0 30px rgba(168, 85, 247, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  animation: discussion-slide-up 0.2s ease;
+}
+
+@keyframes discussion-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.discussion__dialog-title {
+  margin: 0 0 var(--spacing-sm);
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+}
+
+.discussion__dialog-message {
+  margin: 0 0 var(--spacing-lg);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+}
+
+.discussion__dialog-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: flex-end;
+}
+
+.discussion__dialog-btn {
+  min-height: 44px;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.discussion__dialog-btn--cancel {
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text);
+}
+
+.discussion__dialog-btn--cancel:hover {
+  background-color: var(--color-border);
+}
+
+.discussion__dialog-btn--confirm {
+  background: var(--gradient-primary);
+  color: white;
+  transition: box-shadow 0.3s ease, transform 0.2s ease;
+}
+
+.discussion__dialog-btn--confirm:hover {
+  box-shadow: var(--glow-purple);
+}
+
+.discussion__dialog-btn:active {
+  transform: scale(0.98);
+}

--- a/frontend/src/components/Discussion.tsx
+++ b/frontend/src/components/Discussion.tsx
@@ -37,6 +37,7 @@ export function Discussion({ onToolUse }: DiscussionProps): React.ReactNode {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
+  const [showNewSessionDialog, setShowNewSessionDialog] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -261,8 +262,33 @@ export function Discussion({ onToolUse }: DiscussionProps): React.ReactNode {
   const isDisabled = isSubmitting || connectionStatus !== "connected" || !vault;
   const showSlashHint = isSlashCommand(input);
 
+  function handleNewSessionClick() {
+    setShowNewSessionDialog(true);
+  }
+
+  function handleConfirmNewSession() {
+    startNewSession();
+    setShowNewSessionDialog(false);
+  }
+
+  function handleCancelNewSession() {
+    setShowNewSessionDialog(false);
+  }
+
   return (
     <div className="discussion">
+      <div className="discussion__header">
+        <button
+          type="button"
+          className="discussion__new-btn"
+          onClick={handleNewSessionClick}
+          aria-label="Start new session"
+          title="New session"
+        >
+          +
+        </button>
+      </div>
+
       <div className="discussion__messages" role="list" aria-label="Conversation">
         {messages.length === 0 ? (
           <div className="discussion__empty">
@@ -320,6 +346,45 @@ export function Discussion({ onToolUse }: DiscussionProps): React.ReactNode {
           </button>
         </div>
       </form>
+
+      {showNewSessionDialog && (
+        <div
+          className="discussion__dialog-backdrop"
+          onClick={handleCancelNewSession}
+          onKeyDown={(e) => e.key === "Escape" && handleCancelNewSession()}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="new-session-dialog-title"
+        >
+          <div
+            className="discussion__dialog"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id="new-session-dialog-title" className="discussion__dialog-title">
+              Start New Session?
+            </h2>
+            <p className="discussion__dialog-message">
+              This will clear the current conversation. Your notes are already saved to the vault.
+            </p>
+            <div className="discussion__dialog-actions">
+              <button
+                type="button"
+                className="discussion__dialog-btn discussion__dialog-btn--cancel"
+                onClick={handleCancelNewSession}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="discussion__dialog-btn discussion__dialog-btn--confirm"
+                onClick={handleConfirmNewSession}
+              >
+                New
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Moved the "New" session button from the global app header into the Chat/Discussion component
- The button now appears as a subtle (+) in the upper-left of the Chat tab only
- Same confirmation dialog behavior as before

## Why

The New button only affects the Chat tab (clears the conversation), so having it always visible in the header was confusing. Now it's contextually placed where it's relevant.

## Test plan

- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] All 257 tests pass
- [ ] Manual verification: (+) button appears in Chat tab header
- [ ] Manual verification: Clicking (+) shows confirmation dialog
- [ ] Manual verification: Confirming clears the conversation
- [ ] Manual verification: Button is not visible on Home, Note, or Browse tabs

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)