### PR TITLE
feat: add version watermark showing git commit hash in header

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -186,6 +186,14 @@
   align-items: center;
 }
 
+.app-version {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  opacity: 0.6;
+  font-family: var(--font-family-mono, monospace);
+  letter-spacing: 0.02em;
+}
+
 /* Tablet and up - horizontal header layout */
 @media (min-width: 768px) {
   .app-header {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,7 +74,7 @@ function MainContent(): React.ReactNode {
           <ModeToggle />
         </div>
         <div className="app-header__right">
-          {/* New session button moved to Discussion component */}
+          <span className="app-version">{__APP_VERSION__}</span>
         </div>
       </header>
 

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Tests for version watermark global
+ *
+ * Tests that the __APP_VERSION__ global is defined and has expected format.
+ * The version watermark display is tested indirectly through integration tests.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+describe("version watermark", () => {
+  it("__APP_VERSION__ is defined", () => {
+    expect(typeof __APP_VERSION__).toBe("string");
+  });
+
+  it("__APP_VERSION__ has expected test value", () => {
+    // The test setup defines this as "test-abc123"
+    expect(__APP_VERSION__).toBe("test-abc123");
+  });
+
+  it("__APP_VERSION__ is not empty", () => {
+    expect(__APP_VERSION__.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -8,3 +8,6 @@ import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
 // Register happy-dom globals (window, document, etc.)
 GlobalRegistrator.register();
+
+// Define build-time globals for tests
+(globalThis as Record<string, unknown>).__APP_VERSION__ = "test-abc123";

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,14 +1,27 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { execSync } from "child_process";
+
+function getGitCommit(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
 
 /**
  * Vite configuration for Memory Loop frontend
  *
  * - React plugin for JSX transform and Fast Refresh
  * - Proxy /api and /ws to backend server for development
+ * - Injects git commit SHA as __APP_VERSION__ for version watermark
  */
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(getGitCommit()),
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary

- Display the short git commit SHA in the app header to help identify which version is deployed
- Watermark uses subtle styling (small, muted, monospace font) on the right side of the header
- Version is injected at build time via Vite's `define` config

## Test plan

- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Unit tests pass (764 tests)
- [x] Build succeeds with commit hash embedded
- [ ] Visually verify watermark appears in header on desktop and mobile

🤖 Generated with [Claude Code](https://claude.ai/code)