### PR TITLE
docs: add systemd service example for running as user service

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,37 @@ hostname -I | awk '{print $1}'
 http://YOUR_IP:5173
 ```
 
+## Running as a Service (systemd)
+
+To run Memory Loop automatically on boot (Linux with systemd):
+
+```bash
+# Copy the example service file
+mkdir -p ~/.config/systemd/user
+cp scripts/memory-loop.service.example ~/.config/systemd/user/memory-loop.service
+
+# Edit the service file with your paths
+# - Set WorkingDirectory to your memory-loop location
+# - Set VAULTS_DIR to your vaults directory
+# - Uncomment PATH line if bun isn't in /usr/bin
+nano ~/.config/systemd/user/memory-loop.service
+
+# Enable and start the service
+systemctl --user daemon-reload
+systemctl --user enable --now memory-loop
+
+# Start at boot without requiring login
+loginctl enable-linger $USER
+```
+
+Useful commands:
+
+```bash
+systemctl --user status memory-loop   # Check status
+systemctl --user restart memory-loop  # Restart
+journalctl --user -u memory-loop -f   # View logs
+```
+
 ## Architecture
 
 ```

--- a/scripts/memory-loop.service.example
+++ b/scripts/memory-loop.service.example
@@ -1,0 +1,44 @@
+# Memory Loop systemd user service
+#
+# Installation:
+#   1. Copy to ~/.config/systemd/user/memory-loop.service
+#   2. Edit paths and environment variables below
+#   3. Run: systemctl --user daemon-reload
+#   4. Run: systemctl --user enable --now memory-loop
+#
+# To start at boot without login:
+#   loginctl enable-linger $USER
+#
+# Logs:
+#   journalctl --user -u memory-loop -f
+
+[Unit]
+Description=Memory Loop - Obsidian vault interface
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/YOUR_USER/Projects/memory-loop
+
+# Build frontend before starting (remove if you build separately)
+ExecStartPre=/usr/bin/env bash -c 'cd frontend && bun run build'
+
+# Start the backend server
+ExecStart=/usr/bin/env bash -c 'cd backend && exec bun run start'
+
+Restart=on-failure
+RestartSec=5
+
+# Environment - edit these for your setup
+Environment=VAULTS_DIR=/path/to/your/vaults
+Environment=PORT=3000
+Environment=HOST=0.0.0.0
+
+# Uncomment if bun is not in default PATH
+#Environment=PATH=/home/YOUR_USER/.bun/bin:/usr/local/bin:/usr/bin:/bin
+
+# Or use an environment file instead of inline variables:
+#EnvironmentFile=/home/YOUR_USER/.config/memory-loop.env
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

- Add `scripts/memory-loop.service.example` template for running Memory Loop as a systemd user service
- Update README.md with setup instructions for copying, configuring, and enabling the service

## Test plan

- [ ] Verify service file syntax: `systemd-analyze verify memory-loop.service`
- [ ] Test service starts correctly after configuration
- [ ] Confirm logs appear in journalctl

🤖 Generated with [Claude Code](https://claude.com/claude-code)