### PR TITLE
feat: add custom badges for vault cards

### DIFF
--- a/backend/src/__tests__/note-capture.test.ts
+++ b/backend/src/__tests__/note-capture.test.ts
@@ -577,6 +577,7 @@ describe("captureToDaily Integration", () => {
       promptsPerGeneration: 5,
       maxPoolSize: 50,
       quotesPerWeek: 1,
+      badges: [],
     };
   });
 
@@ -804,6 +805,7 @@ describe("Edge Cases", () => {
       promptsPerGeneration: 5,
       maxPoolSize: 50,
       quotesPerWeek: 1,
+      badges: [],
     };
   });
 

--- a/backend/src/__tests__/session-manager.test.ts
+++ b/backend/src/__tests__/session-manager.test.ts
@@ -57,6 +57,7 @@ function createMockVault(overrides: Partial<VaultInfo> = {}): VaultInfo {
     promptsPerGeneration: 5,
     maxPoolSize: 50,
     quotesPerWeek: 1,
+    badges: [],
     ...overrides,
   };
 }

--- a/backend/src/__tests__/test-helpers.ts
+++ b/backend/src/__tests__/test-helpers.ts
@@ -26,6 +26,7 @@ export function createMockVault(overrides: Partial<VaultInfo> = {}): VaultInfo {
     promptsPerGeneration: 5,
     maxPoolSize: 50,
     quotesPerWeek: 1,
+    badges: [],
     ...overrides,
   };
 }

--- a/backend/src/__tests__/vault-manager.test.ts
+++ b/backend/src/__tests__/vault-manager.test.ts
@@ -628,6 +628,7 @@ describe("Filesystem Integration", () => {
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
+        badges: [],
       };
 
       expect(getVaultInboxPath(vault)).toBe("/vaults/test-vault/00_Inbox");
@@ -646,6 +647,7 @@ describe("Filesystem Integration", () => {
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
+        badges: [],
       };
 
       expect(getVaultInboxPath(vault)).toBe("/vaults/test-vault/Custom/Inbox");
@@ -664,6 +666,7 @@ describe("Filesystem Integration", () => {
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
+        badges: [],
       };
 
       expect(getVaultInboxPath(vault)).toBe("/vaults/test-vault/content/00_Inbox");
@@ -1008,6 +1011,7 @@ Item 3
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
+        badges: [],
       };
 
       const goals = await getVaultGoals(vault);
@@ -1041,6 +1045,7 @@ Item 3
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
+        badges: [],
       };
 
       const sections = await getVaultGoals(vault);
@@ -1067,6 +1072,7 @@ Item 3
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
+        badges: [],
       };
 
       const goals = await getVaultGoals(vault);

--- a/backend/src/__tests__/websocket-handler.test.ts
+++ b/backend/src/__tests__/websocket-handler.test.ts
@@ -322,6 +322,7 @@ function createMockVault(overrides: Partial<VaultInfo> = {}): VaultInfo {
     promptsPerGeneration: 5,
     maxPoolSize: 50,
     quotesPerWeek: 1,
+    badges: [],
     ...overrides,
   };
 }

--- a/backend/src/vault-manager.ts
+++ b/backend/src/vault-manager.ts
@@ -17,6 +17,7 @@ import {
   resolvePromptsPerGeneration,
   resolveMaxPoolSize,
   resolveQuotesPerWeek,
+  resolveBadges,
   type VaultConfig,
 } from "./vault-config";
 
@@ -267,6 +268,7 @@ export async function parseVault(
     promptsPerGeneration: resolvePromptsPerGeneration(config),
     maxPoolSize: resolveMaxPoolSize(config),
     quotesPerWeek: resolveQuotesPerWeek(config),
+    badges: resolveBadges(config),
   };
 }
 

--- a/frontend/src/components/VaultSelect.css
+++ b/frontend/src/components/VaultSelect.css
@@ -343,6 +343,56 @@
   border-color: var(--color-success-a30);
 }
 
+/* Custom badge color variants */
+.vault-select__badge--black {
+  background: oklch(from var(--color-background) l c h / 0.15);
+  color: var(--color-text);
+  border-color: oklch(from var(--color-background) l c h / 0.30);
+}
+
+.vault-select__badge--purple {
+  background: var(--color-accent-primary-a15);
+  color: var(--color-text-accent-primary);
+  border-color: var(--color-accent-primary-a30);
+}
+
+.vault-select__badge--red {
+  background: var(--color-accent-secondary-a15);
+  color: var(--color-accent-secondary);
+  border-color: var(--color-accent-secondary-a30);
+}
+
+.vault-select__badge--cyan {
+  background: oklch(from var(--color-accent-tertiary) l c h / 0.15);
+  color: var(--color-accent-tertiary);
+  border-color: oklch(from var(--color-accent-tertiary) l c h / 0.30);
+}
+
+.vault-select__badge--orange {
+  background: oklch(from var(--color-accent-quartary) l c h / 0.15);
+  color: var(--color-accent-quartary);
+  border-color: oklch(from var(--color-accent-quartary) l c h / 0.30);
+}
+
+/* Hue-shifted variants */
+.vault-select__badge--blue {
+  background: oklch(from var(--color-accent-primary) l c calc(h - 45) / 0.15);
+  color: oklch(from var(--color-accent-primary) calc(l + 0.17) c calc(h - 45));
+  border-color: oklch(from var(--color-accent-primary) l c calc(h - 45) / 0.30);
+}
+
+.vault-select__badge--green {
+  background: oklch(from var(--color-accent-tertiary) l c calc(h - 95) / 0.15);
+  color: oklch(from var(--color-accent-tertiary) calc(l + 0.1) c calc(h - 95));
+  border-color: oklch(from var(--color-accent-tertiary) l c calc(h - 95) / 0.30);
+}
+
+.vault-select__badge--yellow {
+  background: oklch(from var(--color-accent-quartary) l c calc(h + 15) / 0.15);
+  color: oklch(from var(--color-accent-quartary) l c calc(h + 15));
+  border-color: oklch(from var(--color-accent-quartary) l c calc(h + 15) / 0.30);
+}
+
 /* Setup button */
 .vault-select__setup-btn {
   align-self: flex-end;

--- a/frontend/src/components/VaultSelect.tsx
+++ b/frontend/src/components/VaultSelect.tsx
@@ -392,6 +392,14 @@ export function VaultSelect({ onReady }: VaultSelectProps): React.ReactNode {
                     Memory Loop
                   </span>
                 )}
+                {vault.badges.map((badge, index) => (
+                  <span
+                    key={`${badge.text}-${index}`}
+                    className={`vault-select__badge vault-select__badge--${badge.color}`}
+                  >
+                    {badge.text}
+                  </span>
+                ))}
               </div>
               {vault.hasClaudeMd && (
                 <button

--- a/frontend/src/components/__tests__/Discussion.test.tsx
+++ b/frontend/src/components/__tests__/Discussion.test.tsx
@@ -76,6 +76,7 @@ const testVault: VaultInfo = {
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
+  badges: [],
 };
 
 function TestWrapper({ children }: { children: ReactNode }) {

--- a/frontend/src/components/__tests__/InspirationCard.test.tsx
+++ b/frontend/src/components/__tests__/InspirationCard.test.tsx
@@ -24,6 +24,7 @@ const testVault: VaultInfo = {
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
+  badges: [],
 };
 
 const mockContextual: InspirationItem = {

--- a/frontend/src/components/__tests__/NoteCapture.test.tsx
+++ b/frontend/src/components/__tests__/NoteCapture.test.tsx
@@ -76,6 +76,7 @@ const testVault: VaultInfo = {
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
+  badges: [],
 };
 
 // Wrapper with providers - vault is pre-selected via localStorage

--- a/frontend/src/components/__tests__/RecentActivity.test.tsx
+++ b/frontend/src/components/__tests__/RecentActivity.test.tsx
@@ -35,6 +35,7 @@ const testVault: VaultInfo = {
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
+  badges: [],
 };
 
 const mockCaptures: RecentNoteEntry[] = [

--- a/frontend/src/components/__tests__/VaultSelect.test.tsx
+++ b/frontend/src/components/__tests__/VaultSelect.test.tsx
@@ -75,6 +75,7 @@ const testVaults: VaultInfo[] = [
     promptsPerGeneration: 5,
     maxPoolSize: 50,
     quotesPerWeek: 1,
+    badges: [],
   },
   {
     id: "vault-2",
@@ -88,6 +89,7 @@ const testVaults: VaultInfo[] = [
     promptsPerGeneration: 5,
     maxPoolSize: 50,
     quotesPerWeek: 1,
+    badges: [],
   },
 ];
 
@@ -164,6 +166,80 @@ describe("VaultSelect", () => {
       });
     });
 
+    it("displays custom badges from vault configuration", async () => {
+      const vaultsWithBadges: VaultInfo[] = [
+        {
+          id: "vault-badges",
+          name: "Vault with Badges",
+          path: "/home/user/vault",
+          hasClaudeMd: true,
+          contentRoot: "/home/user/vault",
+          inboxPath: "inbox",
+          metadataPath: "06_Metadata/memory-loop",
+          setupComplete: false,
+          promptsPerGeneration: 5,
+          maxPoolSize: 50,
+          quotesPerWeek: 1,
+          badges: [
+            { text: "Work", color: "blue" },
+            { text: "Personal", color: "green" },
+          ],
+        },
+      ];
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ vaults: vaultsWithBadges }),
+      };
+
+      render(<VaultSelect />, { wrapper: TestWrapper });
+
+      await waitFor(() => {
+        expect(screen.getByText("Work")).toBeDefined();
+        expect(screen.getByText("Personal")).toBeDefined();
+      });
+
+      // Verify badges have correct CSS classes
+      const workBadge = screen.getByText("Work");
+      const personalBadge = screen.getByText("Personal");
+      expect(workBadge.className).toContain("vault-select__badge--blue");
+      expect(personalBadge.className).toContain("vault-select__badge--green");
+    });
+
+    it("displays custom badges alongside built-in badges", async () => {
+      const vaultsWithAllBadges: VaultInfo[] = [
+        {
+          id: "vault-all-badges",
+          name: "Vault with All Badges",
+          path: "/home/user/vault",
+          hasClaudeMd: true,
+          contentRoot: "/home/user/vault",
+          inboxPath: "inbox",
+          metadataPath: "06_Metadata/memory-loop",
+          setupComplete: true,
+          promptsPerGeneration: 5,
+          maxPoolSize: 50,
+          quotesPerWeek: 1,
+          badges: [{ text: "Custom", color: "purple" }],
+        },
+      ];
+      mockFetchResponse = {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ vaults: vaultsWithAllBadges }),
+      };
+
+      render(<VaultSelect />, { wrapper: TestWrapper });
+
+      await waitFor(() => {
+        // Built-in badges
+        expect(screen.getByText("CLAUDE.md")).toBeDefined();
+        expect(screen.getByText("Memory Loop")).toBeDefined();
+        // Custom badge
+        expect(screen.getByText("Custom")).toBeDefined();
+      });
+    });
+
     it("shows connection status", async () => {
       render(<VaultSelect />, { wrapper: TestWrapper });
 
@@ -188,6 +264,7 @@ describe("VaultSelect", () => {
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
+          badges: [],
         },
       ];
       mockFetchResponse = {
@@ -222,6 +299,7 @@ describe("VaultSelect", () => {
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
+          badges: [],
         },
       ];
       mockFetchResponse = {
@@ -506,6 +584,7 @@ describe("VaultSelect", () => {
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
+          badges: [],
         },
       ];
 
@@ -538,6 +617,7 @@ describe("VaultSelect", () => {
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
+          badges: [],
         },
       ];
 
@@ -585,6 +665,7 @@ describe("VaultSelect", () => {
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
+          badges: [],
         },
       ];
 
@@ -625,6 +706,7 @@ describe("VaultSelect", () => {
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
+          badges: [],
         },
       ];
 
@@ -675,6 +757,7 @@ describe("VaultSelect", () => {
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
+          badges: [],
         },
       ];
 
@@ -727,6 +810,7 @@ describe("VaultSelect", () => {
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
+          badges: [],
         },
       ];
 
@@ -799,6 +883,7 @@ describe("VaultSelect", () => {
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
+          badges: [],
         },
       ];
 

--- a/frontend/src/contexts/__tests__/SessionContext.test.tsx
+++ b/frontend/src/contexts/__tests__/SessionContext.test.tsx
@@ -46,6 +46,7 @@ const testVault: VaultInfo = {
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
+  badges: [],
 };
 
 const testVault2: VaultInfo = {
@@ -60,6 +61,7 @@ const testVault2: VaultInfo = {
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
+  badges: [],
 };
 
 describe("SessionContext", () => {

--- a/frontend/src/hooks/__tests__/useWebSocket.test.ts
+++ b/frontend/src/hooks/__tests__/useWebSocket.test.ts
@@ -260,6 +260,7 @@ describe("useWebSocket", () => {
             promptsPerGeneration: 5,
             maxPoolSize: 50,
             quotesPerWeek: 1,
+            badges: [],
           },
         ],
       };

--- a/frontend/src/test-helpers.ts
+++ b/frontend/src/test-helpers.ts
@@ -26,6 +26,7 @@ export function createMockVault(overrides: Partial<VaultInfo> = {}): VaultInfo {
     promptsPerGeneration: 5,
     maxPoolSize: 50,
     quotesPerWeek: 1,
+    badges: [],
     ...overrides,
   };
 }

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -10,7 +10,7 @@
 export const VERSION = "0.1.0";
 
 // Core types
-export type { VaultInfo, SessionMetadata, ErrorCode, StoredToolInvocation, ConversationMessage } from "./types.js";
+export type { VaultInfo, SessionMetadata, ErrorCode, StoredToolInvocation, ConversationMessage, Badge, BadgeColor } from "./types.js";
 
 // Protocol schemas
 export {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -8,6 +8,32 @@
 import { z } from "zod";
 
 // =============================================================================
+// Badge Schema
+// =============================================================================
+
+/**
+ * Schema for badge color enum - valid named colors for badges
+ */
+export const BadgeColorSchema = z.enum([
+  "black",
+  "purple",
+  "red",
+  "cyan",
+  "orange",
+  "blue",
+  "green",
+  "yellow",
+]);
+
+/**
+ * Schema for Badge - custom badge configured in .memory-loop.json
+ */
+export const BadgeSchema = z.object({
+  text: z.string().min(1, "Badge text is required"),
+  color: BadgeColorSchema,
+});
+
+// =============================================================================
 // Vault Info Schema
 // =============================================================================
 
@@ -17,6 +43,7 @@ import { z } from "zod";
 export const VaultInfoSchema = z.object({
   id: z.string().min(1, "Vault ID is required"),
   name: z.string().min(1, "Vault name is required"),
+  subtitle: z.string().optional(),
   path: z.string().min(1, "Vault path is required"),
   hasClaudeMd: z.boolean(),
   contentRoot: z.string().min(1, "Content root is required"),
@@ -27,6 +54,7 @@ export const VaultInfoSchema = z.object({
   promptsPerGeneration: z.number().int().positive(),
   maxPoolSize: z.number().int().positive(),
   quotesPerWeek: z.number().int().positive(),
+  badges: z.array(BadgeSchema),
 });
 
 // =============================================================================

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -6,6 +6,31 @@
  */
 
 /**
+ * Named colors for custom badges.
+ * These map to theme CSS variables for consistent styling.
+ */
+export type BadgeColor =
+  | "black"
+  | "purple"
+  | "red"
+  | "cyan"
+  | "orange"
+  | "blue"
+  | "green"
+  | "yellow";
+
+/**
+ * A custom badge configured in .memory-loop.json.
+ *
+ * @property text - The badge label text
+ * @property color - Named color from the theme palette
+ */
+export interface Badge {
+  text: string;
+  color: BadgeColor;
+}
+
+/**
  * Information about an Obsidian vault discovered by the backend.
  *
  * @property id - Directory name (unique identifier)
@@ -21,6 +46,7 @@
  * @property promptsPerGeneration - Number of prompts to generate per cycle (default: 5)
  * @property maxPoolSize - Maximum items to keep in inspiration pools (default: 50)
  * @property quotesPerWeek - Number of quotes to generate per week (default: 1)
+ * @property badges - Custom badges configured in .memory-loop.json
  */
 export interface VaultInfo {
   id: string;
@@ -36,6 +62,7 @@ export interface VaultInfo {
   promptsPerGeneration: number;
   maxPoolSize: number;
   quotesPerWeek: number;
+  badges: Badge[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add support for custom badges configured in `.memory-loop.json`
- Badges display on vault cards with configurable text and color
- 8 theme-aware colors: black, purple, red, cyan, orange, plus hue-shifted blue, green, and yellow variants
- Full-stack implementation with Zod validation across shared/backend/frontend

## Configuration
```json
{
  "badges": [
    { "text": "Work", "color": "blue" },
    { "text": "Personal", "color": "green" }
  ]
}
```

## Test plan
- [x] All 900+ existing tests pass
- [x] Type checking passes across all workspaces
- [x] Lint passes
- [ ] Visual verification of badge rendering on vault cards

Closes #187

🤖 Generated with [Claude Code](https://claude.ai/code)