### PR TITLE
feat: Improve TaskList with sticky headers, sort by date, and hide completed

### DIFF
--- a/backend/src/__tests__/task-manager.test.ts
+++ b/backend/src/__tests__/task-manager.test.ts
@@ -425,12 +425,13 @@ describe("parseTasksFromFile", () => {
 
     const tasks = await parseTasksFromFile(testDir, "note.md");
     expect(tasks).toHaveLength(1);
-    expect(tasks[0]).toEqual({
+    expect(tasks[0]).toMatchObject({
       text: "Buy groceries",
       state: " ",
       filePath: "note.md",
       lineNumber: 1,
     });
+    expect(tasks[0].fileMtime).toBeGreaterThan(0);
   });
 
   test("parses multiple tasks", async () => {

--- a/frontend/src/components/TaskList.css
+++ b/frontend/src/components/TaskList.css
@@ -58,6 +58,44 @@
 }
 
 /* ============================================
+   Task List Header
+   ============================================ */
+
+.task-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin: 0 var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.task-list__hide-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  cursor: pointer;
+  user-select: none;
+}
+
+.task-list__hide-toggle input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+}
+
+.task-list__total-count {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  background: rgba(168, 85, 247, 0.15);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+}
+
+/* ============================================
    Task Group
    ============================================ */
 
@@ -81,6 +119,11 @@
   cursor: pointer;
   text-align: left;
   transition: background-color 0.2s ease;
+
+  /* Sticky header - sticks to top when scrolling within group */
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 .task-list__group-header:hover {

--- a/frontend/src/contexts/__tests__/SessionContext.test.tsx
+++ b/frontend/src/contexts/__tests__/SessionContext.test.tsx
@@ -1649,8 +1649,8 @@ describe("SessionContext", () => {
       });
 
       const tasks = [
-        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1 },
-        { text: "Task 2", state: "x", filePath: "folder/file.md", lineNumber: 2 },
+        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task 2", state: "x", filePath: "folder/file.md", lineNumber: 2, fileMtime: 1000 },
       ];
 
       act(() => {
@@ -1735,9 +1735,9 @@ describe("SessionContext", () => {
       });
 
       const tasks = [
-        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1 },
-        { text: "Task 2", state: " ", filePath: "folder/file.md", lineNumber: 2 },
-        { text: "Task 3", state: " ", filePath: "other/file.md", lineNumber: 1 },
+        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task 2", state: " ", filePath: "folder/file.md", lineNumber: 2, fileMtime: 1000 },
+        { text: "Task 3", state: " ", filePath: "other/file.md", lineNumber: 1, fileMtime: 2000 },
       ];
 
       act(() => {
@@ -1760,7 +1760,7 @@ describe("SessionContext", () => {
       });
 
       const tasks = [
-        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1 },
+        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1, fileMtime: 1000 },
       ];
 
       act(() => {
@@ -1781,7 +1781,7 @@ describe("SessionContext", () => {
       });
 
       const tasks = [
-        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1 },
+        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
       ];
 
       act(() => {
@@ -1808,7 +1808,7 @@ describe("SessionContext", () => {
         result.current.selectVault(testVault);
         result.current.setViewMode("tasks");
         result.current.setTasks([
-          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1 },
+          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
         ]);
       });
 
@@ -1832,7 +1832,7 @@ describe("SessionContext", () => {
       act(() => {
         result.current.selectVault(testVault);
         result.current.setTasks([
-          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1 },
+          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
         ]);
       });
 
@@ -1854,7 +1854,7 @@ describe("SessionContext", () => {
       // Set up task state
       act(() => {
         result.current.setTasks([
-          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1 },
+          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
         ]);
         result.current.setTasksError("Some error");
       });

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -73,6 +73,8 @@ export const TaskEntrySchema = z.object({
   filePath: z.string().min(1, "File path is required"),
   /** Line number in file (1-indexed) */
   lineNumber: z.number().int().min(1, "Line number must be at least 1"),
+  /** File modification time (Unix timestamp in ms) for sorting */
+  fileMtime: z.number().int().min(0),
 });
 
 /**


### PR DESCRIPTION
## Summary

- **Sticky filename headers** - The currently visible file's header now sticks to the top when scrolling through tasks
- **Newest-first sort order** - Files are now sorted by modification time (newest first) instead of alphabetically
- **Hide completed toggle** - New checkbox in the TaskList header to filter out completed tasks, with overall count display

## Changes

- Added `fileMtime` field to `TaskEntry` protocol schema
- Backend retrieves file modification time when parsing tasks
- Frontend sorts file groups by mtime descending
- CSS `position: sticky` on group headers
- New header section with hide toggle and total count

Closes #110

## Test plan

- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] All 375 tests pass
- [x] Code review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)