### PR TITLE
fix: Add scroll to vault selection when list overflows

### DIFF
--- a/frontend/src/components/VaultSelect.css
+++ b/frontend/src/components/VaultSelect.css
@@ -222,6 +222,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--spacing-md);
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-bottom: var(--spacing-lg);
 }
 
 /* Vault card */
@@ -349,5 +353,6 @@
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: var(--spacing-md);
+    align-content: start;
   }
 }


### PR DESCRIPTION
## Summary
- Fixes missing scroll on vault selection page when there are more vaults than fit on screen
- Added `flex: 1`, `min-height: 0`, and `overflow-y: auto` to the vault list
- Added `align-content: start` to tablet grid layout

## Test plan
- [ ] Open vault selection with many vaults configured
- [ ] Verify the list scrolls when vaults exceed viewport height
- [ ] Test on mobile and tablet viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)