### PR TITLE
fix: render ConfirmDialog via portal to fix positioning

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { useId } from "react";
+import { createPortal } from "react-dom";
 import "./ConfirmDialog.css";
 
 export interface ConfirmDialogProps {
@@ -41,7 +42,7 @@ export function ConfirmDialog({
     }
   }
 
-  return (
+  return createPortal(
     <div
       className="confirm-dialog__backdrop"
       onClick={handleBackdropClick}
@@ -74,6 +75,7 @@ export function ConfirmDialog({
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/frontend/src/components/__tests__/ConfirmDialog.test.tsx
+++ b/frontend/src/components/__tests__/ConfirmDialog.test.tsx
@@ -96,10 +96,10 @@ describe("ConfirmDialog", () => {
 
     it("calls onCancel when backdrop is clicked", () => {
       const onCancel = mock(() => {});
-      const { container } = render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
+      render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
 
-      // Click on the backdrop (parent of the dialog)
-      const backdrop = container.querySelector(".confirm-dialog__backdrop");
+      // Click on the backdrop (rendered to document.body via portal)
+      const backdrop = document.querySelector(".confirm-dialog__backdrop");
       expect(backdrop).not.toBeNull();
       fireEvent.click(backdrop!);
 
@@ -119,10 +119,10 @@ describe("ConfirmDialog", () => {
 
     it("calls onCancel when Escape key is pressed", () => {
       const onCancel = mock(() => {});
-      const { container } = render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
+      render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
 
-      // Escape key handler is on the backdrop
-      const backdrop = container.querySelector(".confirm-dialog__backdrop");
+      // Escape key handler is on the backdrop (rendered to document.body via portal)
+      const backdrop = document.querySelector(".confirm-dialog__backdrop");
       fireEvent.keyDown(backdrop!, { key: "Escape" });
 
       expect(onCancel).toHaveBeenCalledTimes(1);
@@ -130,9 +130,9 @@ describe("ConfirmDialog", () => {
 
     it("does not call onCancel for other keys", () => {
       const onCancel = mock(() => {});
-      const { container } = render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
+      render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
 
-      const backdrop = container.querySelector(".confirm-dialog__backdrop");
+      const backdrop = document.querySelector(".confirm-dialog__backdrop");
       fireEvent.keyDown(backdrop!, { key: "Enter" });
 
       expect(onCancel).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Render ConfirmDialog to `document.body` via React portal to fix CSS stacking context issue
- The change vault dialog was appearing at the bottom instead of centered because App.css's `.app > *` rule overrode `position: fixed` with `position: relative`
- Updated tests to query `document` instead of container since portal renders outside the test container

Fixes #125

## Test plan

- [ ] Open the app with a vault selected
- [ ] Click the vault name button in the header to trigger the "Change Vault?" dialog
- [ ] Verify the dialog appears centered and covers the full screen with a backdrop
- [ ] Verify clicking outside the dialog dismisses it
- [ ] Verify the "New Session" dialog in Discussion mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)