### PR TITLE
Float new session button over discussion content

### DIFF
--- a/frontend/src/components/Discussion.css
+++ b/frontend/src/components/Discussion.css
@@ -9,6 +9,7 @@
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+  position: relative;
 }
 
 /* Messages container */
@@ -240,23 +241,21 @@
 }
 
 /* ============================================
-   New Session Button
+   New Session Button (floating overlay)
    ============================================ */
 
-.discussion__header {
-  display: flex;
-  align-items: center;
-  padding: var(--spacing-xs) var(--spacing-md);
-  flex-shrink: 0;
-}
-
 .discussion__new-btn {
+  position: absolute;
+  top: var(--spacing-sm);
+  left: var(--spacing-md);
+  z-index: 10;
   width: 32px;
   height: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
   background: transparent;
+  backdrop-filter: blur(var(--glass-blur-light));
   color: var(--color-text-secondary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -265,6 +264,12 @@
   line-height: 1;
   cursor: pointer;
   transition: all 0.2s ease;
+}
+
+@supports not (backdrop-filter: blur(10px)) {
+  .discussion__new-btn {
+    background-color: var(--color-surface);
+  }
 }
 
 .discussion__new-btn:hover {

--- a/frontend/src/components/Discussion.tsx
+++ b/frontend/src/components/Discussion.tsx
@@ -339,17 +339,15 @@ export function Discussion(): React.ReactNode {
 
   return (
     <div className="discussion">
-      <div className="discussion__header">
-        <button
-          type="button"
-          className="discussion__new-btn"
-          onClick={handleNewSessionClick}
-          aria-label="Start new session"
-          title="New session"
-        >
-          +
-        </button>
-      </div>
+      <button
+        type="button"
+        className="discussion__new-btn"
+        onClick={handleNewSessionClick}
+        aria-label="Start new session"
+        title="New session"
+      >
+        +
+      </button>
 
       <div className="discussion__messages" role="list" aria-label="Conversation">
         {messages.length === 0 ? (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -155,6 +155,7 @@
   --glass-border-hover: rgba(168, 85, 247, 0.5);
   --glass-border-accent: rgba(85, 168, 247, 0.5);
   --glass-blur: 10px;
+  --glass-blur-light: 2px;
   --glass-shadow:
     0 4px 24px rgba(0, 0, 0, 0.3),
     inset 0 1px 0 rgba(255, 255, 255, 0.07),


### PR DESCRIPTION
## Summary
- Remove the dedicated header section that created dead space above the chat
- Position the new session button as a floating overlay in the top-left corner
- Add subtle backdrop blur to keep the button visible when scrolling over messages

## Test plan
- [ ] Verify the button appears in the top-left corner of the discussion view
- [ ] Scroll through messages and confirm the button remains visible and clickable
- [ ] Click the button and verify the new session dialog still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)