### PR TITLE
fix: Prevent race condition when starting new session

### DIFF
--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -110,6 +110,8 @@ export interface SessionState {
   pendingSessionId: string | null;
   /** Whether the new session confirmation dialog is shown (persists across tab switches) */
   showNewSessionDialog: boolean;
+  /** Whether user wants a new session (skip auto-resume on reconnect) */
+  wantsNewSession: boolean;
 }
 
 /**
@@ -345,6 +347,7 @@ function sessionReducer(
         // Clear transient UI state when switching vaults
         discussionPrefill: null,
         showNewSessionDialog: false,
+        wantsNewSession: false,
       };
 
     case "CLEAR_VAULT":
@@ -359,12 +362,14 @@ function sessionReducer(
         goals: null,
         discussionPrefill: null,
         showNewSessionDialog: false,
+        wantsNewSession: false,
       };
 
     case "SET_SESSION_ID":
       return {
         ...state,
         sessionId: action.sessionId,
+        wantsNewSession: false, // Clear when session is established
       };
 
     case "SET_SESSION_START_TIME":
@@ -420,6 +425,7 @@ function sessionReducer(
         ...state,
         sessionId: null,
         messages: [],
+        wantsNewSession: true,
       };
 
     case "SET_MESSAGES":
@@ -592,6 +598,8 @@ function sessionReducer(
       return {
         ...state,
         pendingSessionId: action.sessionId,
+        // Clear wantsNewSession - explicit resume request overrides "new session" intent
+        wantsNewSession: action.sessionId ? false : state.wantsNewSession,
       };
 
     case "SET_SHOW_NEW_SESSION_DIALOG":
@@ -806,6 +814,7 @@ const initialState: SessionState = {
   discussionPrefill: null,
   pendingSessionId: null,
   showNewSessionDialog: false,
+  wantsNewSession: false,
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add `wantsNewSession` flag to SessionContext to persist intent to start fresh
- Vault selection effect skips auto-resume when flag is set
- Resume button clears the flag (explicit resume overrides new session intent)

## Root Cause

After clicking "New" to start a fresh session, the component would sometimes auto-resume the old session due to a race condition:
1. `startNewSession()` clears sessionId
2. Vault selection effect re-runs and fetches `/api/sessions/{vaultId}`
3. API returns old session before `new_session` is processed by backend
4. Old session gets resumed instead of starting fresh

## Test plan

- [x] All 395 tests pass (7 new tests for wantsNewSession)
- [x] Typecheck passes
- [x] Manual: Click New → confirm → new session starts (not old one)
- [x] Manual: Click New → switch tabs → switch back → new session (not old)
- [x] Manual: Click New → go to Home → click Resume → resumes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)