### PR TITLE
feat: add hue-rotate filters for holiday background images

### DIFF
--- a/frontend/src/components/Discussion.css
+++ b/frontend/src/components/Discussion.css
@@ -57,6 +57,7 @@
   width: 60px;
   height: 60px;
   background-image: url('/images/empty-state.webp');
+  filter: hue-rotate(var(--holiday-hue-rotate, 0deg));
   background-size: contain;
   background-repeat: no-repeat;
   background-position: center;

--- a/frontend/src/components/GoalsCard.css
+++ b/frontend/src/components/GoalsCard.css
@@ -14,6 +14,7 @@
   border-radius: inherit;
   opacity: 0.1;
   z-index: -1;
+  filter: hue-rotate(var(--holiday-hue-rotate, 0deg));
 }
 
 .goals-card {

--- a/frontend/src/components/InspirationCard.css
+++ b/frontend/src/components/InspirationCard.css
@@ -66,6 +66,7 @@
   border-radius: inherit;
   opacity: 0.15;
   z-index: -1;
+  filter: hue-rotate(var(--holiday-hue-rotate, 0deg));
 }
 
 .inspiration-card__prompt:hover {
@@ -89,6 +90,7 @@
   border-radius: inherit;
   opacity: 0.15;
   z-index: -1;
+  filter: hue-rotate(var(--holiday-hue-rotate, 0deg));
 }
 
 .inspiration-card__quote:hover {

--- a/frontend/src/holidays.scss
+++ b/frontend/src/holidays.scss
@@ -26,6 +26,7 @@
   --color-accent-secondary: oklch(0.70 0.12 10);  /* Soft pink */
   --color-accent-tertiary: oklch(0.58 0.08 320);  /* Mauve */
   --color-accent-quartary: oklch(0.82 0.06 30);   /* Warm blush */
+  --holiday-hue-rotate: 330deg;                   /* Shift to pink/rose */
 
   @include derived-colors;
 }
@@ -42,6 +43,7 @@
   --color-accent-secondary: oklch(0.72 0.10 350); /* Soft pink */
   --color-accent-tertiary: oklch(0.68 0.10 160);  /* Mint green */
   --color-accent-quartary: oklch(0.82 0.12 95);   /* Soft yellow */
+  --holiday-hue-rotate: 270deg;                   /* Shift to lavender */
 
   @include derived-colors;
 }
@@ -58,6 +60,7 @@
   --color-accent-secondary: oklch(0.70 0.14 45);  /* Coral */
   --color-accent-tertiary: oklch(0.62 0.10 230);  /* Sky blue */
   --color-accent-quartary: oklch(0.78 0.10 85);   /* Sandy gold */
+  --holiday-hue-rotate: 180deg;                   /* Shift to cyan/teal */
 
   @include derived-colors;
 }
@@ -74,6 +77,7 @@
   --color-accent-secondary: oklch(0.48 0.16 300); /* Witch purple */
   --color-accent-tertiary: oklch(0.58 0.16 130);  /* Slime green */
   --color-accent-quartary: oklch(0.78 0.14 80);   /* Candy corn */
+  --holiday-hue-rotate: 30deg;                    /* Shift to orange */
 
   @include derived-colors;
 }
@@ -90,6 +94,7 @@
   --color-accent-secondary: oklch(0.50 0.14 20);  /* Cranberry */
   --color-accent-tertiary: oklch(0.55 0.08 140);  /* Sage green */
   --color-accent-quartary: oklch(0.75 0.14 85);   /* Harvest gold */
+  --holiday-hue-rotate: 25deg;                    /* Shift to burnt orange */
 
   @include derived-colors;
 }
@@ -106,6 +111,7 @@
   --color-accent-secondary: oklch(0.48 0.12 145); /* Forest green */
   --color-accent-tertiary: oklch(0.72 0.14 85);   /* Gold */
   --color-accent-quartary: oklch(0.88 0.04 90);   /* Warm cream */
+  --holiday-hue-rotate: 120deg;                   /* Shift to green */
 
   @include derived-colors;
 }


### PR DESCRIPTION
## Summary
- Adds `--holiday-hue-rotate` CSS variable to each holiday theme in `holidays.scss`
- Applies hue-rotate filter to background images in GoalsCard, InspirationCard, and Discussion components
- Background images now shift color to match the active holiday palette

## Test plan
- [ ] Enable each holiday theme and verify background images shift appropriately
- [ ] Verify default theme (no holiday) shows unfiltered images

🤖 Generated with [Claude Code](https://claude.com/claude-code)