### PR TITLE
feat: add vault title/subtitle parsing and config overrides

### DIFF
--- a/backend/src/__tests__/vault-config.test.ts
+++ b/backend/src/__tests__/vault-config.test.ts
@@ -122,6 +122,77 @@ describe("vault-config", () => {
       expect(config).toEqual({ metadataPath: "meta" });
     });
 
+    test("loads config with only title", async () => {
+      await writeFile(
+        join(testDir, CONFIG_FILE_NAME),
+        JSON.stringify({ title: "Custom Vault Title" })
+      );
+
+      const config = await loadVaultConfig(testDir);
+      expect(config).toEqual({ title: "Custom Vault Title" });
+    });
+
+    test("loads config with title and other fields", async () => {
+      const configData: VaultConfig = {
+        title: "My Vault",
+        contentRoot: "content",
+        inboxPath: "inbox",
+      };
+      await writeFile(
+        join(testDir, CONFIG_FILE_NAME),
+        JSON.stringify(configData)
+      );
+
+      const config = await loadVaultConfig(testDir);
+      expect(config).toEqual(configData);
+    });
+
+    test("ignores non-string title value", async () => {
+      await writeFile(
+        join(testDir, CONFIG_FILE_NAME),
+        JSON.stringify({ title: 123, contentRoot: "content" })
+      );
+
+      const config = await loadVaultConfig(testDir);
+      expect(config).toEqual({ contentRoot: "content" });
+      expect(config.title).toBeUndefined();
+    });
+
+    test("loads config with only subtitle", async () => {
+      await writeFile(
+        join(testDir, CONFIG_FILE_NAME),
+        JSON.stringify({ subtitle: "Personal Notes" })
+      );
+
+      const config = await loadVaultConfig(testDir);
+      expect(config).toEqual({ subtitle: "Personal Notes" });
+    });
+
+    test("loads config with title and subtitle", async () => {
+      const configData: VaultConfig = {
+        title: "My Vault",
+        subtitle: "Personal Notes",
+      };
+      await writeFile(
+        join(testDir, CONFIG_FILE_NAME),
+        JSON.stringify(configData)
+      );
+
+      const config = await loadVaultConfig(testDir);
+      expect(config).toEqual(configData);
+    });
+
+    test("ignores non-string subtitle value", async () => {
+      await writeFile(
+        join(testDir, CONFIG_FILE_NAME),
+        JSON.stringify({ subtitle: 123, contentRoot: "content" })
+      );
+
+      const config = await loadVaultConfig(testDir);
+      expect(config).toEqual({ contentRoot: "content" });
+      expect(config.subtitle).toBeUndefined();
+    });
+
     test("loads config with only projectPath", async () => {
       await writeFile(
         join(testDir, CONFIG_FILE_NAME),

--- a/backend/src/vault-config.ts
+++ b/backend/src/vault-config.ts
@@ -26,6 +26,18 @@ export const CONFIG_FILE_NAME = ".memory-loop.json";
  */
 export interface VaultConfig {
   /**
+   * Override the vault title extracted from CLAUDE.md.
+   * If set, this takes precedence over the H1 heading.
+   */
+  title?: string;
+
+  /**
+   * Override the vault subtitle extracted from CLAUDE.md.
+   * If set, this takes precedence over the portion after " - " in the heading.
+   */
+  subtitle?: string;
+
+  /**
    * Root directory for vault content.
    * Use when content is in a subdirectory (e.g., "content" for Quartz).
    * Default: "" (vault root)
@@ -108,6 +120,14 @@ export async function loadVaultConfig(vaultPath: string): Promise<VaultConfig> {
     // Extract and validate known fields
     const config: VaultConfig = {};
     const obj = parsed as Record<string, unknown>;
+
+    if (typeof obj.title === "string") {
+      config.title = obj.title;
+    }
+
+    if (typeof obj.subtitle === "string") {
+      config.subtitle = obj.subtitle;
+    }
 
     if (typeof obj.contentRoot === "string") {
       config.contentRoot = obj.contentRoot;

--- a/frontend/src/components/VaultSelect.css
+++ b/frontend/src/components/VaultSelect.css
@@ -300,6 +300,12 @@
   margin: 0;
 }
 
+.vault-select__vault-subtitle {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
 .vault-select__vault-path {
   font-size: var(--font-size-xs);
   font-family: var(--font-family-mono);

--- a/frontend/src/components/VaultSelect.tsx
+++ b/frontend/src/components/VaultSelect.tsx
@@ -377,6 +377,9 @@ export function VaultSelect({ onReady }: VaultSelectProps): React.ReactNode {
               aria-disabled={selectedVaultId !== null}
             >
               <h2 className="vault-select__vault-name">{vault.name}</h2>
+              {vault.subtitle && (
+                <p className="vault-select__vault-subtitle">{vault.subtitle}</p>
+              )}
               <p className="vault-select__vault-path">{vault.path}</p>
               <div className="vault-select__vault-badges">
                 {vault.hasClaudeMd && (

--- a/frontend/src/components/__tests__/VaultSelect.test.tsx
+++ b/frontend/src/components/__tests__/VaultSelect.test.tsx
@@ -166,6 +166,68 @@ describe("VaultSelect", () => {
         expect(statusElements.length).toBeGreaterThan(0);
       });
     });
+
+    it("displays subtitle when vault has one", async () => {
+      const vaultsWithSubtitle: VaultInfo[] = [
+        {
+          id: "vault-sub",
+          name: "My Vault",
+          subtitle: "Personal Notes",
+          path: "/home/user/vault",
+          hasClaudeMd: true,
+          contentRoot: "/home/user/vault",
+          inboxPath: "inbox",
+          metadataPath: "06_Metadata/memory-loop",
+          setupComplete: false,
+        },
+      ];
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ vaults: vaultsWithSubtitle }),
+      };
+
+      render(<VaultSelect />, { wrapper: TestWrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("My Vault")).toBeDefined();
+        expect(screen.getByText("Personal Notes")).toBeDefined();
+      });
+
+      // Verify subtitle has correct CSS class
+      const subtitle = screen.getByText("Personal Notes");
+      expect(subtitle.className).toContain("vault-select__vault-subtitle");
+    });
+
+    it("does not display subtitle element when vault has no subtitle", async () => {
+      const vaultsWithoutSubtitle: VaultInfo[] = [
+        {
+          id: "vault-no-sub",
+          name: "Simple Vault",
+          path: "/home/user/vault",
+          hasClaudeMd: true,
+          contentRoot: "/home/user/vault",
+          inboxPath: "inbox",
+          metadataPath: "06_Metadata/memory-loop",
+          setupComplete: false,
+        },
+      ];
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ vaults: vaultsWithoutSubtitle }),
+      };
+
+      render(<VaultSelect />, { wrapper: TestWrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Simple Vault")).toBeDefined();
+      });
+
+      // Verify no subtitle element exists
+      const subtitleElements = document.querySelectorAll(".vault-select__vault-subtitle");
+      expect(subtitleElements.length).toBe(0);
+    });
   });
 
   describe("empty state", () => {

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -9,7 +9,8 @@
  * Information about an Obsidian vault discovered by the backend.
  *
  * @property id - Directory name (unique identifier)
- * @property name - Human-readable name from CLAUDE.md title or fallback to id
+ * @property name - Human-readable name (title portion before " - " or full heading)
+ * @property subtitle - Optional subtitle (portion after " - " in heading)
  * @property path - Absolute path to the vault root directory
  * @property hasClaudeMd - Whether the vault has a CLAUDE.md file
  * @property contentRoot - Absolute path to content root (may differ from path if configured)
@@ -21,6 +22,7 @@
 export interface VaultInfo {
   id: string;
   name: string;
+  subtitle?: string;
   path: string;
   hasClaudeMd: boolean;
   contentRoot: string;


### PR DESCRIPTION
## Summary

- Parse CLAUDE.md H1 headings with ` - ` separator into title and subtitle
- Display subtitle below title in vault cards with secondary text styling
- Add `.memory-loop.json` config overrides for `title` and `subtitle`

## Changes

**Backend:**
- `extractVaultName()` returns `{ title, subtitle? }` instead of string
- `parseVault()` applies config overrides for both title and subtitle
- `VaultConfig` interface extended with `title` and `subtitle` fields

**Frontend:**
- `VaultSelect` conditionally renders subtitle with `--color-text-secondary` and smaller font

## Test plan

- [x] TypeScript type checking passes
- [x] All backend tests pass (176 tests)
- [x] All frontend tests pass (27 tests)
- [x] New tests cover title/subtitle parsing and config overrides

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)