### PR TITLE
fix: filter out fuzzy-only matches with zero exact matches

### DIFF
--- a/backend/src/search/search-index.ts
+++ b/backend/src/search/search-index.ts
@@ -237,7 +237,13 @@ export class SearchIndexManager {
       const fileName = basename(filePath);
 
       // Count actual matches in the file content
+      // MiniSearch uses fuzzy matching, so a file might be returned even if
+      // the exact query string doesn't appear in it. Skip such results.
       const matchCount = await this.countMatches(filePath, query);
+      if (matchCount === 0) {
+        log.debug(`Skipping fuzzy-only match (no exact matches): ${filePath}`);
+        continue;
+      }
 
       results.push({
         path: filePath,


### PR DESCRIPTION
## Summary
- Fixes Zod validation errors (`too_small` on `matchCount`) when content search returns fuzzy-only matches
- MiniSearch's fuzzy matching (0.2 threshold) can return files where the query approximately matches but no exact literal match exists
- The fix filters out results where `countMatches()` returns 0, ensuring only files with actual matches are returned

## Test plan
- [x] All existing search tests pass (83 unit tests, 33 integration tests)
- [x] Manual test: search queries that previously triggered fuzzy-only matches no longer cause Zod errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)