### PR TITLE
fix: add PWA meta tags and manifest for iOS home screen icon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,9 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Memory Loop" />
+    <meta name="theme-color" content="#1a1a2e" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="manifest" href="/manifest.json" />
     <title>Memory Loop</title>
   </head>
   <body>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,27 @@
+{
+  "name": "Memory Loop",
+  "short_name": "Memory Loop",
+  "description": "Mobile interface for Obsidian vaults via Claude AI",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#1a1a2e",
+  "theme_color": "#1a1a2e",
+  "icons": [
+    {
+      "src": "/favicon-16.png",
+      "sizes": "16x16",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon-32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add iOS-specific meta tags (`apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`, `apple-mobile-web-app-title`) for proper home screen app behavior
- Add `theme-color` meta tag for browser UI theming
- Create `manifest.json` with app metadata and icon definitions for PWA support

## Context
The `apple-touch-icon` wasn't being picked up when adding the app to iOS home screen. iOS requires additional PWA configuration beyond just the icon link tag.

## Test plan
- [ ] Deploy to HTTPS server
- [ ] Clear Safari cache on iOS device
- [ ] Visit site and tap Share > Add to Home Screen
- [ ] Verify the custom icon appears instead of a screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)