### PR TITLE
feat: add vault transfer MCP tool for cross-vault file operations

### DIFF
--- a/backend/src/session-manager.ts
+++ b/backend/src/session-manager.ts
@@ -667,7 +667,7 @@ export async function createSession(
 
     const mergedOptions: Partial<Options> = {
       ...DISCUSSION_MODE_OPTIONS,
-      ...options, // Caller options first, then we override specific fields
+      ...options, // Merge defaults then caller options, then force specific fields below
       cwd: vault.path,
       settingSources: ["project", "user"],
       mcpServers: {
@@ -769,7 +769,7 @@ export async function resumeSession(
 
     const mergedOptions: Partial<Options> = {
       ...DISCUSSION_MODE_OPTIONS,
-      ...options, // Caller options first, then we override specific fields
+      ...options, // Merge defaults then caller options, then force specific fields below
       resume: sessionId,
       cwd: metadata.vaultPath,
       settingSources: ["project", "user"],


### PR DESCRIPTION
## Summary

- Adds SDK MCP server with `transfer_file` and `list_vaults` tools for Claude to move/copy markdown files between vaults
- Integrates vault transfer server into Discussion mode sessions
- Implements security protections: path traversal prevention, symlink rejection, markdown-only restriction

## Test plan

- [x] Unit tests for copy operations (same path, different path, nested directories)
- [x] Unit tests for move operations (delete source after copy)
- [x] Unit tests for overwrite behavior (enabled/disabled)
- [x] Unit tests for error cases (missing vault, missing file, invalid file type)
- [x] Unit tests for security (path traversal, symlink attacks)
- [x] Unit tests for move operation failure recovery
- [x] All backend tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes

Closes #152

🤖 Generated with [Claude Code](https://claude.ai/code)