### PR TITLE
feat: Add stop/abort button during AI response streaming

### DIFF
--- a/frontend/src/components/Discussion.css
+++ b/frontend/src/components/Discussion.css
@@ -176,6 +176,20 @@
   height: 20px;
 }
 
+/* Stop button state - red/warning appearance */
+.discussion__send--stop {
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%);
+}
+
+.discussion__send--stop:hover:not(:disabled) {
+  box-shadow: 0 0 20px rgba(239, 68, 68, 0.4);
+}
+
+.discussion__stop-icon {
+  width: 16px;
+  height: 16px;
+}
+
 .discussion__send-spinner {
   width: 20px;
   height: 20px;

--- a/frontend/src/components/Discussion.tsx
+++ b/frontend/src/components/Discussion.tsx
@@ -266,11 +266,17 @@ export function Discussion({ onToolUse }: DiscussionProps): React.ReactNode {
     }
   }
 
+  function handleAbort() {
+    if (!isSubmitting) return;
+    sendMessage({ type: "abort" });
+    setIsSubmitting(false);
+  }
+
   function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     setInput(e.target.value);
   }
 
-  const isDisabled = isSubmitting || connectionStatus !== "connected" || !vault;
+  const isDisconnected = connectionStatus !== "connected" || !vault;
   const showSlashHint = isSlashCommand(input);
 
   function handleNewSessionClick() {
@@ -337,13 +343,21 @@ export function Discussion({ onToolUse }: DiscussionProps): React.ReactNode {
             aria-label="Message input"
           />
           <button
-            type="submit"
-            className="discussion__send"
-            disabled={isDisabled || !input.trim()}
-            aria-label="Send message"
+            type={isSubmitting ? "button" : "submit"}
+            className={`discussion__send${isSubmitting ? " discussion__send--stop" : ""}`}
+            disabled={!isSubmitting && (isDisconnected || !input.trim())}
+            onClick={isSubmitting ? handleAbort : undefined}
+            aria-label={isSubmitting ? "Stop response" : "Send message"}
           >
             {isSubmitting ? (
-              <span className="discussion__send-spinner" aria-hidden="true" />
+              <svg
+                className="discussion__stop-icon"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <rect x="6" y="6" width="12" height="12" rx="1" />
+              </svg>
             ) : (
               <svg
                 className="discussion__send-icon"


### PR DESCRIPTION
## Summary

- Replace the spinner with a clickable stop button when waiting for AI response
- Clicking the button sends an abort message to interrupt the Claude Agent SDK query
- Button displays red styling to clearly indicate "stop" action

## Changes

- **Discussion.tsx**: Add `handleAbort()` function, modify button to switch between send/stop states
- **Discussion.css**: Add stop button styles with red gradient
- **Discussion.test.tsx**: Add 5 tests covering abort functionality

## Test plan

- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] All 32 Discussion tests pass (including 5 new abort tests)
- [ ] Manual test: Submit message, verify stop button appears
- [ ] Manual test: Click stop button, verify response stops and button reverts to send

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)