### PR TITLE
feat: display vault subtitle in HomeView context card

### DIFF
--- a/frontend/src/components/HomeView.css
+++ b/frontend/src/components/HomeView.css
@@ -53,6 +53,12 @@
   margin: 0;
 }
 
+.home-view__vault-subtitle {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
 /* Debrief Buttons */
 .home-view__debrief-buttons {
   display: flex;

--- a/frontend/src/components/HomeView.tsx
+++ b/frontend/src/components/HomeView.tsx
@@ -248,6 +248,9 @@ export function HomeView(): React.ReactNode {
         <div className="home-view__vault-info">
           <span className="home-view__vault-label">Current Vault</span>
           <h2 className="home-view__vault-name">{vault?.name ?? "—"}</h2>
+          {vault?.subtitle && (
+            <p className="home-view__vault-subtitle">{vault.subtitle}</p>
+          )}
         </div>
         {debriefButtons.length > 0 && (
           <div className="home-view__debrief-buttons">


### PR DESCRIPTION
## Summary
- Displays the vault subtitle below the vault name in the HomeView session context card
- App header continues to show only the title
- Subtitle only renders when present (conditional display)

## Test plan
- [x] TypeScript type checking passes
- [x] All 682 frontend tests pass
- [ ] Manually verify subtitle appears in HomeView when vault has a subtitle
- [ ] Verify app header still shows only the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)