### PR TITLE
ux: move capture button above textarea for iOS keyboard visibility

### DIFF
--- a/frontend/src/components/NoteCapture.tsx
+++ b/frontend/src/components/NoteCapture.tsx
@@ -198,6 +198,13 @@ export function NoteCapture({ onCaptured }: NoteCaptureProps): React.ReactNode {
   return (
     <div className="note-capture">
       <form className="note-capture__form" onSubmit={handleSubmit}>
+        <button
+          type="submit"
+          className="note-capture__submit"
+          disabled={isDisabled || !content.trim()}
+        >
+          {isSubmitting ? "Saving..." : "Capture Note"}
+        </button>
         <textarea
           ref={textareaRef}
           className="note-capture__input"
@@ -208,13 +215,6 @@ export function NoteCapture({ onCaptured }: NoteCaptureProps): React.ReactNode {
           rows={3}
           aria-label="Note content"
         />
-        <button
-          type="submit"
-          className="note-capture__submit"
-          disabled={isDisabled || !content.trim()}
-        >
-          {isSubmitting ? "Saving..." : "Capture Note"}
-        </button>
       </form>
 
       {toast.visible && (


### PR DESCRIPTION
## Summary
- Moves the "Capture Note" button above the textarea in the NoteCapture component
- Fixes iOS issue where the keyboard obscures the submit button when positioned below the input

## Test plan
- [ ] Open the app on iOS Safari
- [ ] Navigate to the Note capture screen
- [ ] Tap the textarea to open the keyboard
- [ ] Verify the "Capture Note" button remains visible and accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)