### PR TITLE
fix: include slash commands in new_session response

### DIFF
--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -1171,10 +1171,15 @@ export class WebSocketHandler {
     // Clear session ID - next discussion_message will create a new session
     this.state.currentSessionId = null;
 
+    // Load cached slash commands so autocomplete remains available
+    const vaultConfig = await loadVaultConfig(this.state.currentVault.path);
+    const cachedCommands = vaultConfig.slashCommands;
+
     this.send(ws, {
       type: "session_ready",
       sessionId: "", // Empty indicates new session will be created
       vaultId: this.state.currentVault.id,
+      slashCommands: cachedCommands && cachedCommands.length > 0 ? cachedCommands : undefined,
     });
   }
 


### PR DESCRIPTION
## Summary

- Fixes slash command autocomplete disappearing after clicking "+" button to start new session
- `handleNewSession` now loads cached slash commands from vault config and includes them in `session_ready` response
- Matches existing pattern used by `select_vault` and `resume_session` handlers

Fixes #195

## Test plan

- [x] Added unit test verifying slash commands included in new_session response
- [x] All 120 websocket handler tests pass
- [x] TypeScript type checking passes
- [ ] Manual test: Open Discussion tab, type "/" to see autocomplete, click "+", confirm dialog, type "/" again - autocomplete should still appear

🤖 Generated with [Claude Code](https://claude.ai/code)