### PR TITLE
feat: add seasonal holiday theming with SCSS

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "bun-types": "^1.1.43",
     "happy-dom": "^20.0.11",
+    "sass": "^1.97.2",
     "typescript": "^5.7.2",
     "vite": "^6.0.0"
   }

--- a/frontend/src/_derived-colors.scss
+++ b/frontend/src/_derived-colors.scss
@@ -1,0 +1,145 @@
+/**
+ * Derived Color Definitions
+ *
+ * Mixin containing all colors derived from the 5 base colors.
+ * Used in both :root (index.scss) and [data-holiday] (holidays.scss)
+ * to ensure derived colors recalculate when base colors change.
+ *
+ * Base colors (defined elsewhere):
+ * - --color-background
+ * - --color-accent-primary
+ * - --color-accent-secondary
+ * - --color-accent-tertiary
+ * - --color-accent-quartary
+ */
+
+@mixin derived-colors {
+  /* Surfaces & Borders (from background) */
+  --color-surface: oklch(from var(--color-background) calc(l + 0.05) calc(c + 0.01) h);
+  --color-surface-elevated: oklch(from var(--color-background) calc(l + 0.10) calc(c + 0.02) h);
+  --color-border: oklch(from var(--color-background) calc(l + 0.15) calc(c + 0.02) h);
+
+  /* Accent Variants (from accent-primary) */
+  --color-accent: var(--color-accent-primary);
+  --color-accent-hover: oklch(from var(--color-accent-primary) calc(l + 0.08) c h);
+
+  /* Text Accent Colors (from accents) */
+  --color-text-accent-primary: oklch(from var(--color-accent-primary) calc(l + 0.17) c h);
+  --color-text-accent-secondary: var(--color-accent-secondary);
+  --color-text-accent-tertiary: var(--color-accent-tertiary);
+  --color-text-accent-quartary: var(--color-accent-quartary);
+  --color-text-accent: var(--color-text-accent-primary);
+
+  /* Status text colors - same as status (already WCAG compliant) */
+  --color-text-error: var(--color-error);
+  --color-text-success: var(--color-success);
+  --color-text-warning: var(--color-warning);
+
+  /* Text Hierarchy (from accents) */
+  --color-text-primary: oklch(from var(--color-accent-primary) 0.96 0.01 h);
+  --color-text-secondary: oklch(from var(--color-accent-primary) 0.89 0.02 h);
+  --color-text-muted: oklch(from var(--color-accent-secondary) 0.72 0.12 h);
+  --color-text-heading: var(--color-text-accent-quartary);
+  --color-text-highlight: oklch(from var(--color-text-accent-quartary) calc(l + 0.15) c h);
+
+  /* Status backgrounds - darkened versions */
+  --color-bg-error: oklch(from var(--color-error) calc(l / 4) c h);
+  --color-bg-warning: oklch(from var(--color-warning) calc(l / 4) c h);
+  --color-bg-success: oklch(from var(--color-success) calc(l / 4) c h);
+
+  /* Alpha Variants - Accent Primary */
+  --color-accent-primary-a05: oklch(from var(--color-accent-primary) l c h / 0.05);
+  --color-accent-primary-a08: oklch(from var(--color-accent-primary) l c h / 0.08);
+  --color-accent-primary-a10: oklch(from var(--color-accent-primary) l c h / 0.10);
+  --color-accent-primary-a12: oklch(from var(--color-accent-primary) l c h / 0.12);
+  --color-accent-primary-a15: oklch(from var(--color-accent-primary) l c h / 0.15);
+  --color-accent-primary-a20: oklch(from var(--color-accent-primary) l c h / 0.20);
+  --color-accent-primary-a25: oklch(from var(--color-accent-primary) l c h / 0.25);
+  --color-accent-primary-a30: oklch(from var(--color-accent-primary) l c h / 0.30);
+  --color-accent-primary-a40: oklch(from var(--color-accent-primary) l c h / 0.40);
+
+  /* Alpha Variants - Accent Secondary */
+  --color-accent-secondary-a10: oklch(from var(--color-accent-secondary) l c h / 0.10);
+  --color-accent-secondary-a15: oklch(from var(--color-accent-secondary) l c h / 0.15);
+  --color-accent-secondary-a30: oklch(from var(--color-accent-secondary) l c h / 0.30);
+  --color-accent-secondary-a40: oklch(from var(--color-accent-secondary) l c h / 0.40);
+
+  /* Alpha Variants - Accent Tertiary */
+  --color-accent-tertiary-a40: oklch(from var(--color-accent-tertiary) l c h / 0.40);
+
+  /* Alpha Variants - Accent Quartary */
+  --color-accent-quartary-a40: oklch(from var(--color-accent-quartary) l c h / 0.40);
+
+  /* Alpha Variants - Error */
+  --color-error-a10: oklch(from var(--color-error) l c h / 0.10);
+  --color-error-a30: oklch(from var(--color-error) l c h / 0.30);
+  --color-error-a40: oklch(from var(--color-error) l c h / 0.40);
+
+  /* Alpha Variants - Success */
+  --color-success-a10: oklch(from var(--color-success) l c h / 0.10);
+  --color-success-a20: oklch(from var(--color-success) l c h / 0.20);
+  --color-success-a30: oklch(from var(--color-success) l c h / 0.30);
+
+  /* Alpha Variants - Black (Shadows & Overlays) */
+  --color-black-a20: oklch(0 0 0 / 0.20);
+  --color-black-a30: oklch(0 0 0 / 0.30);
+  --color-black-a40: oklch(0 0 0 / 0.40);
+  --color-black-a50: oklch(0 0 0 / 0.50);
+  --color-black-a60: oklch(0 0 0 / 0.60);
+
+  /* Alpha Variants - White (Highlights & Borders) */
+  --color-white-a03: oklch(1 0 0 / 0.03);
+  --color-white-a05: oklch(1 0 0 / 0.05);
+  --color-white-a07: oklch(1 0 0 / 0.07);
+  --color-white-a10: oklch(1 0 0 / 0.10);
+  --color-white-a30: oklch(1 0 0 / 0.30);
+
+  /* Alpha Variants - Background & Surface */
+  --color-background-a60: oklch(from var(--color-background) l c h / 0.60);
+  --color-surface-a90: oklch(from var(--color-surface) l c h / 0.90);
+  --color-surface-a95: oklch(from var(--color-surface) l c h / 0.95);
+
+  /* Semantic Aliases */
+  --color-bg: var(--color-background);
+  --color-bg-secondary: var(--color-surface);
+  --color-bg-tertiary: var(--color-surface-elevated);
+  --color-text: var(--color-text-primary);
+
+  /* Gradients */
+  --gradient-primary: linear-gradient(135deg, var(--color-accent-primary) 0%, var(--color-accent-secondary) 100%);
+  --gradient-secondary: linear-gradient(135deg, var(--color-accent-tertiary) 0%, var(--color-accent-primary) 100%);
+  --gradient-tertiary: linear-gradient(135deg, oklch(from var(--color-accent-quartary) calc(l - 0.2) c h) 0%, oklch(from var(--color-accent-secondary) calc(l - 0.15) c h) 100%);
+  --gradient-text-primary: linear-gradient(135deg, var(--color-text-accent-primary) 0%, var(--color-text-accent-secondary) 100%);
+  --gradient-secondary-hover: linear-gradient(135deg, oklch(from var(--color-accent-tertiary) calc(l + 0.08) c h) 0%, var(--color-accent-hover) 100%);
+  --gradient-surface: linear-gradient(180deg, var(--color-surface) 0%, var(--color-background) 100%);
+  --gradient-error: linear-gradient(135deg, var(--color-error) 0%, oklch(from var(--color-error) calc(l - 0.14) c h) 100%);
+
+  /* Glassmorphism */
+  --glass-bg: var(--color-surface-a90);
+  --glass-bg-primary: oklch(from var(--color-accent-primary) 0.22 0.04 h / 0.85);
+  --glass-bg-primary-button: oklch(from var(--color-accent-primary) 0.25 0.05 h / 0.85);
+  --glass-bg-primary-hover: oklch(from var(--color-accent-primary) 0.32 0.06 h / 0.85);
+  --glass-bg-secondary: oklch(from var(--color-accent-secondary) 0.22 0.04 h / 0.85);
+  --glass-bg-tertiary: oklch(from var(--color-accent-tertiary) 0.22 0.04 h / 0.85);
+  --glass-bg-quartary: oklch(from var(--color-accent-quartary) 0.22 0.04 h / 0.85);
+  --glass-border: var(--color-accent-primary-a25);
+  --glass-border-hover: oklch(from var(--color-accent-primary) l c h / 0.5);
+  --glass-border-accent: oklch(from var(--color-accent-tertiary) l c h / 0.5);
+  --glass-blur: 10px;
+  --glass-blur-light: 2px;
+  --glass-shadow:
+    0 4px 24px var(--color-black-a30),
+    inset 0 1px 0 var(--color-white-a07),
+    inset 0 -1px 0 var(--color-black-a20);
+  --glass-shadow-hover:
+    0 8px 32px var(--color-black-a40),
+    0 0 24px var(--color-accent-primary-a15),
+    inset 0 1px 0 var(--color-white-a10);
+
+  /* Glow Effects */
+  --glow-primary: 0 0 20px var(--color-accent-primary-a40);
+  --glow-secondary: 0 0 20px var(--color-accent-secondary-a40);
+  --glow-tertiary: 0 0 20px var(--color-accent-tertiary-a40);
+  --glow-quartary: 0 0 20px var(--color-accent-quartary-a40);
+  --glow-success: 0 0 20px var(--color-success-a30);
+}

--- a/frontend/src/holidays.scss
+++ b/frontend/src/holidays.scss
@@ -1,0 +1,111 @@
+/**
+ * Holiday Theme Overrides
+ *
+ * Seasonal color palettes that override the 5 base colors.
+ * All derived colors recalculate automatically via the shared mixin.
+ *
+ * Base colors overridden:
+ * - --color-background
+ * - --color-accent-primary
+ * - --color-accent-secondary
+ * - --color-accent-tertiary
+ * - --color-accent-quartary
+ */
+
+@use "derived-colors" as *;
+
+/* ============================================
+   Valentine's Day - Soft Rose Tones
+
+   Deep wine background with dusty rose accents.
+   Romantic but not overly saturated.
+   ============================================ */
+[data-holiday="valentine"] {
+  --color-background: oklch(0.12 0.04 350);       /* Deep wine */
+  --color-accent-primary: oklch(0.55 0.10 350);   /* Dusty rose */
+  --color-accent-secondary: oklch(0.70 0.12 10);  /* Soft pink */
+  --color-accent-tertiary: oklch(0.58 0.08 320);  /* Mauve */
+  --color-accent-quartary: oklch(0.82 0.06 30);   /* Warm blush */
+
+  @include derived-colors;
+}
+
+/* ============================================
+   Easter - Spring Pastels
+
+   Soft lavender base with pastel accents.
+   Light, airy, springtime feel.
+   ============================================ */
+[data-holiday="easter"] {
+  --color-background: oklch(0.14 0.03 300);       /* Deep lavender */
+  --color-accent-primary: oklch(0.65 0.10 300);   /* Lavender */
+  --color-accent-secondary: oklch(0.72 0.10 350); /* Soft pink */
+  --color-accent-tertiary: oklch(0.68 0.10 160);  /* Mint green */
+  --color-accent-quartary: oklch(0.82 0.12 95);   /* Soft yellow */
+
+  @include derived-colors;
+}
+
+/* ============================================
+   Summer - Beach Vibes
+
+   Deep ocean base with tropical accents.
+   Cyan waters, coral sunsets, sandy warmth.
+   ============================================ */
+[data-holiday="summer"] {
+  --color-background: oklch(0.12 0.04 220);       /* Deep ocean */
+  --color-accent-primary: oklch(0.55 0.12 195);   /* Teal */
+  --color-accent-secondary: oklch(0.70 0.14 45);  /* Coral */
+  --color-accent-tertiary: oklch(0.62 0.10 230);  /* Sky blue */
+  --color-accent-quartary: oklch(0.78 0.10 85);   /* Sandy gold */
+
+  @include derived-colors;
+}
+
+/* ============================================
+   Halloween - Spooky Night
+
+   Near-black with orange warmth.
+   Pumpkins, witches, slime, candy corn.
+   ============================================ */
+[data-holiday="halloween"] {
+  --color-background: oklch(0.10 0.02 50);        /* Warm black */
+  --color-accent-primary: oklch(0.62 0.18 55);    /* Pumpkin orange */
+  --color-accent-secondary: oklch(0.48 0.16 300); /* Witch purple */
+  --color-accent-tertiary: oklch(0.58 0.16 130);  /* Slime green */
+  --color-accent-quartary: oklch(0.78 0.14 80);   /* Candy corn */
+
+  @include derived-colors;
+}
+
+/* ============================================
+   Thanksgiving - Harvest Warmth
+
+   Deep brown earth tones.
+   Burnt orange, cranberry, sage, gold.
+   ============================================ */
+[data-holiday="thanksgiving"] {
+  --color-background: oklch(0.12 0.03 55);        /* Deep brown */
+  --color-accent-primary: oklch(0.55 0.14 55);    /* Burnt orange */
+  --color-accent-secondary: oklch(0.50 0.14 20);  /* Cranberry */
+  --color-accent-tertiary: oklch(0.55 0.08 140);  /* Sage green */
+  --color-accent-quartary: oklch(0.75 0.14 85);   /* Harvest gold */
+
+  @include derived-colors;
+}
+
+/* ============================================
+   Christmas - Traditional
+
+   Deep evergreen base.
+   Classic red and green with gold accents.
+   ============================================ */
+[data-holiday="christmas"] {
+  --color-background: oklch(0.11 0.04 145);       /* Deep evergreen */
+  --color-accent-primary: oklch(0.52 0.18 25);    /* Holly red */
+  --color-accent-secondary: oklch(0.48 0.12 145); /* Forest green */
+  --color-accent-tertiary: oklch(0.72 0.14 85);   /* Gold */
+  --color-accent-quartary: oklch(0.88 0.04 90);   /* Warm cream */
+
+  @include derived-colors;
+}

--- a/frontend/src/hooks/useHoliday.ts
+++ b/frontend/src/hooks/useHoliday.ts
@@ -139,12 +139,22 @@ export function getHoliday(date: Date = new Date()): Holiday {
   return null;
 }
 
+const VALID_HOLIDAYS = ['valentine', 'easter', 'summer', 'halloween', 'thanksgiving', 'christmas'] as const;
+
 /**
  * React hook that returns the current holiday.
- * Re-checks at midnight in case the date changes while the app is open.
+ * Supports ?holiday=<name> query parameter for testing or mood-based override.
+ * Use ?holiday=none to disable holiday theming.
  */
 export function useHoliday(): Holiday {
-  // For SSR safety and to avoid hydration mismatches, we just calculate once.
-  // The date doesn't change often enough to warrant a subscription.
+  // Check for query parameter override
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search);
+    const override = params.get('holiday');
+    if (override === 'none') return null;
+    if (VALID_HOLIDAYS.includes(override as typeof VALID_HOLIDAYS[number])) {
+      return override as Holiday;
+    }
+  }
   return getHoliday();
 }

--- a/frontend/src/index.scss
+++ b/frontend/src/index.scss
@@ -5,6 +5,8 @@
  * Breakpoints: 320px (mobile), 768px (tablet), 1024px (desktop)
  */
 
+@use "derived-colors" as *;
+
 /* ============================================
    Font System (Self-hosted)
 
@@ -170,172 +172,17 @@
   --color-accent-tertiary:  oklch(0.62 0.06 255);  /* Dusk Blue */
   --color-accent-quartary:  oklch(0.78 0.10 75);   /* Sunset Gold */
 
-
   /* Status colors */
   --color-error:  oklch(0.67 0.18 25);    /* Red */
   --color-success: oklch(0.80 0.18 145); /* Green */
   --color-warning: oklch(0.82 0.16 85);  /* Yellow */
 
+  /* Include all derived colors from mixin */
+  @include derived-colors;
 
   /* ==========================================
-     Derived Colors - Surfaces & Borders
-
-     All share background hue, vary in lightness.
+     Non-color Design Tokens
      ========================================== */
-  --color-surface: oklch(from var(--color-background) calc(l + 0.05) calc(c + 0.01) h);
-  --color-surface-elevated: oklch(from var(--color-background) calc(l + 0.10) calc(c + 0.02) h);
-  --color-border: oklch(from var(--color-background) calc(l + 0.15) calc(c + 0.02) h);
-
-  /* ==========================================
-     Derived Colors - Accent Variants
-     ========================================== */
-  --color-accent: var(--color-accent-primary);
-  --color-accent-hover: oklch(from var(--color-accent-primary) calc(l + 0.08) c h);
-
-  /* Text accent colors - lighter for WCAG on dark backgrounds */
-  --color-text-accent-primary: oklch(from var(--color-accent-primary) calc(l + 0.17) c h);
-  --color-text-accent-secondary: var(--color-accent-secondary); /* oklch(from var(--color-accent-secondary) calc(l + 0.13) calc(c - 0.05) h); */
-  --color-text-accent-tertiary: var(--color-accent-tertiary);  /* Already light */
-  --color-text-accent-quartary: var(--color-accent-quartary);  /* Already light */
-  --color-text-accent: var(--color-text-accent-primary);
-
-  /* Status text colors - same as status (already WCAG compliant) */
-  --color-text-error: var(--color-error);
-  --color-text-success: var(--color-success);
-  --color-text-warning: var(--color-warning);
-
-  /* ==========================================
-     Derived Colors - Text Hierarchy
-
-     All derive from accent hues for consistency.
-     ========================================== */
-  --color-text-primary: oklch(from var(--color-accent-primary) 0.96 0.01 h);
-  --color-text-secondary: oklch(from var(--color-accent-primary) 0.89 0.02 h);
-  --color-text-muted: oklch(from var(--color-accent-secondary) 0.72 0.12 h); /* Slight hue shift for purple tint */
-  --color-text-heading: var(--color-text-accent-quartary);
-  --color-text-highlight: oklch(from var(--color-text-accent-quartary) calc(l + 0.15) c h);
-
-  /* Status backgrounds - darkened versions */
-  --color-bg-error: oklch(from var(--color-error) calc(l / 4) c h);
-  --color-bg-warning: oklch(from var(--color-warning) calc(l / 4) c h);
-  --color-bg-success: oklch(from var(--color-success) calc(l / 4) c h);
-
-  /* ==========================================
-     Alpha Variants
-
-     Naming: --color-{name}-a{opacity}
-     Opacity scale: 03, 05, 07, 10, 12, 15, 20, 25, 30, 40, 50, 60, 95
-     ========================================== */
-
-  /* Accent Primary - Purple (most commonly used) */
-  --color-accent-primary-a05: oklch(from var(--color-accent-primary) l c h / 0.05);
-  --color-accent-primary-a08: oklch(from var(--color-accent-primary) l c h / 0.08);
-  --color-accent-primary-a10: oklch(from var(--color-accent-primary) l c h / 0.10);
-  --color-accent-primary-a12: oklch(from var(--color-accent-primary) l c h / 0.12);
-  --color-accent-primary-a15: oklch(from var(--color-accent-primary) l c h / 0.15);
-  --color-accent-primary-a20: oklch(from var(--color-accent-primary) l c h / 0.20);
-  --color-accent-primary-a25: oklch(from var(--color-accent-primary) l c h / 0.25);
-  --color-accent-primary-a30: oklch(from var(--color-accent-primary) l c h / 0.30);
-  --color-accent-primary-a40: oklch(from var(--color-accent-primary) l c h / 0.40);
-
-  /* Accent Secondary - Pink */
-  --color-accent-secondary-a10: oklch(from var(--color-accent-secondary) l c h / 0.10);
-  --color-accent-secondary-a15: oklch(from var(--color-accent-secondary) l c h / 0.15);
-  --color-accent-secondary-a30: oklch(from var(--color-accent-secondary) l c h / 0.30);
-  --color-accent-secondary-a40: oklch(from var(--color-accent-secondary) l c h / 0.40);
-
-  /* Accent Tertiary - Cyan */
-  --color-accent-tertiary-a40: oklch(from var(--color-accent-tertiary) l c h / 0.40);
-
-  /* Accent Quartary - Orange */
-  --color-accent-quartary-a40: oklch(from var(--color-accent-quartary) l c h / 0.40);
-
-  /* Error - Red */
-  --color-error-a10: oklch(from var(--color-error) l c h / 0.10);
-  --color-error-a30: oklch(from var(--color-error) l c h / 0.30);
-  --color-error-a40: oklch(from var(--color-error) l c h / 0.40);
-
-  /* Success - Green */
-  --color-success-a10: oklch(from var(--color-success) l c h / 0.10);
-  --color-success-a20: oklch(from var(--color-success) l c h / 0.20);
-  --color-success-a30: oklch(from var(--color-success) l c h / 0.30);
-
-  /* Black - Shadows & Overlays */
-  --color-black-a20: oklch(0 0 0 / 0.20);
-  --color-black-a30: oklch(0 0 0 / 0.30);
-  --color-black-a40: oklch(0 0 0 / 0.40);
-  --color-black-a50: oklch(0 0 0 / 0.50);
-  --color-black-a60: oklch(0 0 0 / 0.60);
-
-  /* White - Highlights & Borders */
-  --color-white-a03: oklch(1 0 0 / 0.03);
-  --color-white-a05: oklch(1 0 0 / 0.05);
-  --color-white-a07: oklch(1 0 0 / 0.07);
-  --color-white-a10: oklch(1 0 0 / 0.10);
-  --color-white-a30: oklch(1 0 0 / 0.30);
-
-  /* Background - For overlays */
-  --color-background-a60: oklch(from var(--color-background) l c h / 0.60);
-
-  /* Surface - For glass effects */
-  --color-surface-a90: oklch(from var(--color-surface) l c h / 0.90);
-  --color-surface-a95: oklch(from var(--color-surface) l c h / 0.95);
-
-  /* ==========================================
-     Semantic Aliases
-     ========================================== */
-
-  /* Component compatibility */
-  --color-bg: var(--color-background);
-  --color-bg-secondary: var(--color-surface);
-  --color-bg-tertiary: var(--color-surface-elevated);
-  --color-text: var(--color-text-primary);
-
-  /* ==========================================
-     Gradients
-     ========================================== */
-  --gradient-primary: linear-gradient(135deg, var(--color-accent-primary) 0%, var(--color-accent-secondary) 100%);
-  --gradient-secondary: linear-gradient(135deg, var(--color-accent-tertiary) 0%, var(--color-accent-primary) 100%);
-  --gradient-tertiary: linear-gradient(135deg, oklch(from var(--color-accent-quartary) calc(l - 0.2) c h) 0%, oklch(from var(--color-accent-secondary) calc(l - 0.15) c h) 100%);
-  --gradient-text-primary: linear-gradient(135deg, var(--color-text-accent-primary) 0%, var(--color-text-accent-secondary) 100%);
-  --gradient-secondary-hover: linear-gradient(135deg, oklch(from var(--color-accent-tertiary) calc(l + 0.08) c h) 0%, var(--color-accent-hover) 100%);
-  --gradient-surface: linear-gradient(180deg, var(--color-surface) 0%, var(--color-background) 100%);
-  --gradient-error: linear-gradient(135deg, var(--color-error) 0%, oklch(from var(--color-error) calc(l - 0.14) c h) 100%);
-
-  /* ==========================================
-     Glassmorphism
-
-     Glass backgrounds use accent hues at low lightness/chroma.
-     ========================================== */
-  --glass-bg: var(--color-surface-a90);
-  --glass-bg-primary: oklch(from var(--color-accent-primary) 0.22 0.04 h / 0.85);
-  --glass-bg-primary-button: oklch(from var(--color-accent-primary) 0.25 0.05 h / 0.85);
-  --glass-bg-primary-hover: oklch(from var(--color-accent-primary) 0.32 0.06 h / 0.85);
-  --glass-bg-secondary: oklch(from var(--color-accent-secondary) 0.22 0.04 h / 0.85);
-  --glass-bg-tertiary: oklch(from var(--color-accent-tertiary) 0.22 0.04 h / 0.85);
-  --glass-bg-quartary: oklch(from var(--color-accent-quartary) 0.22 0.04 h / 0.85);
-  --glass-border: var(--color-accent-primary-a25);
-  --glass-border-hover: oklch(from var(--color-accent-primary) l c h / 0.5);
-  --glass-border-accent: oklch(from var(--color-accent-tertiary) l c h / 0.5);
-  --glass-blur: 10px;
-  --glass-blur-light: 2px;
-  --glass-shadow:
-    0 4px 24px var(--color-black-a30),
-    inset 0 1px 0 var(--color-white-a07),
-    inset 0 -1px 0 var(--color-black-a20);
-  --glass-shadow-hover:
-    0 8px 32px var(--color-black-a40),
-    0 0 24px var(--color-accent-primary-a15),
-    inset 0 1px 0 var(--color-white-a10);
-
-  /* ==========================================
-     Glow Effects
-     ========================================== */
-  --glow-primary: 0 0 20px var(--color-accent-primary-a40);
-  --glow-secondary: 0 0 20px var(--color-accent-secondary-a40);
-  --glow-tertiary: 0 0 20px var(--color-accent-tertiary-a40);
-  --glow-quartary: 0 0 20px var(--color-accent-quartary-a40);
-  --glow-success: 0 0 20px var(--color-success-a30);
 
   /* Spacing scale (4px base) */
   --space-1: 0.25rem;   /* 4px */

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,7 +11,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
-import "./index.css";
+import "./index.scss";
+import "./holidays.scss";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {


### PR DESCRIPTION
## Summary
- Add `useHoliday` hook with `?holiday=` query param override for testing/mood selection
- 6 seasonal color palettes: valentine, easter, summer, halloween, thanksgiving, christmas
- SCSS mixin system eliminates duplication of derived color calculations
- Each theme overrides 5 base colors; all derived colors (surfaces, text, glows, glass) recalculate automatically

## Test plan
- [ ] Visit app with `?holiday=halloween` and verify orange/purple/green theme
- [ ] Visit app with `?holiday=christmas` and verify red/green/gold theme
- [ ] Visit app with `?holiday=valentine` and verify rose/pink theme
- [ ] Visit app with `?holiday=easter` and verify pastel lavender/pink/mint theme
- [ ] Visit app with `?holiday=summer` and verify teal/coral/sky blue theme
- [ ] Visit app with `?holiday=thanksgiving` and verify orange/cranberry/sage theme
- [ ] Visit app with `?holiday=none` and verify default synthwave theme
- [ ] Visit app without query param and verify date-based detection works

🤖 Generated with [Claude Code](https://claude.ai/code)