### PR TITLE
fix: Persist new session dialog state across tab switches

### DIFF
--- a/frontend/src/components/Discussion.tsx
+++ b/frontend/src/components/Discussion.tsx
@@ -29,7 +29,6 @@ export function Discussion(): React.ReactNode {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [isTouchDevice, setIsTouchDevice] = useState(false);
-  const [showNewSessionDialog, setShowNewSessionDialog] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -46,6 +45,8 @@ export function Discussion(): React.ReactNode {
     setDiscussionPrefill,
     pendingSessionId,
     setPendingSessionId,
+    showNewSessionDialog,
+    setShowNewSessionDialog,
     addToolToLastMessage,
     updateToolInput,
     completeToolInvocation,
@@ -282,8 +283,8 @@ export function Discussion(): React.ReactNode {
   }
 
   function handleConfirmNewSession() {
-    startNewSession();
     setShowNewSessionDialog(false);
+    startNewSession();
   }
 
   function handleCancelNewSession() {

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -108,6 +108,8 @@ export interface SessionState {
   discussionPrefill: string | null;
   /** Session ID pending resume (set by RecentActivity, consumed by Discussion) */
   pendingSessionId: string | null;
+  /** Whether the new session confirmation dialog is shown (persists across tab switches) */
+  showNewSessionDialog: boolean;
 }
 
 /**
@@ -164,6 +166,8 @@ export interface SessionActions {
   setDiscussionPrefill: (text: string | null) => void;
   /** Set pending session ID for resume (called by RecentActivity) */
   setPendingSessionId: (sessionId: string | null) => void;
+  /** Set new session dialog visibility (persists across tab switches) */
+  setShowNewSessionDialog: (show: boolean) => void;
   /** Enter adjust mode (copies currentFileContent to adjustContent) */
   startAdjust: () => void;
   /** Update the content being edited in adjust mode */
@@ -243,6 +247,7 @@ type SessionAction =
   | { type: "SET_GOALS"; goals: GoalSection[] | null }
   | { type: "SET_DISCUSSION_PREFILL"; text: string | null }
   | { type: "SET_PENDING_SESSION_ID"; sessionId: string | null }
+  | { type: "SET_SHOW_NEW_SESSION_DIALOG"; show: boolean }
   | { type: "START_ADJUST" }
   | { type: "UPDATE_ADJUST_CONTENT"; content: string }
   | { type: "CANCEL_ADJUST" }
@@ -337,8 +342,9 @@ function sessionReducer(
         recentDiscussions: [],
         // Clear goals when switching vaults
         goals: null,
-        // Clear discussion prefill when switching vaults (transient state)
+        // Clear transient UI state when switching vaults
         discussionPrefill: null,
+        showNewSessionDialog: false,
       };
 
     case "CLEAR_VAULT":
@@ -352,6 +358,7 @@ function sessionReducer(
         recentDiscussions: [],
         goals: null,
         discussionPrefill: null,
+        showNewSessionDialog: false,
       };
 
     case "SET_SESSION_ID":
@@ -587,6 +594,12 @@ function sessionReducer(
         pendingSessionId: action.sessionId,
       };
 
+    case "SET_SHOW_NEW_SESSION_DIALOG":
+      return {
+        ...state,
+        showNewSessionDialog: action.show,
+      };
+
     case "START_ADJUST":
       return {
         ...state,
@@ -792,6 +805,7 @@ const initialState: SessionState = {
   goals: null,
   discussionPrefill: null,
   pendingSessionId: null,
+  showNewSessionDialog: false,
 };
 
 /**
@@ -1092,6 +1106,10 @@ export function SessionProvider({
     dispatch({ type: "SET_PENDING_SESSION_ID", sessionId });
   }, []);
 
+  const setShowNewSessionDialog = useCallback((show: boolean) => {
+    dispatch({ type: "SET_SHOW_NEW_SESSION_DIALOG", show });
+  }, []);
+
   // Adjust mode action creators
   const startAdjust = useCallback(() => {
     dispatch({ type: "START_ADJUST" });
@@ -1179,6 +1197,7 @@ export function SessionProvider({
     setGoals,
     setDiscussionPrefill,
     setPendingSessionId,
+    setShowNewSessionDialog,
     startAdjust,
     updateAdjustContent,
     cancelAdjust,

--- a/frontend/src/contexts/__tests__/SessionContext.test.tsx
+++ b/frontend/src/contexts/__tests__/SessionContext.test.tsx
@@ -1897,4 +1897,133 @@ describe("SessionContext", () => {
       expect(result.current.browser.viewMode).toBe("tasks");
     });
   });
+
+  describe("showNewSessionDialog", () => {
+    it("provides initial state with showNewSessionDialog false", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(false);
+    });
+
+    it("setShowNewSessionDialog(true) shows the dialog", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setShowNewSessionDialog(true);
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(true);
+    });
+
+    it("setShowNewSessionDialog(false) hides the dialog", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setShowNewSessionDialog(true);
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(true);
+
+      act(() => {
+        result.current.setShowNewSessionDialog(false);
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(false);
+    });
+
+    it("dialog state is preserved when switching modes", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setShowNewSessionDialog(true);
+      });
+
+      // Switch to note mode
+      act(() => {
+        result.current.setMode("note");
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(true);
+
+      // Switch to home mode
+      act(() => {
+        result.current.setMode("home");
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(true);
+
+      // Switch back to discussion mode
+      act(() => {
+        result.current.setMode("discussion");
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(true);
+    });
+
+    it("dialog is closed when vault changes (selectVault)", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.selectVault(testVault);
+        result.current.setShowNewSessionDialog(true);
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(true);
+
+      // Switch to different vault
+      act(() => {
+        result.current.selectVault(testVault2);
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(false);
+    });
+
+    it("dialog is closed when vault is cleared (clearVault)", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.selectVault(testVault);
+        result.current.setShowNewSessionDialog(true);
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(true);
+
+      act(() => {
+        result.current.clearVault();
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(false);
+    });
+
+    it("dialog state is NOT persisted to localStorage (transient state)", () => {
+      const { result } = renderHook(() => useSession(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setShowNewSessionDialog(true);
+      });
+
+      expect(result.current.showNewSessionDialog).toBe(true);
+
+      // Check localStorage doesn't contain dialog state
+      const allKeys = Object.keys(localStorage);
+      const dialogKeys = allKeys.filter(
+        (key) => key.includes("dialog") || key.includes("Dialog") || key.includes("newSession")
+      );
+      expect(dialogKeys.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Move `showNewSessionDialog` state from local `useState` in Discussion.tsx to SessionContext
- Dialog state now survives tab switches (component unmount/remount)
- Reset dialog state when vault changes to prevent stale dialogs

## Root Cause

The Discussion component was conditionally rendered based on mode in App.tsx. When switching tabs, the component unmounted, losing the local `showNewSessionDialog` state. On remount, the dialog was gone.

## Test plan

- [x] Typecheck passes
- [x] All 382 tests pass (7 new tests added)
- [ ] Manual: Click + button on Discussion tab → switch to Home → switch back → dialog should still be visible
- [ ] Manual: Open dialog → change vault → dialog should close

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)