### PR TITLE
ux: improve note capture placeholder to show destination

### DIFF
--- a/frontend/src/components/NoteCapture.tsx
+++ b/frontend/src/components/NoteCapture.tsx
@@ -210,7 +210,7 @@ export function NoteCapture({ onCaptured }: NoteCaptureProps): React.ReactNode {
           className="note-capture__input"
           value={content}
           onChange={handleChange}
-          placeholder="What's on your mind?"
+          placeholder="What's on your mind? Goes to your daily note."
           disabled={isSubmitting}
           rows={3}
           aria-label="Note content"

--- a/frontend/src/components/__tests__/NoteCapture.test.tsx
+++ b/frontend/src/components/__tests__/NoteCapture.test.tsx
@@ -117,7 +117,7 @@ describe("NoteCapture", () => {
         expect(wsInstances.length).toBeGreaterThan(0);
       });
 
-      expect(screen.getByPlaceholderText("What's on your mind?")).toBeDefined();
+      expect(screen.getByPlaceholderText("What's on your mind? Goes to your daily note.")).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- Updates the note capture placeholder from "What's on your mind?" to "What's on your mind? Goes to your daily note."
- Helps users understand where captured notes are saved without adding visual clutter

Closes #142

## Test plan
- [x] Placeholder text updated in NoteCapture component
- [x] Test updated to match new placeholder
- [x] All 13 NoteCapture tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)