### PR TITLE
fix: Treat wikilinks with paths as absolute from vault root

### DIFF
--- a/frontend/src/components/MarkdownViewer.tsx
+++ b/frontend/src/components/MarkdownViewer.tsx
@@ -290,9 +290,17 @@ export function MarkdownViewer({
     isSaving,
   } = browser;
 
-  // Handle wiki-link clicks - resolve relative paths
+  // Handle wiki-link clicks - resolve paths
+  // Obsidian wikilinks with paths (containing /) are absolute from vault root
+  // Wikilinks without paths are relative to current directory
   const handleWikiLinkClick = useCallback(
     (targetPath: string) => {
+      // If target contains a path separator, treat as absolute from content root
+      if (targetPath.includes("/")) {
+        onNavigate?.(targetPath);
+        return;
+      }
+      // Otherwise, resolve relative to current directory
       const currentDir = currentPath.includes("/")
         ? currentPath.substring(0, currentPath.lastIndexOf("/"))
         : "";

--- a/frontend/src/components/__tests__/MarkdownViewer.test.tsx
+++ b/frontend/src/components/__tests__/MarkdownViewer.test.tsx
@@ -249,6 +249,25 @@ describe("MarkdownViewer", () => {
       expect(onNavigate).toHaveBeenCalledWith("docs/other-note.md");
     });
 
+    it("treats wiki-links with paths as absolute from vault root", () => {
+      // Wikilinks like [[folder/note]] are absolute from content root,
+      // not relative to current file (Obsidian behavior)
+      const content = "See [[02_Areas/Projects/index]] for more.";
+      const onNavigate = mock(() => {});
+      const { container } = render(<MarkdownViewer onNavigate={onNavigate} />, {
+        wrapper: createTestWrapper({
+          currentPath: "docs/nested/guide.md",
+          currentFileContent: content,
+        }),
+      });
+
+      const wikiLink = container.querySelector(".markdown-viewer__wiki-link");
+      fireEvent.click(wikiLink!);
+
+      // Should NOT prepend current dir - path with / is absolute
+      expect(onNavigate).toHaveBeenCalledWith("02_Areas/Projects/index.md");
+    });
+
     it("handles wiki-links with .md extension", () => {
       const content = "See [[other-note.md]] for more.";
       const { container } = render(<MarkdownViewer />, {


### PR DESCRIPTION
## Summary

- Wikilinks with paths (e.g., `[[folder/note]]`) are now resolved from the vault content root, not relative to the current file
- Fixes path doubling bug: viewing `docs/guide.md` and clicking `[[02_Areas/Projects/index]]` was resolving to `docs/02_Areas/Projects/index.md` instead of `02_Areas/Projects/index.md`
- Wikilinks without paths (e.g., `[[note]]`) still resolve relative to the current directory

## Test plan

- [x] Added test case for absolute path wikilinks
- [x] All 52 MarkdownViewer tests pass
- [ ] Manual test: Navigate to a file in Recall tab, click a wikilink with a path, verify it resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)