### PR TITLE
feat: Expand session permissions and turn limit

### DIFF
--- a/backend/src/__tests__/session-manager.test.ts
+++ b/backend/src/__tests__/session-manager.test.ts
@@ -722,7 +722,7 @@ describe("Session Manager", () => {
       expect(callArgs).toBeDefined();
       expect(callArgs!.prompt).toBe("Hello");
       expect(callArgs!.options.cwd).toBe(vault.path);
-      expect(callArgs!.options.settingSources).toEqual(["project"]);
+      expect(callArgs!.options.settingSources).toEqual(["project", "user"]);
       expect(callArgs!.options.resume).toBeUndefined();
     });
 

--- a/backend/src/session-manager.ts
+++ b/backend/src/session-manager.ts
@@ -45,8 +45,8 @@ export const DISCUSSION_MODE_OPTIONS: Partial<Options> = {
   ],
   // Auto-accept file edits - the user is working in their own vault
   permissionMode: "acceptEdits",
-  // Prevent runaway conversations (50 turns = ~100 messages)
-  maxTurns: 50,
+  // Prevent runaway conversations (100 turns = ~200 messages)
+  maxTurns: 100,
   // Hard cost cap as safety net ($2 is generous for a single conversation)
   maxBudgetUsd: 2.0,
   // Enable streaming for real-time response display
@@ -620,7 +620,7 @@ export async function createSession(
     const mergedOptions: Partial<Options> = {
       ...DISCUSSION_MODE_OPTIONS,
       cwd: vault.path,
-      settingSources: ["project"],
+      settingSources: ["project", "user"],
       ...options, // Caller options override defaults
     };
     log.debug("SDK options:", {
@@ -705,7 +705,7 @@ export async function resumeSession(
       ...DISCUSSION_MODE_OPTIONS,
       resume: sessionId,
       cwd: metadata.vaultPath,
-      settingSources: ["project"],
+      settingSources: ["project", "user"],
       ...options, // Caller options override defaults
     };
     log.debug("SDK options:", {


### PR DESCRIPTION
## Summary
- Increase `maxTurns` from 50 to 100 for longer conversations
- Add `"user"` to `settingSources` to enable user-level Claude Code config (MCP servers, allowed tools, etc.)

## Test plan
- [x] Existing tests updated and passing
- [ ] Manual test: verify sessions can use user-level MCP servers
- [ ] Manual test: verify conversations can exceed 50 turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)