### PR TITLE
fix: Clear localStorage when input is emptied

### DIFF
--- a/frontend/src/components/Discussion.tsx
+++ b/frontend/src/components/Discussion.tsx
@@ -203,6 +203,8 @@ export function Discussion({ onToolUse }: DiscussionProps): React.ReactNode {
   useEffect(() => {
     if (input) {
       localStorage.setItem(STORAGE_KEY, input);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
     }
   }, [input]);
 

--- a/frontend/src/components/NoteCapture.tsx
+++ b/frontend/src/components/NoteCapture.tsx
@@ -87,6 +87,8 @@ export function NoteCapture({ onCaptured }: NoteCaptureProps): React.ReactNode {
   useEffect(() => {
     if (content) {
       localStorage.setItem(STORAGE_KEY, content);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
     }
   }, [content]);
 


### PR DESCRIPTION
## Summary
- Fixes bug where deleting the last character in Discussion or NoteCapture inputs did not clear localStorage
- The draft save effect only ran when input was truthy, leaving stale data when emptied
- Now explicitly removes the localStorage key when input becomes empty string

## Test plan
- [x] Existing tests pass (257 tests)
- [ ] Type text in Discussion input, delete all characters, refresh page - input should be empty
- [ ] Type text in Note Capture input, delete all characters, refresh page - input should be empty

🤖 Generated with [Claude Code](https://claude.ai/claude-code)