### PR TITLE
fix: refresh button now also refreshes task list

### DIFF
--- a/frontend/src/components/BrowseMode.tsx
+++ b/frontend/src/components/BrowseMode.tsx
@@ -244,12 +244,15 @@ export function BrowseMode({ assetBaseUrl }: BrowseModeProps): React.ReactNode {
     setIsTreeCollapsed((prev) => !prev);
   }, []);
 
-  // Reload file tree (clear cache and refetch root, preserves pinned folders)
+  // Reload file tree and task list (clear cache and refetch, preserves pinned folders)
   const handleReload = useCallback(() => {
     clearDirectoryCache();
     setFileLoading(true);
     sendMessage({ type: "list_directory", path: "" });
-  }, [clearDirectoryCache, setFileLoading, sendMessage]);
+    // Also refresh task list
+    setTasksLoading(true);
+    sendMessage({ type: "get_tasks" });
+  }, [clearDirectoryCache, setFileLoading, setTasksLoading, sendMessage]);
 
   // Toggle mobile tree overlay
   const toggleMobileTree = useCallback(() => {


### PR DESCRIPTION
## Summary
- Fixes the refresh button in Browse mode to also refresh the task list, not just the file tree
- When clicked, the reload button now sends both `list_directory` and `get_tasks` messages

Fixes #164

## Test plan
- [x] All 532 frontend tests pass
- [x] TypeScript type checking passes
- [ ] Manual test: switch to Tasks view, click refresh, verify tasks reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)