### PR TITLE
feat: add support for viewing TXT files in Browse mode

### DIFF
--- a/backend/src/file-browser.ts
+++ b/backend/src/file-browser.ts
@@ -23,7 +23,7 @@ export const MAX_FILE_SIZE = 1024 * 1024; // 1MB
  * Allowed file extensions for text file reading/writing.
  * Lowercase, including the leading dot.
  */
-const ALLOWED_TEXT_EXTENSIONS = new Set([".md", ".json"]);
+const ALLOWED_TEXT_EXTENSIONS = new Set([".md", ".json", ".txt"]);
 
 /**
  * Checks if a file path has an allowed text extension.

--- a/frontend/src/components/BrowseMode.tsx
+++ b/frontend/src/components/BrowseMode.tsx
@@ -16,9 +16,10 @@ import { ImageViewer } from "./ImageViewer";
 import { VideoViewer } from "./VideoViewer";
 import { PdfViewer } from "./PdfViewer";
 import { JsonViewer } from "./JsonViewer";
+import { TxtViewer } from "./TxtViewer";
 import { SearchHeader } from "./SearchHeader";
 import { SearchResults } from "./SearchResults";
-import { isImageFile, isVideoFile, isPdfFile, isMarkdownFile, isJsonFile } from "../utils/file-types";
+import { isImageFile, isVideoFile, isPdfFile, isMarkdownFile, isJsonFile, isTxtFile } from "../utils/file-types";
 import type { FileSearchResult, ContentSearchResult } from "@memory-loop/shared";
 import "./BrowseMode.css";
 
@@ -126,7 +127,7 @@ export function BrowseMode(): React.ReactNode {
     }
 
     // Check if this is a text file that needs loading
-    const isTextFile = isMarkdownFile(path) || isJsonFile(path);
+    const isTextFile = isMarkdownFile(path) || isJsonFile(path) || isTxtFile(path);
 
     // For text files, auto-load if not already loaded
     if (
@@ -506,6 +507,8 @@ export function BrowseMode(): React.ReactNode {
             <PdfViewer path={browser.currentPath} assetBaseUrl={assetBaseUrl} />
           ) : isJsonFile(browser.currentPath) ? (
             <JsonViewer onNavigate={handleNavigate} onSave={handleSave} />
+          ) : isTxtFile(browser.currentPath) ? (
+            <TxtViewer onNavigate={handleNavigate} onSave={handleSave} />
           ) : (
             <MarkdownViewer onNavigate={handleNavigate} assetBaseUrl={assetBaseUrl} onSave={handleSave} />
           )}

--- a/frontend/src/components/TxtViewer.css
+++ b/frontend/src/components/TxtViewer.css
@@ -1,0 +1,366 @@
+/**
+ * TxtViewer Component Styles
+ *
+ * Styling for plain text content display with editing support.
+ */
+
+.txt-viewer {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: transparent;
+}
+
+.txt-viewer--empty {
+  justify-content: center;
+  align-items: center;
+}
+
+.txt-viewer--loading,
+.txt-viewer--error {
+  overflow-y: auto;
+}
+
+/* Breadcrumb navigation */
+.txt-viewer__breadcrumb {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--glass-bg-quartary);
+  backdrop-filter: blur(var(--glass-blur));
+  border-bottom: 1px solid var(--glass-border);
+  font-size: var(--text-sm);
+  min-height: 44px;
+}
+
+@supports not (backdrop-filter: blur(10px)) {
+  .txt-viewer__breadcrumb {
+    background-color: var(--color-surface);
+  }
+}
+
+.txt-viewer__breadcrumb-item {
+  background: transparent;
+  border: 1px solid transparent;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  color: var(--color-text-accent);
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.3s ease;
+}
+
+.txt-viewer__breadcrumb-item:hover {
+  background: var(--color-accent-primary-a10);
+  border-color: var(--glass-border);
+  box-shadow: 0 0 8px var(--color-accent-primary-a10);
+}
+
+@media (hover: none) {
+  .txt-viewer__breadcrumb-item:hover {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+  }
+}
+
+.txt-viewer__breadcrumb-separator {
+  color: var(--color-text-secondary);
+}
+
+.txt-viewer__breadcrumb-current {
+  color: var(--color-text);
+  font-weight: var(--font-medium);
+}
+
+/* Truncation warning */
+.txt-viewer__truncation-warning {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-bg-warning);
+  color: var(--color-text-warning);
+  font-size: var(--text-sm);
+  border-bottom: 1px solid var(--color-warning);
+}
+
+/* Content area */
+.txt-viewer__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--spacing-md) var(--spacing-lg);
+  background-color: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+}
+
+@supports not (backdrop-filter: blur(10px)) {
+  .txt-viewer__content {
+    background-color: var(--color-surface);
+  }
+}
+
+/* Text display */
+.txt-viewer__text {
+  margin: 0;
+  padding: var(--spacing-md);
+  background: var(--color-background-a60);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  color: var(--color-text);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.txt-viewer__text code {
+  font-family: inherit;
+  background: none;
+  padding: 0;
+}
+
+/* Empty state */
+.txt-viewer__empty-content {
+  text-align: center;
+  color: var(--color-text-secondary);
+  padding: var(--spacing-lg);
+}
+
+/* Error state */
+.txt-viewer__error-content {
+  padding: var(--spacing-lg);
+  text-align: center;
+}
+
+.txt-viewer__error-message {
+  color: var(--color-text-error);
+  font-size: var(--text-base);
+}
+
+/* Loading skeleton */
+.txt-viewer__skeleton {
+  padding: var(--spacing-md) var(--spacing-lg);
+}
+
+.txt-viewer__skeleton-line {
+  height: 1em;
+  background: linear-gradient(
+    90deg,
+    var(--color-accent-primary-a05) 25%,
+    var(--color-accent-primary-a12) 50%,
+    var(--color-accent-primary-a05) 75%
+  );
+  background-size: 200% 100%;
+  animation: txt-skeleton-shimmer 1.5s infinite;
+  border-radius: var(--radius-md);
+  margin-bottom: var(--spacing-sm);
+}
+
+.txt-viewer__skeleton-line--short {
+  width: 40%;
+}
+
+.txt-viewer__skeleton-line--medium {
+  width: 70%;
+}
+
+@keyframes txt-skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Mobile adjustments */
+@media (max-width: 767px) {
+  .txt-viewer__content {
+    padding: var(--spacing-sm) var(--spacing-md);
+    backdrop-filter: blur(4px);
+  }
+
+  .txt-viewer__breadcrumb {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    backdrop-filter: blur(4px);
+  }
+
+  .txt-viewer__text {
+    padding: var(--spacing-sm);
+    font-size: var(--text-xs);
+  }
+}
+
+/* ============================================
+   Adjust Mode Styles
+   ============================================ */
+
+.txt-viewer--adjusting {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* View header with Adjust button */
+.txt-viewer__view-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: var(--glass-bg-tertiary);
+  border-bottom: 1px solid var(--glass-border);
+  min-height: 44px;
+}
+
+/* Adjust header with Save/Cancel buttons */
+.txt-viewer__adjust-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: var(--spacing-xs) var(--spacing-md);
+  background: var(--glass-bg-tertiary);
+  border-bottom: 1px solid var(--glass-border);
+  min-height: 44px;
+}
+
+.txt-viewer__adjust-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+/* Button styling */
+.txt-viewer__adjust-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xs) var(--spacing-md);
+  min-height: 32px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.3s ease;
+}
+
+.txt-viewer__adjust-btn:hover:not(:disabled) {
+  background: var(--color-accent-primary-a10);
+  border-color: var(--glass-border);
+  color: var(--color-text);
+  box-shadow: 0 0 12px var(--color-accent-primary-a15);
+}
+
+.txt-viewer__adjust-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Save button - primary action styling */
+.txt-viewer__adjust-btn--save {
+  background: var(--color-accent-primary-a15);
+  border-color: var(--glass-border);
+  color: var(--color-text-accent);
+}
+
+.txt-viewer__adjust-btn--save:hover:not(:disabled) {
+  background: var(--color-accent-primary-a25);
+  box-shadow: 0 0 16px var(--color-accent-primary-a20);
+}
+
+/* Cancel button - subtle styling */
+.txt-viewer__adjust-btn--cancel {
+  color: var(--color-text-secondary);
+}
+
+@media (hover: none) {
+  .txt-viewer__adjust-btn:hover:not(:disabled) {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+  }
+
+  .txt-viewer__adjust-btn--save:hover:not(:disabled) {
+    background: var(--color-accent-primary-a15);
+    border-color: var(--glass-border);
+    box-shadow: none;
+  }
+}
+
+/* Error message display */
+.txt-viewer__adjust-error {
+  padding: var(--spacing-sm) var(--spacing-md);
+  background-color: var(--color-error-a10);
+  border-bottom: 1px solid var(--color-error-a30);
+  color: var(--color-text-error);
+  font-size: var(--text-sm);
+}
+
+/* Textarea container */
+.txt-viewer__adjust-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: var(--spacing-md);
+  min-height: 200px;
+}
+
+/* Textarea styling */
+.txt-viewer__adjust-textarea {
+  flex: 1;
+  width: 100%;
+  min-height: 200px;
+  padding: var(--spacing-md);
+  background: var(--color-background-a60);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  resize: none;
+  overflow-y: auto;
+}
+
+.txt-viewer__adjust-textarea:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-primary-a20);
+}
+
+.txt-viewer__adjust-textarea:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.txt-viewer__adjust-textarea::placeholder {
+  color: var(--color-text-secondary);
+  opacity: 0.6;
+}
+
+/* Mobile adjustments for adjust mode */
+@media (max-width: 767px) {
+  .txt-viewer__view-header,
+  .txt-viewer__adjust-header {
+    padding: var(--spacing-xs) var(--spacing-sm);
+  }
+
+  .txt-viewer__adjust-content {
+    padding: var(--spacing-sm);
+  }
+
+  .txt-viewer__adjust-textarea {
+    padding: var(--spacing-sm);
+  }
+
+  .txt-viewer__adjust-btn {
+    min-height: 44px;
+    padding: var(--spacing-sm) var(--spacing-md);
+  }
+}

--- a/frontend/src/components/TxtViewer.tsx
+++ b/frontend/src/components/TxtViewer.tsx
@@ -1,0 +1,286 @@
+/**
+ * TxtViewer Component
+ *
+ * Renders plain text content with display and editing support.
+ * Similar to JsonViewer but without JSON parsing/validation.
+ */
+
+import {
+  useCallback,
+  useState,
+  type ReactNode,
+  type KeyboardEvent,
+} from "react";
+import { useSession } from "../contexts/SessionContext";
+import "./TxtViewer.css";
+
+/**
+ * Props for TxtViewer component.
+ */
+export interface TxtViewerProps {
+  /** Callback when a path is navigated (breadcrumb) */
+  onNavigate?: (path: string) => void;
+  /** Callback to save file content in adjust mode */
+  onSave?: (content: string) => void;
+}
+
+/**
+ * Breadcrumb component for file path navigation.
+ */
+function Breadcrumb({
+  path,
+  onNavigate,
+}: {
+  path: string;
+  onNavigate: (path: string) => void;
+}): ReactNode {
+  const segments = path.split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const crumbs = segments.map((segment, index) => ({
+    name: segment,
+    path: segments.slice(0, index + 1).join("/"),
+    isLast: index === segments.length - 1,
+  }));
+
+  return (
+    <nav className="txt-viewer__breadcrumb" aria-label="File path">
+      <button
+        type="button"
+        className="txt-viewer__breadcrumb-item"
+        onClick={() => onNavigate("")}
+      >
+        Root
+      </button>
+      {crumbs.map((crumb) => (
+        <span key={crumb.path}>
+          <span className="txt-viewer__breadcrumb-separator">/</span>
+          {crumb.isLast ? (
+            <span className="txt-viewer__breadcrumb-current">{crumb.name}</span>
+          ) : (
+            <button
+              type="button"
+              className="txt-viewer__breadcrumb-item"
+              onClick={() => onNavigate(crumb.path)}
+            >
+              {crumb.name}
+            </button>
+          )}
+        </span>
+      ))}
+    </nav>
+  );
+}
+
+/**
+ * Loading skeleton for text content.
+ */
+function LoadingSkeleton(): ReactNode {
+  return (
+    <div className="txt-viewer__skeleton" aria-label="Loading content">
+      <div className="txt-viewer__skeleton-line txt-viewer__skeleton-line--short" />
+      <div className="txt-viewer__skeleton-line" />
+      <div className="txt-viewer__skeleton-line txt-viewer__skeleton-line--medium" />
+      <div className="txt-viewer__skeleton-line" />
+      <div className="txt-viewer__skeleton-line txt-viewer__skeleton-line--short" />
+    </div>
+  );
+}
+
+/**
+ * TxtViewer renders vault plain text files with:
+ * - Plain text display
+ * - Breadcrumb navigation
+ * - Adjust mode for editing
+ */
+export function TxtViewer({
+  onNavigate,
+  onSave,
+}: TxtViewerProps): ReactNode {
+  const {
+    browser,
+    setCurrentPath,
+    startAdjust,
+    updateAdjustContent,
+    cancelAdjust,
+  } = useSession();
+  const {
+    currentPath,
+    currentFileContent,
+    currentFileTruncated,
+    fileError,
+    isLoading,
+    isAdjusting,
+    adjustContent,
+    adjustError,
+    isSaving,
+  } = browser;
+
+  // Local state for any save errors
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Handle breadcrumb navigation
+  const handleBreadcrumbNavigate = useCallback(
+    (path: string) => {
+      setCurrentPath(path);
+      if (!path.endsWith(".txt")) {
+        onNavigate?.("");
+      }
+    },
+    [setCurrentPath, onNavigate]
+  );
+
+  // Handle Escape key in adjust mode
+  const handleTextareaKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        cancelAdjust();
+        setSaveError(null);
+      }
+    },
+    [cancelAdjust]
+  );
+
+  // Handle textarea content change
+  const handleContentChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      updateAdjustContent(event.target.value);
+      // Clear error when user types
+      if (saveError) {
+        setSaveError(null);
+      }
+    },
+    [updateAdjustContent, saveError]
+  );
+
+  // Handle save button click
+  const handleSave = useCallback(() => {
+    setSaveError(null);
+    onSave?.(adjustContent);
+  }, [onSave, adjustContent]);
+
+  // Handle cancel with cleanup
+  const handleCancel = useCallback(() => {
+    cancelAdjust();
+    setSaveError(null);
+  }, [cancelAdjust]);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="txt-viewer txt-viewer--loading">
+        <Breadcrumb path={currentPath} onNavigate={handleBreadcrumbNavigate} />
+        <LoadingSkeleton />
+      </div>
+    );
+  }
+
+  // Error state
+  if (fileError) {
+    return (
+      <div className="txt-viewer txt-viewer--error">
+        <Breadcrumb path={currentPath} onNavigate={handleBreadcrumbNavigate} />
+        <div className="txt-viewer__error-content">
+          <p className="txt-viewer__error-message">{fileError}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state - no file selected
+  if (!currentFileContent) {
+    return (
+      <div className="txt-viewer txt-viewer--empty">
+        <div className="txt-viewer__empty-content">
+          <p>Select a file to view its content</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Adjust mode - show textarea for editing
+  if (isAdjusting) {
+    return (
+      <div className="txt-viewer txt-viewer--adjusting">
+        <Breadcrumb path={currentPath} onNavigate={handleBreadcrumbNavigate} />
+
+        <div className="txt-viewer__adjust-header">
+          <div className="txt-viewer__adjust-actions">
+            <button
+              type="button"
+              className="txt-viewer__adjust-btn txt-viewer__adjust-btn--save"
+              onClick={handleSave}
+              disabled={isSaving}
+              aria-label="Save changes"
+            >
+              {isSaving ? "Saving..." : "Save"}
+            </button>
+            <button
+              type="button"
+              className="txt-viewer__adjust-btn txt-viewer__adjust-btn--cancel"
+              onClick={handleCancel}
+              disabled={isSaving}
+              aria-label="Cancel editing"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+
+        {/* Error message display */}
+        {(adjustError || saveError) && (
+          <div className="txt-viewer__adjust-error" role="alert">
+            {adjustError || saveError}
+          </div>
+        )}
+
+        <div className="txt-viewer__adjust-content">
+          <textarea
+            className="txt-viewer__adjust-textarea"
+            value={adjustContent}
+            onChange={handleContentChange}
+            onKeyDown={handleTextareaKeyDown}
+            disabled={isSaving}
+            autoFocus
+            spellCheck={false}
+            aria-label="File content editor"
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // Normal view mode
+  return (
+    <div className="txt-viewer">
+      <Breadcrumb path={currentPath} onNavigate={handleBreadcrumbNavigate} />
+
+      <div className="txt-viewer__view-header">
+        <button
+          type="button"
+          className="txt-viewer__adjust-btn"
+          onClick={startAdjust}
+          aria-label="Adjust file"
+        >
+          Adjust
+        </button>
+      </div>
+
+      {currentFileTruncated && (
+        <div className="txt-viewer__truncation-warning" role="alert">
+          This file was truncated due to size limits. Some content may be missing.
+        </div>
+      )}
+
+      <div className="txt-viewer__content">
+        <pre className="txt-viewer__text">
+          <code>{currentFileContent}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/utils/__tests__/file-types.test.ts
+++ b/frontend/src/utils/__tests__/file-types.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { isImageFile, isMarkdownFile, IMAGE_EXTENSIONS } from "../file-types";
+import { isImageFile, isMarkdownFile, isTxtFile, IMAGE_EXTENSIONS } from "../file-types";
 
 describe("isImageFile", () => {
   it("returns true for common image extensions", () => {
@@ -78,6 +78,34 @@ describe("isMarkdownFile", () => {
 
   it("returns false for empty string", () => {
     expect(isMarkdownFile("")).toBe(false);
+  });
+});
+
+describe("isTxtFile", () => {
+  it("returns true for .txt files", () => {
+    expect(isTxtFile("notes.txt")).toBe(true);
+    expect(isTxtFile("readme.txt")).toBe(true);
+    expect(isTxtFile("log.txt")).toBe(true);
+  });
+
+  it("handles uppercase extensions", () => {
+    expect(isTxtFile("notes.TXT")).toBe(true);
+    expect(isTxtFile("README.Txt")).toBe(true);
+  });
+
+  it("handles paths with directories", () => {
+    expect(isTxtFile("docs/readme.txt")).toBe(true);
+    expect(isTxtFile("logs/2024-01-01.txt")).toBe(true);
+  });
+
+  it("returns false for non-txt files", () => {
+    expect(isTxtFile("photo.jpg")).toBe(false);
+    expect(isTxtFile("document.md")).toBe(false);
+    expect(isTxtFile("data.json")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isTxtFile("")).toBe(false);
   });
 });
 

--- a/frontend/src/utils/file-types.ts
+++ b/frontend/src/utils/file-types.ts
@@ -85,6 +85,16 @@ export function isJsonFile(path: string): boolean {
 }
 
 /**
+ * Checks if a file path is a plain text file.
+ *
+ * @param path - File path to check
+ * @returns true if the file has .txt extension
+ */
+export function isTxtFile(path: string): boolean {
+  return path.toLowerCase().endsWith(".txt");
+}
+
+/**
  * Encodes a file path for use in URLs.
  * Encodes each path segment separately to preserve directory structure.
  *


### PR DESCRIPTION
## Summary

- Add `TxtViewer` component for displaying plain text files with breadcrumb navigation, loading states, and editing support (Adjust mode)
- Add `isTxtFile()` utility function for file type detection
- Update backend to allow reading and writing `.txt` files alongside `.md` and `.json`
- Route `.txt` files to the new viewer in BrowseMode

Closes #211

## Test plan

- [x] All 766 frontend tests pass
- [x] All 91 backend tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes
- [ ] Manual test: Browse to a `.txt` file and verify it displays correctly
- [ ] Manual test: Use Adjust mode to edit a `.txt` file and save

🤖 Generated with [Claude Code](https://claude.com/claude-code)