### PR TITLE
fix: task toggle and context menu use correct state

### DIFF
--- a/backend/src/__tests__/websocket-handler.test.ts
+++ b/backend/src/__tests__/websocket-handler.test.ts
@@ -3021,7 +3021,8 @@ describe("WebSocket Handler", () => {
       expect(mockToggleTask).toHaveBeenCalledWith(
         vault.contentRoot,
         "00_Inbox/tasks.md",
-        5
+        5,
+        undefined
       );
     });
 

--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -425,7 +425,7 @@ export class WebSocketHandler {
         await this.handleGetTasks(ws);
         break;
       case "toggle_task":
-        await this.handleToggleTask(ws, message.filePath, message.lineNumber);
+        await this.handleToggleTask(ws, message.filePath, message.lineNumber, message.newState);
         break;
       case "delete_session":
         await this.handleDeleteSession(ws, message.sessionId);
@@ -1574,15 +1574,16 @@ export class WebSocketHandler {
 
   /**
    * Handles toggle_task message.
-   * Toggles the checkbox state of a task in a file.
-   * State cycle: ' ' -> 'x' -> '/' -> '?' -> 'b' -> 'f' -> ' '
+   * If newState is provided, sets to that state. Otherwise cycles:
+   * ' ' -> 'x' -> '/' -> '?' -> 'b' -> 'f' -> ' '
    */
   private async handleToggleTask(
     ws: WebSocketLike,
     filePath: string,
-    lineNumber: number
+    lineNumber: number,
+    newState?: string
   ): Promise<void> {
-    log.info(`Toggling task: ${filePath}:${lineNumber}`);
+    log.info(`Toggling task: ${filePath}:${lineNumber}${newState ? ` -> '${newState}'` : ""}`);
     if (!this.state.currentVault) {
       log.warn("No vault selected for task toggle");
       this.sendError(
@@ -1597,7 +1598,8 @@ export class WebSocketHandler {
       const result = await toggleTask(
         this.state.currentVault.contentRoot,
         filePath,
-        lineNumber
+        lineNumber,
+        newState
       );
 
       if (!result.success) {

--- a/frontend/src/components/BrowseMode.tsx
+++ b/frontend/src/components/BrowseMode.tsx
@@ -273,7 +273,7 @@ export function BrowseMode({ assetBaseUrl }: BrowseModeProps): React.ReactNode {
   // Handle task toggle from TaskList
   // Returns true if message was sent, false if unable to send (e.g., disconnected)
   const handleToggleTask = useCallback(
-    (filePath: string, lineNumber: number, originalState: string): boolean => {
+    (filePath: string, lineNumber: number, newState: string, originalState: string): boolean => {
       // Check connection status before attempting to send
       if (connectionStatus !== "connected") {
         setTasksError("Not connected. Please wait and try again.");
@@ -284,11 +284,12 @@ export function BrowseMode({ assetBaseUrl }: BrowseModeProps): React.ReactNode {
       const taskKey = `${filePath}:${lineNumber}`;
       pendingTaskTogglesRef.current.set(taskKey, originalState);
 
-      // Send toggle request to server
+      // Send toggle request to server with the desired new state
       sendMessage({
         type: "toggle_task",
         filePath,
         lineNumber,
+        newState,
       });
 
       return true;

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -15,7 +15,7 @@ import "./TaskList.css";
  */
 export interface TaskListProps {
   /** Callback when a task is toggled. Returns false to indicate failure (triggers rollback). */
-  onToggleTask?: (filePath: string, lineNumber: number, originalState: string) => boolean;
+  onToggleTask?: (filePath: string, lineNumber: number, newState: string, originalState: string) => boolean;
   /** Callback when a task's file is selected for viewing */
   onFileSelect?: (path: string) => void;
 }
@@ -361,9 +361,9 @@ export function TaskList({ onToggleTask, onFileSelect }: TaskListProps): React.R
       // Clear any previous error
       setTasksError(null);
 
-      // Notify parent to send WebSocket message
+      // Notify parent to send WebSocket message with both new and original state
       // Parent returns false if unable to send (e.g., disconnected)
-      const success = onToggleTask?.(filePath, lineNumber, currentState) ?? true;
+      const success = onToggleTask?.(filePath, lineNumber, newState, currentState) ?? true;
 
       // Rollback if parent indicates failure
       if (!success) {
@@ -446,8 +446,8 @@ export function TaskList({ onToggleTask, onFileSelect }: TaskListProps): React.R
       // Clear any previous error
       setTasksError(null);
 
-      // Notify parent to send WebSocket message
-      onToggleTask?.(filePath, lineNumber);
+      // Notify parent to send WebSocket message with both new and original state
+      onToggleTask?.(filePath, lineNumber, newState, currentState);
 
       // Close the menu
       closeContextMenu();

--- a/frontend/src/components/__tests__/TaskList.test.tsx
+++ b/frontend/src/components/__tests__/TaskList.test.tsx
@@ -26,7 +26,7 @@ function TaskListWithTasks({
   onToggleTask,
 }: {
   tasks: TaskEntry[];
-  onToggleTask?: (filePath: string, lineNumber: number, originalState: string) => boolean;
+  onToggleTask?: (filePath: string, lineNumber: number, newState: string, originalState: string) => boolean;
 }) {
   const { setTasks } = useSession();
 
@@ -155,15 +155,17 @@ describe("TaskList", () => {
 
       let toggledFilePath = "";
       let toggledLineNumber = 0;
+      let toggledNewState = "";
       let toggledOriginalState = "";
 
       render(
         <SessionProvider>
           <TaskListWithTasks
             tasks={tasks}
-            onToggleTask={(filePath, lineNumber, originalState) => {
+            onToggleTask={(filePath, lineNumber, newState, originalState) => {
               toggledFilePath = filePath;
               toggledLineNumber = lineNumber;
+              toggledNewState = newState;
               toggledOriginalState = originalState;
               return true;
             }}
@@ -179,6 +181,7 @@ describe("TaskList", () => {
 
       expect(toggledFilePath).toBe("file.md");
       expect(toggledLineNumber).toBe(5);
+      expect(toggledNewState).toBe("x"); // ' ' toggles to 'x'
       expect(toggledOriginalState).toBe(" ");
     });
 
@@ -497,14 +500,19 @@ describe("TaskList", () => {
 
       let toggledFilePath = "";
       let toggledLineNumber = 0;
+      let toggledNewState = "";
+      let toggledOriginalState = "";
 
       render(
         <SessionProvider>
           <TaskListWithTasks
             tasks={tasks}
-            onToggleTask={(filePath, lineNumber) => {
+            onToggleTask={(filePath, lineNumber, newState, originalState) => {
               toggledFilePath = filePath;
               toggledLineNumber = lineNumber;
+              toggledNewState = newState;
+              toggledOriginalState = originalState;
+              return true;
             }}
           />
         </SessionProvider>
@@ -520,9 +528,11 @@ describe("TaskList", () => {
       const urgentOption = screen.getByRole("menuitem", { name: /urgent/i });
       fireEvent.click(urgentOption);
 
-      // Should call onToggleTask
+      // Should call onToggleTask with the selected state
       expect(toggledFilePath).toBe("file.md");
       expect(toggledLineNumber).toBe(1);
+      expect(toggledNewState).toBe("f"); // 'f' is the urgent state
+      expect(toggledOriginalState).toBe(" ");
 
       // Context menu should be closed
       expect(screen.queryByRole("menu")).toBeNull();

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -263,13 +263,16 @@ export const GetTasksMessageSchema = z.object({
 });
 
 /**
- * Client requests to toggle a task's checkbox state
- * Server will cycle through states: ' ' -> 'x' -> '/' -> '?' -> 'b' -> 'f' -> ' '
+ * Client requests to toggle a task's checkbox state.
+ * If newState is provided, sets task to that state directly.
+ * Otherwise cycles through states: ' ' -> 'x' -> '/' -> '?' -> 'b' -> 'f' -> ' '
  */
 export const ToggleTaskMessageSchema = z.object({
   type: z.literal("toggle_task"),
   filePath: z.string().min(1, "File path is required"),
   lineNumber: z.number().int().min(1, "Line number must be at least 1"),
+  /** Optional: set task to this specific state instead of cycling */
+  newState: z.string().length(1, "State must be a single character").optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- **Left-click task toggle now works correctly**: toggles between incomplete (`[ ]`) and complete (`[x]`), or resets other states to incomplete
- **Right-click context menu selection now works**: clicking a state in the context menu sets the task to that state
- Added optional `newState` field to `toggle_task` WebSocket message to support explicit state setting

## Root Cause

The `toggle_task` message only sent `filePath` and `lineNumber`. The server always cycled through all states (`' '` → `x` → `/` → `?` → `b` → `f` → `' '`), ignoring the frontend's intended state. The server's response would overwrite any optimistic update.

## Changes

- **Protocol**: Added optional `newState` field to `ToggleTaskMessageSchema`
- **Backend**: `toggleTask()` now accepts optional `newState` parameter; if provided, sets directly instead of cycling
- **Frontend**: `onToggleTask` callback now passes `(filePath, lineNumber, newState, originalState)` so server gets the intended state

## Test plan

- [x] All pre-commit checks pass (typecheck, lint, unit tests)
- [ ] Manual test: Left-click toggles `[ ]` ↔ `[x]`
- [ ] Manual test: Right-click → select state → task shows selected state

🤖 Generated with [Claude Code](https://claude.com/claude-code)