### PR TITLE
fix: include cached slash commands in resume_session response

### DIFF
--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -1106,13 +1106,19 @@ export class WebSocketHandler {
 
       log.info(`Resuming session ${sessionId} with ${metadata.messages.length} messages`);
 
+      // Load cached slash commands for immediate autocomplete
+      const vaultConfig = await loadVaultConfig(this.state.currentVault.path);
+      const cachedCommands = vaultConfig.slashCommands;
+
       // Send session_ready with conversation history for frontend to display
+      // Include cached slash commands for immediate autocomplete availability
       this.send(ws, {
         type: "session_ready",
         sessionId,
         vaultId: this.state.currentVault.id,
         messages: metadata.messages,
         createdAt: metadata.createdAt,
+        slashCommands: cachedCommands && cachedCommands.length > 0 ? cachedCommands : undefined,
       });
     } catch (error) {
       log.error("Failed to load session for validation", error);


### PR DESCRIPTION
## Summary

- Adds cached slash command loading to `handleResumeSession` in the backend
- Fixes slash command autocomplete being empty after page refresh

The caching feature (#159) only added cached command loading to `handleSelectVault`, missing `handleResumeSession`. When users refresh the page, auto-resume sends `resume_session` which was returning `session_ready` without `slashCommands`, causing autocomplete to be empty.

## Test plan

- [x] Backend tests pass (96 tests)
- [x] Frontend tests pass (532 tests)
- [x] Typecheck passes
- [ ] Manual test: refresh page with existing session, verify slash command autocomplete works immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)