### PR TITLE
feat: add optional HTTPS/TLS support via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,14 @@ VAULTS_DIR=/path/to/your/vaults
 
 # Server port (optional, default: 3000)
 PORT=3000
+
+# HTTPS/TLS Configuration (optional)
+# Both TLS_CERT and TLS_KEY are required to enable HTTPS
+# TLS_CERT=/path/to/certificate.pem
+# TLS_KEY=/path/to/private-key.pem
+
+# Optional: Passphrase for encrypted private keys
+# TLS_PASSPHRASE=your-passphrase
+
+# Optional: CA certificate chain for client certificate verification
+# TLS_CA=/path/to/ca-chain.pem

--- a/README.md
+++ b/README.md
@@ -163,6 +163,88 @@ hostname -I | awk '{print $1}'
 http://YOUR_IP:5173
 ```
 
+## HTTPS/TLS Setup
+
+For secure access (required for some mobile browsers and recommended for remote access), configure TLS certificates.
+
+### Environment Variables
+
+```bash
+# Both required to enable HTTPS
+TLS_CERT=/path/to/certificate.pem
+TLS_KEY=/path/to/private-key.pem
+
+# Optional: passphrase for encrypted private keys
+TLS_PASSPHRASE=your-passphrase
+```
+
+### Option 1: Self-Signed Certificate (Local Network)
+
+For local network access where you control all devices:
+
+```bash
+# Generate a self-signed certificate (valid 365 days)
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes \
+  -subj "/CN=memory-loop" \
+  -addext "subjectAltName=DNS:localhost,IP:YOUR_LOCAL_IP"
+
+# Set environment variables
+export TLS_CERT=/path/to/cert.pem
+export TLS_KEY=/path/to/key.pem
+```
+
+You'll need to accept the browser security warning on first visit, or add the certificate to your device's trusted store.
+
+### Option 2: Let's Encrypt (Public Domain)
+
+For a publicly accessible domain with automatic certificate renewal:
+
+```bash
+# Install certbot
+sudo apt install certbot  # Debian/Ubuntu
+
+# Get a certificate (standalone mode)
+sudo certbot certonly --standalone -d yourdomain.com
+
+# Certificates are stored in /etc/letsencrypt/live/yourdomain.com/
+export TLS_CERT=/etc/letsencrypt/live/yourdomain.com/fullchain.pem
+export TLS_KEY=/etc/letsencrypt/live/yourdomain.com/privkey.pem
+```
+
+Note: Let's Encrypt certificates need renewal every 90 days. Set up a cron job or systemd timer for `certbot renew`.
+
+### Option 3: mkcert (Development)
+
+For development with locally-trusted certificates:
+
+```bash
+# Install mkcert (https://github.com/FiloSottile/mkcert)
+# macOS: brew install mkcert
+# Linux: see mkcert GitHub for installation
+
+# Create and install local CA
+mkcert -install
+
+# Generate certificate for your domains
+mkcert localhost 192.168.1.100 memory-loop.local
+
+# Use the generated files
+export TLS_CERT=./localhost+2.pem
+export TLS_KEY=./localhost+2-key.pem
+```
+
+mkcert certificates are trusted by browsers on machines where you ran `mkcert -install`.
+
+### Verifying HTTPS
+
+After starting the server with TLS configured, you should see:
+
+```
+Memory Loop Backend running at https://localhost:3000
+WebSocket available at wss://localhost:3000/ws
+TLS enabled - connections are encrypted
+```
+
 ## Running as a Service (systemd)
 
 To run Memory Loop automatically on boot (Linux with systemd):

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,15 +7,21 @@
  * - Claude Agent SDK integration for AI conversations
  */
 
-import { serverConfig } from "./server";
+import { serverConfig, isTlsEnabled } from "./server";
 import { serverLog as log } from "./logger";
 
 const server = Bun.serve(serverConfig);
 
 const displayHost = server.hostname === "0.0.0.0" ? "localhost" : server.hostname;
-log.info(`Memory Loop Backend running at http://${displayHost}:${server.port}`);
-log.info(`WebSocket available at ws://${displayHost}:${server.port}/ws`);
-log.info(`Health check at http://${displayHost}:${server.port}/api/health`);
+const httpProtocol = isTlsEnabled() ? "https" : "http";
+const wsProtocol = isTlsEnabled() ? "wss" : "ws";
+
+log.info(`Memory Loop Backend running at ${httpProtocol}://${displayHost}:${server.port}`);
+log.info(`WebSocket available at ${wsProtocol}://${displayHost}:${server.port}/ws`);
+log.info(`Health check at ${httpProtocol}://${displayHost}:${server.port}/api/health`);
+if (isTlsEnabled()) {
+  log.info(`TLS enabled - connections are encrypted`);
+}
 if (server.hostname === "0.0.0.0") {
   log.info(`Server bound to all interfaces (0.0.0.0) - accessible remotely`);
 }

--- a/scripts/memory-loop.service.example
+++ b/scripts/memory-loop.service.example
@@ -34,6 +34,11 @@ Environment=VAULTS_DIR=/path/to/your/vaults
 Environment=PORT=3000
 Environment=HOST=0.0.0.0
 
+# HTTPS/TLS - uncomment and set paths to enable HTTPS
+#Environment=TLS_CERT=/path/to/certificate.pem
+#Environment=TLS_KEY=/path/to/private-key.pem
+#Environment=TLS_PASSPHRASE=your-passphrase-if-needed
+
 # Uncomment if bun is not in default PATH
 #Environment=PATH=/home/YOUR_USER/.bun/bin:/usr/local/bin:/usr/bin:/bin
 


### PR DESCRIPTION
## Summary

- Add optional HTTPS/TLS support controlled by environment variables (`TLS_CERT`, `TLS_KEY`)
- Server automatically switches to HTTPS mode when certificates are configured
- WebSocket connections upgrade to WSS when TLS is enabled
- Add comprehensive documentation with three certificate setup options (self-signed, Let's Encrypt, mkcert)

## Changes

- `backend/src/server.ts`: Add `getTlsConfig()` and `isTlsEnabled()` functions
- `backend/src/index.ts`: Update startup logging to show correct protocol
- `backend/src/__tests__/server.test.ts`: Add 14 tests for TLS configuration
- `.env.example`: Document TLS environment variables
- `scripts/memory-loop.service.example`: Add TLS vars for systemd deployments
- `README.md`: Add HTTPS/TLS Setup section with certificate instructions

## Test plan

- [x] All 580 existing tests pass
- [x] New TLS configuration tests cover all edge cases
- [x] TypeScript type checking passes
- [x] ESLint passes
- [ ] Manual test: Start server without TLS vars (should use HTTP)
- [ ] Manual test: Start server with TLS_CERT and TLS_KEY (should use HTTPS)

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)