### PR TITLE
feat: add file deletion to Browse mode context menu

### DIFF
--- a/frontend/src/components/FileTree.css
+++ b/frontend/src/components/FileTree.css
@@ -306,3 +306,16 @@
   height: 14px;
   color: var(--color-text-accent-secondary);
 }
+
+/* Danger variant for destructive actions */
+.file-tree__context-menu-item--danger {
+  color: var(--color-error);
+}
+
+.file-tree__context-menu-item--danger:hover {
+  background: color-mix(in srgb, var(--color-error) 15%, transparent);
+}
+
+.file-tree__context-menu-item--danger .file-tree__icon-svg {
+  color: var(--color-error);
+}

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -419,6 +419,15 @@ export const GetSnippetsMessageSchema = z.object({
 });
 
 /**
+ * Client requests to delete a file from the vault
+ * Path is relative to vault content root
+ */
+export const DeleteFileMessageSchema = z.object({
+  type: z.literal("delete_file"),
+  path: z.string().min(1, "File path is required"),
+});
+
+/**
  * Discriminated union of all client message types
  */
 export const ClientMessageSchema = z.discriminatedUnion("type", [
@@ -444,6 +453,7 @@ export const ClientMessageSchema = z.discriminatedUnion("type", [
   SearchFilesMessageSchema,
   SearchContentMessageSchema,
   GetSnippetsMessageSchema,
+  DeleteFileMessageSchema,
 ]);
 
 // =============================================================================
@@ -736,6 +746,14 @@ export const IndexProgressMessageSchema = z.object({
 });
 
 /**
+ * Server confirms file was deleted successfully
+ */
+export const FileDeletedMessageSchema = z.object({
+  type: z.literal("file_deleted"),
+  path: z.string().min(1, "File path is required"),
+});
+
+/**
  * Discriminated union of all server message types
  */
 export const ServerMessageSchema = z.discriminatedUnion("type", [
@@ -765,6 +783,7 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
   SearchResultsMessageSchema,
   SnippetsMessageSchema,
   IndexProgressMessageSchema,
+  FileDeletedMessageSchema,
 ]);
 
 // =============================================================================
@@ -820,6 +839,7 @@ export type SetupVaultMessage = z.infer<typeof SetupVaultMessageSchema>;
 export type SearchFilesMessage = z.infer<typeof SearchFilesMessageSchema>;
 export type SearchContentMessage = z.infer<typeof SearchContentMessageSchema>;
 export type GetSnippetsMessage = z.infer<typeof GetSnippetsMessageSchema>;
+export type DeleteFileMessage = z.infer<typeof DeleteFileMessageSchema>;
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;
 
 // Server message types
@@ -851,6 +871,7 @@ export type SetupCompleteMessage = z.infer<typeof SetupCompleteMessageSchema>;
 export type SearchResultsMessage = z.infer<typeof SearchResultsMessageSchema>;
 export type SnippetsMessage = z.infer<typeof SnippetsMessageSchema>;
 export type IndexProgressMessage = z.infer<typeof IndexProgressMessageSchema>;
+export type FileDeletedMessage = z.infer<typeof FileDeletedMessageSchema>;
 export type ServerMessage = z.infer<typeof ServerMessageSchema>;
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add delete button to file context menu in Recall (Browse) tab
- Confirmation dialog required before deletion to prevent accidents
- Files only (directories cannot be deleted for safety)

Closes #204

## Changes
- **Protocol**: Added `delete_file` client message and `file_deleted` server response
- **Backend**: `deleteFile()` function with path traversal protection, symlink rejection
- **Frontend**: Delete button in context menu with `ConfirmDialog` integration
- **Tests**: 26 new tests covering backend and frontend functionality

## Test plan
- [x] All 768 tests pass
- [x] Linting passes
- [ ] Manual testing: right-click file → Delete → confirm → file removed
- [ ] Verify delete option not shown for directories
- [ ] Verify confirmation dialog appears and can be cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)