### PR TITLE
fix: correct Archive directory name from plural to singular

### DIFF
--- a/.sdd/plans/memory-loop/2026-01-05-vault-setup-plan.md
+++ b/.sdd/plans/memory-loop/2026-01-05-vault-setup-plan.md
@@ -199,7 +199,7 @@ Validation happens first, before any filesystem modifications. If validation fai
 
 Strategy:
 1. Load vault config for custom paths
-2. For each PARA directory (01_Projects, 02_Areas, 03_Resources, 04_Archives):
+2. For each PARA directory (01_Projects, 02_Areas, 03_Resources, 04_Archive):
    - Resolve path using config or defaults
    - Check if exists
    - If missing, create with `mkdir -p` equivalent
@@ -277,7 +277,7 @@ Vault configuration:
   - Projects: {projectPath}
   - Areas: {areaPath}
   - Resources: 03_Resources
-  - Archives: 04_Archives
+  - Archives: 04_Archive
 
 Instructions:
 1. Preserve all existing content

--- a/.sdd/specs/memory-loop/2026-01-05-vault-setup.md
+++ b/.sdd/specs/memory-loop/2026-01-05-vault-setup.md
@@ -88,7 +88,7 @@ As a Memory Loop user setting up a new vault, I want to click a single button th
 - **REQ-F-32**: Setup must create `01_Projects/` if it doesn't exist
 - **REQ-F-33**: Setup must create `02_Areas/` if it doesn't exist
 - **REQ-F-34**: Setup must create `03_Resources/` if it doesn't exist
-- **REQ-F-35**: Setup must create `04_Archives/` if it doesn't exist
+- **REQ-F-35**: Setup must create `04_Archive/` if it doesn't exist
 - **REQ-F-36**: Setup must respect custom paths from `.memory-loop.json` (projectPath, areaPath)
 - **REQ-F-37**: Existing directories must not be modified (only missing ones created)
 
@@ -168,7 +168,7 @@ Commands will be stored in the backend and copied to vaults during setup:
 
 5. **Command Preservation**: Given a vault with existing `.claude/commands/daily-debrief.md`, when setup runs, then the existing file is not overwritten and summary notes it was skipped.
 
-6. **PARA Creation**: Given a vault without PARA directories, when setup completes, then `01_Projects/`, `02_Areas/`, `03_Resources/`, `04_Archives/` exist relative to content root.
+6. **PARA Creation**: Given a vault without PARA directories, when setup completes, then `01_Projects/`, `02_Areas/`, `03_Resources/`, `04_Archive/` exist relative to content root.
 
 7. **PARA Preservation**: Given a vault with existing `01_Projects/` containing files, when setup runs, then the directory and its contents are unchanged.
 

--- a/backend/src/__tests__/vault-setup.test.ts
+++ b/backend/src/__tests__/vault-setup.test.ts
@@ -265,7 +265,7 @@ describe("createParaDirectories", () => {
     expect(await directoryExists(join(vaultPath, "01_Projects"))).toBe(true);
     expect(await directoryExists(join(vaultPath, "02_Areas"))).toBe(true);
     expect(await directoryExists(join(vaultPath, "03_Resources"))).toBe(true);
-    expect(await directoryExists(join(vaultPath, "04_Archives"))).toBe(true);
+    expect(await directoryExists(join(vaultPath, "04_Archive"))).toBe(true);
   });
 
   test("skips existing directories", async () => {
@@ -318,7 +318,7 @@ describe("createParaDirectories", () => {
     expect(await directoryExists(join(contentRoot, "01_Projects"))).toBe(true);
     expect(await directoryExists(join(contentRoot, "02_Areas"))).toBe(true);
     expect(await directoryExists(join(contentRoot, "03_Resources"))).toBe(true);
-    expect(await directoryExists(join(contentRoot, "04_Archives"))).toBe(true);
+    expect(await directoryExists(join(contentRoot, "04_Archive"))).toBe(true);
   });
 
   test("returns list of created directories", async () => {
@@ -337,7 +337,7 @@ describe("createParaDirectories", () => {
     await mkdir(join(vaultPath, "01_Projects"));
     await mkdir(join(vaultPath, "02_Areas"));
     await mkdir(join(vaultPath, "03_Resources"));
-    await mkdir(join(vaultPath, "04_Archives"));
+    await mkdir(join(vaultPath, "04_Archive"));
 
     const result = await createParaDirectories(vaultPath, {});
 
@@ -675,7 +675,7 @@ describe("runVaultSetup", () => {
     expect(await directoryExists(join(vaultPath, "01_Projects"))).toBe(true);
     expect(await directoryExists(join(vaultPath, "02_Areas"))).toBe(true);
     expect(await directoryExists(join(vaultPath, "03_Resources"))).toBe(true);
-    expect(await directoryExists(join(vaultPath, "04_Archives"))).toBe(true);
+    expect(await directoryExists(join(vaultPath, "04_Archive"))).toBe(true);
 
     // Verify marker written
     expect(await isSetupComplete(vaultPath)).toBe(true);

--- a/backend/src/vault-setup.ts
+++ b/backend/src/vault-setup.ts
@@ -118,7 +118,7 @@ export const DEFAULT_RESOURCES_PATH = "03_Resources";
 /**
  * Default path for Archives directory (relative to content root).
  */
-export const DEFAULT_ARCHIVES_PATH = "04_Archives";
+export const DEFAULT_ARCHIVES_PATH = "04_Archive";
 
 /**
  * Path to CLAUDE.md backup relative to vault root.


### PR DESCRIPTION
## Summary

Fixes #171 - Corrects the Archive directory name from plural "04_Archives" to singular "04_Archive" to align with PARA methodology.

## Changes

- `backend/src/vault-setup.ts`: Changed `DEFAULT_ARCHIVES_PATH` constant from "04_Archives" to "04_Archive"
- `backend/src/__tests__/vault-setup.test.ts`: Updated all 4 test assertions to expect the singular form
- `.sdd/specs/memory-loop/2026-01-05-vault-setup.md`: Updated spec documentation references
- `.sdd/plans/memory-loop/2026-01-05-vault-setup-plan.md`: Updated plan documentation references

## Test Plan

- ✅ All 36 tests in `vault-setup.test.ts` passing
- ✅ Tests verify that "04_Archive" directory is created during vault setup
- ✅ No other functionality affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)