### PR TITLE
fix: include vaultId in image asset URLs (#202)

### DIFF
--- a/frontend/src/components/BrowseMode.tsx
+++ b/frontend/src/components/BrowseMode.tsx
@@ -21,14 +21,6 @@ import "./BrowseMode.css";
 const SAVE_ERROR_CODES = ["PATH_TRAVERSAL", "INVALID_FILE_TYPE", "FILE_NOT_FOUND", "INTERNAL_ERROR"] as const;
 
 /**
- * Props for BrowseMode component.
- */
-export interface BrowseModeProps {
-  /** Base URL for vault assets (images) */
-  assetBaseUrl?: string;
-}
-
-/**
  * BrowseMode provides a split-pane view for browsing vault files.
  *
  * Features:
@@ -37,7 +29,7 @@ export interface BrowseModeProps {
  * - Automatic root directory loading on mount
  * - Coordinates file selection between tree and viewer
  */
-export function BrowseMode({ assetBaseUrl }: BrowseModeProps): React.ReactNode {
+export function BrowseMode(): React.ReactNode {
   const [isTreeCollapsed, setIsTreeCollapsed] = useState(false);
   const [isMobileTreeOpen, setIsMobileTreeOpen] = useState(false);
 
@@ -45,6 +37,9 @@ export function BrowseMode({ assetBaseUrl }: BrowseModeProps): React.ReactNode {
   const [hasSessionReady, setHasSessionReady] = useState(false);
 
   const { browser, vault, cacheDirectory, clearDirectoryCache, setFileContent, setFileError, setFileLoading, startSave, saveSuccess, saveError, setViewMode, setTasks, setTasksLoading, setTasksError, updateTask, setSearchActive, setSearchMode, setSearchQuery, setSearchResults, setSearchLoading, toggleResultExpanded, setSnippets, clearSearch } = useSession();
+
+  // Construct asset base URL with vaultId for image serving
+  const assetBaseUrl = vault ? `/vault/${vault.id}/assets` : "/vault/assets";
 
   const { viewMode } = browser;
 


### PR DESCRIPTION
## Summary

- Fix embedded vault images not displaying by including vaultId in asset URLs
- Backend serves at `/vault/:vaultId/assets/*` but frontend was generating `/vault/assets/*`
- Compute `assetBaseUrl` dynamically from `vault.id` in BrowseMode

Fixes #202

## Test plan

- [x] BrowseMode tests pass (22 tests)
- [x] MarkdownViewer tests pass (61 tests)
- [x] TypeScript type check passes
- [x] ESLint passes
- [ ] Manual verification: open a vault note with embedded images and confirm they display

🤖 Generated with [Claude Code](https://claude.com/claude-code)