### PR TITLE
Add background sigils to mode toggle buttons

### DIFF
--- a/frontend/src/components/ModeToggle.css
+++ b/frontend/src/components/ModeToggle.css
@@ -60,3 +60,27 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+.mode-toggle__label {
+  position: relative;
+  z-index: 1;
+}
+
+.mode-toggle__sigil {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.25rem;
+  opacity: 0.15;
+  filter: blur(2px);
+  transform: translate(2px, -2px);
+  z-index: 0;
+  pointer-events: none;
+  user-select: none;
+}
+
+.mode-toggle__segment--selected .mode-toggle__sigil {
+  opacity: 0.25;
+}

--- a/frontend/src/components/ModeToggle.tsx
+++ b/frontend/src/components/ModeToggle.tsx
@@ -22,16 +22,17 @@ export interface ModeToggleProps {
 interface ModeOption {
   value: AppMode;
   label: string;
+  sigil: string;
 }
 
 /**
  * Available mode options.
  */
 const modes: ModeOption[] = [
-  { value: "home", label: "Ground" },
-  { value: "note", label: "Capture" },
-  { value: "discussion", label: "Think" },
-  { value: "browse", label: "Recall" },
+  { value: "home", label: "Ground", sigil: "🪨" },
+  { value: "note", label: "Capture", sigil: "🪶" },
+  { value: "discussion", label: "Think", sigil: "✨" },
+  { value: "browse", label: "Recall", sigil: "🪞" },
 ];
 
 /**
@@ -64,7 +65,10 @@ export function ModeToggle({ disabled = false }: ModeToggleProps): React.ReactNo
           onClick={() => handleClick(option.value)}
           disabled={disabled}
         >
-          {option.label}
+          <span className="mode-toggle__sigil" aria-hidden="true">
+            {option.sigil}
+          </span>
+          <span className="mode-toggle__label">{option.label}</span>
         </button>
       ))}
     </div>


### PR DESCRIPTION
## Summary

- Add faint emoji sigils behind each header button as decorative watermarks
- Ground: 🪨 (rock), Capture: 🪶 (quill), Think: ✨ (constellation), Recall: 🪞 (mirror)
- Sigils are enlarged, blurred, low opacity, and slightly offset

## Test plan

- [ ] Verify sigils appear behind each button with subtle blur effect
- [ ] Confirm sigils are more visible when button is selected
- [ ] Check appearance on mobile viewport

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)