### PR TITLE
feat: add HTTP to HTTPS redirect server

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,21 +7,30 @@
  * - Claude Agent SDK integration for AI conversations
  */
 
-import { serverConfig, isTlsEnabled } from "./server";
+import { serverConfig, isTlsEnabled, createHttpRedirectServer, getPort } from "./server";
 import { serverLog as log } from "./logger";
 
 const server = Bun.serve(serverConfig);
 
 const displayHost = server.hostname === "0.0.0.0" ? "localhost" : server.hostname;
+const serverPort = getPort();
 const httpProtocol = isTlsEnabled() ? "https" : "http";
 const wsProtocol = isTlsEnabled() ? "wss" : "ws";
 
-log.info(`Memory Loop Backend running at ${httpProtocol}://${displayHost}:${server.port}`);
-log.info(`WebSocket available at ${wsProtocol}://${displayHost}:${server.port}/ws`);
-log.info(`Health check at ${httpProtocol}://${displayHost}:${server.port}/api/health`);
+log.info(`Memory Loop Backend running at ${httpProtocol}://${displayHost}:${serverPort}`);
+log.info(`WebSocket available at ${wsProtocol}://${displayHost}:${serverPort}/ws`);
+log.info(`Health check at ${httpProtocol}://${displayHost}:${serverPort}/api/health`);
+
+// Start HTTP redirect server when TLS is enabled
 if (isTlsEnabled()) {
   log.info(`TLS enabled - connections are encrypted`);
+  const redirectConfig = createHttpRedirectServer(serverPort);
+  const redirectServer = Bun.serve(redirectConfig);
+  log.info(
+    `HTTP redirect server running at http://${displayHost}:${redirectServer.port} -> https://${displayHost}:${serverPort}`
+  );
 }
+
 if (server.hostname === "0.0.0.0") {
   log.info(`Server bound to all interfaces (0.0.0.0) - accessible remotely`);
 }


### PR DESCRIPTION
## Summary

- When TLS is enabled, starts a second HTTP server that redirects all requests to HTTPS (308 Permanent Redirect)
- Configurable via `HTTP_PORT` environment variable (default: 80)
- Documents Linux privileged port options in README (sysctl, setcap, nftables, reverse proxy)

## Test plan

- [x] Unit tests for `getHttpRedirectPort()` configuration
- [x] Unit tests for redirect behavior (path, query string, static files)
- [x] All 204 backend tests pass
- [x] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)