### PR TITLE
fix: Use contentRoot for Recall tab file browsing

### DIFF
--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -765,7 +765,7 @@ export class WebSocketHandler {
     }
 
     try {
-      const entries = await listDirectory(this.state.currentVault.path, path);
+      const entries = await listDirectory(this.state.currentVault.contentRoot, path);
       log.info(`Found ${entries.length} entries in ${path || "/"}`);
       this.send(ws, {
         type: "directory_listing",
@@ -804,7 +804,7 @@ export class WebSocketHandler {
     }
 
     try {
-      const result = await readMarkdownFile(this.state.currentVault.path, path);
+      const result = await readMarkdownFile(this.state.currentVault.contentRoot, path);
       log.info(`File read: ${path} (truncated: ${result.truncated})`);
       this.send(ws, {
         type: "file_content",
@@ -845,7 +845,7 @@ export class WebSocketHandler {
     }
 
     try {
-      await writeMarkdownFile(this.state.currentVault.path, path, content);
+      await writeMarkdownFile(this.state.currentVault.contentRoot, path, content);
       log.info(`File written: ${path} (${content.length} bytes)`);
       this.send(ws, {
         type: "file_written",


### PR DESCRIPTION
## Summary

- File browser operations (`listDirectory`, `readMarkdownFile`, `writeMarkdownFile`) now use `vault.contentRoot` instead of `vault.path`
- Fixes wikilink resolution in vaults with configured `contentRoot` (e.g., Quartz sites)
- File paths in Recall tab now match what Obsidian sees as the vault root

## Test plan

- [x] All existing tests pass (267 tests)
- [ ] Manual test: Configure a vault with `contentRoot: "content"` and verify the Recall tab shows files relative to the content directory
- [ ] Manual test: Click a wikilink in a viewed file and verify it resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)