### PR TITLE
feat: add right-click context menu for task state selection

### DIFF
--- a/frontend/src/components/TaskList.css
+++ b/frontend/src/components/TaskList.css
@@ -326,3 +326,95 @@
     padding: var(--spacing-sm);
   }
 }
+
+/* ============================================
+   Context Menu for Task State Selection
+   ============================================ */
+
+.task-list__context-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 160px;
+  padding: var(--spacing-xs);
+  background: var(--glass-bg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 32px var(--color-black-a40);
+  animation: task-list-context-menu-appear 0.15s ease-out;
+}
+
+@keyframes task-list-context-menu-appear {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.task-list__context-menu-header {
+  padding: var(--spacing-xs) var(--spacing-md);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--glass-border);
+  margin-bottom: var(--spacing-xs);
+}
+
+.task-list__context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  width: 100%;
+  min-height: 44px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.task-list__context-menu-item:hover {
+  background: var(--color-accent-primary-a15);
+}
+
+.task-list__context-menu-item:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.task-list__context-menu-item--active {
+  background: var(--color-accent-primary-a10);
+}
+
+.task-list__context-menu-indicator {
+  font-size: 18px;
+  line-height: 1;
+  min-width: 24px;
+  text-align: center;
+}
+
+/* State-specific indicator colors in context menu */
+.task-list__context-menu-indicator[data-state="/"] {
+  color: var(--color-warning, #f59e0b);
+}
+
+.task-list__context-menu-indicator[data-state="?"] {
+  color: var(--color-info, #3b82f6);
+}
+
+.task-list__context-menu-indicator[data-state="b"],
+.task-list__context-menu-indicator[data-state="f"] {
+  /* Emojis have their own colors */
+  color: inherit;
+}


### PR DESCRIPTION
## Summary

- Changes task toggle behavior: left-click toggles between incomplete/complete only
- Adds right-click context menu for special states (partial, needs info, bookmarked, urgent)
- Includes iOS long-press support (500ms timer) following FileTree's pin/unpin pattern

## Test plan

- [x] Left-click on incomplete task toggles to complete
- [x] Left-click on complete task toggles to incomplete
- [x] Left-click on special state (e.g., partial) resets to incomplete
- [x] Right-click opens context menu with special state options
- [x] Selecting a state from menu updates the task
- [x] Context menu closes on click outside or Escape key
- [x] All 540 tests pass

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)