### PR TITLE
feat: add download option for unsupported file types in Browse mode

### DIFF
--- a/frontend/src/components/DownloadViewer.css
+++ b/frontend/src/components/DownloadViewer.css
@@ -1,0 +1,68 @@
+/**
+ * DownloadViewer Styles
+ *
+ * Centered layout with file icon, name, and download button.
+ */
+
+.download-viewer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: var(--spacing-lg);
+}
+
+.download-viewer__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--spacing-md);
+  max-width: 300px;
+}
+
+.download-viewer__icon {
+  color: var(--text-muted);
+}
+
+.download-viewer__file-icon {
+  width: 64px;
+  height: 64px;
+}
+
+.download-viewer__filename {
+  font-size: var(--font-size-lg);
+  font-weight: 500;
+  color: var(--text-primary);
+  word-break: break-word;
+  margin: 0;
+}
+
+.download-viewer__message {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.download-viewer__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  background-color: var(--accent-primary);
+  color: var(--text-on-accent);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  text-decoration: none;
+  transition: background-color 0.15s ease;
+  margin-top: var(--spacing-sm);
+}
+
+.download-viewer__button:hover {
+  background-color: var(--accent-hover);
+}
+
+.download-viewer__button:active {
+  background-color: var(--accent-active);
+}

--- a/frontend/src/components/DownloadViewer.tsx
+++ b/frontend/src/components/DownloadViewer.tsx
@@ -1,0 +1,72 @@
+/**
+ * DownloadViewer Component
+ *
+ * Displays a download option for file types that don't have a dedicated viewer.
+ * Provides a simple interface with file info and download button.
+ */
+
+import type { ReactNode } from "react";
+import { encodeAssetPath } from "../utils/file-types";
+import "./DownloadViewer.css";
+
+export interface DownloadViewerProps {
+  /** Path to the file relative to vault content root */
+  path: string;
+  /** Base URL for vault assets (e.g., /vault/{vaultId}/assets) */
+  assetBaseUrl: string;
+}
+
+/**
+ * DownloadViewer shows a download prompt for unsupported file types.
+ *
+ * Uses the existing asset serving endpoint to provide the download,
+ * with the download attribute to trigger browser download behavior.
+ */
+export function DownloadViewer({ path, assetBaseUrl }: DownloadViewerProps): ReactNode {
+  const downloadUrl = `${assetBaseUrl}/${encodeAssetPath(path)}`;
+  const fileName = path.split("/").pop() ?? path;
+  const extension = fileName.includes(".") ? fileName.split(".").pop()?.toUpperCase() : "FILE";
+
+  return (
+    <div className="download-viewer">
+      <div className="download-viewer__content">
+        <div className="download-viewer__icon" aria-hidden="true">
+          <FileIcon />
+        </div>
+        <p className="download-viewer__filename">{fileName}</p>
+        <p className="download-viewer__message">
+          No preview available for {extension} files
+        </p>
+        <a
+          href={downloadUrl}
+          download={fileName}
+          className="download-viewer__button"
+        >
+          Download File
+        </a>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Generic file icon for unsupported file types.
+ */
+function FileIcon(): ReactNode {
+  return (
+    <svg
+      className="download-viewer__file-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <line x1="12" y1="18" x2="12" y2="12" />
+      <line x1="9" y1="15" x2="15" y2="15" />
+    </svg>
+  );
+}

--- a/frontend/src/components/__tests__/BrowseMode.adjust.test.tsx
+++ b/frontend/src/components/__tests__/BrowseMode.adjust.test.tsx
@@ -352,7 +352,7 @@ describe("BrowseMode Adjust Integration", () => {
     it("shows error and preserves content when PATH_TRAVERSAL error received", async () => {
       render(<BrowseMode />, {
         wrapper: createTestWrapper({
-          currentPath: "../etc/passwd",
+          currentPath: "../etc/config.md",
           currentFileContent: "malicious content",
         }),
       });
@@ -397,8 +397,8 @@ describe("BrowseMode Adjust Integration", () => {
     it("shows error when INVALID_FILE_TYPE error received during save", async () => {
       render(<BrowseMode />, {
         wrapper: createTestWrapper({
-          currentPath: "script.js",
-          currentFileContent: "console.log('test');",
+          currentPath: "test-file.md",
+          currentFileContent: "# Test content",
         }),
       });
 

--- a/frontend/src/components/__tests__/DownloadViewer.test.tsx
+++ b/frontend/src/components/__tests__/DownloadViewer.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * DownloadViewer Component Tests
+ */
+
+import { describe, expect, it, afterEach } from "bun:test";
+import { render, screen, cleanup } from "@testing-library/react";
+import { DownloadViewer } from "../DownloadViewer";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DownloadViewer", () => {
+  const defaultProps = {
+    path: "attachments/document.docx",
+    assetBaseUrl: "/vault/test-vault/assets",
+  };
+
+  it("renders the filename", () => {
+    render(<DownloadViewer {...defaultProps} />);
+
+    expect(screen.getByText("document.docx")).toBeDefined();
+  });
+
+  it("extracts filename from nested path", () => {
+    render(<DownloadViewer path="deep/nested/archive.zip" assetBaseUrl="/vault/v1/assets" />);
+
+    expect(screen.getByText("archive.zip")).toBeDefined();
+  });
+
+  it("shows file extension in message", () => {
+    render(<DownloadViewer {...defaultProps} />);
+
+    expect(screen.getByText("No preview available for DOCX files")).toBeDefined();
+  });
+
+  it("shows correct extension for different file types", () => {
+    const { rerender } = render(
+      <DownloadViewer path="data.xlsx" assetBaseUrl="/vault/v1/assets" />
+    );
+    expect(screen.getByText("No preview available for XLSX files")).toBeDefined();
+
+    rerender(<DownloadViewer path="archive.zip" assetBaseUrl="/vault/v1/assets" />);
+    expect(screen.getByText("No preview available for ZIP files")).toBeDefined();
+  });
+
+  it("renders download button with correct link", () => {
+    render(<DownloadViewer {...defaultProps} />);
+
+    const link = screen.getByRole("link", { name: "Download File" });
+    expect(link).toBeDefined();
+    expect(link.getAttribute("href")).toBe("/vault/test-vault/assets/attachments/document.docx");
+  });
+
+  it("has download attribute with filename", () => {
+    render(<DownloadViewer {...defaultProps} />);
+
+    const link = screen.getByRole("link", { name: "Download File" });
+    expect(link.getAttribute("download")).toBe("document.docx");
+  });
+
+  it("encodes special characters in URL", () => {
+    render(<DownloadViewer path="files/my document (1).docx" assetBaseUrl="/vault/v1/assets" />);
+
+    const link = screen.getByRole("link", { name: "Download File" });
+    expect(link.getAttribute("href")).toBe("/vault/v1/assets/files/my%20document%20(1).docx");
+  });
+
+  it("handles files without extension gracefully", () => {
+    render(<DownloadViewer path="Makefile" assetBaseUrl="/vault/v1/assets" />);
+
+    expect(screen.getByText("Makefile")).toBeDefined();
+    expect(screen.getByText("No preview available for FILE files")).toBeDefined();
+  });
+
+  it("uses path as filename when no separator exists", () => {
+    render(<DownloadViewer path="simple.zip" assetBaseUrl="/vault/v1/assets" />);
+
+    expect(screen.getByText("simple.zip")).toBeDefined();
+    const link = screen.getByRole("link", { name: "Download File" });
+    expect(link.getAttribute("download")).toBe("simple.zip");
+  });
+
+  it("constructs URL correctly with different base URLs", () => {
+    const { rerender } = render(
+      <DownloadViewer path="file.zip" assetBaseUrl="/vault/vault-1/assets" />
+    );
+
+    let link = screen.getByRole("link", { name: "Download File" });
+    expect(link.getAttribute("href")).toBe("/vault/vault-1/assets/file.zip");
+
+    rerender(<DownloadViewer path="file.zip" assetBaseUrl="/vault/vault-2/assets" />);
+    link = screen.getByRole("link", { name: "Download File" });
+    expect(link.getAttribute("href")).toBe("/vault/vault-2/assets/file.zip");
+  });
+});

--- a/frontend/src/utils/__tests__/file-types.test.ts
+++ b/frontend/src/utils/__tests__/file-types.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { isImageFile, isMarkdownFile, isTxtFile, IMAGE_EXTENSIONS } from "../file-types";
+import { isImageFile, isMarkdownFile, isTxtFile, hasSupportedViewer, IMAGE_EXTENSIONS } from "../file-types";
 
 describe("isImageFile", () => {
   it("returns true for common image extensions", () => {
@@ -126,5 +126,67 @@ describe("IMAGE_EXTENSIONS", () => {
     expect(IMAGE_EXTENSIONS.has("md")).toBe(false);
     expect(IMAGE_EXTENSIONS.has("txt")).toBe(false);
     expect(IMAGE_EXTENSIONS.has("pdf")).toBe(false);
+  });
+});
+
+describe("hasSupportedViewer", () => {
+  it("returns true for image files", () => {
+    expect(hasSupportedViewer("photo.jpg")).toBe(true);
+    expect(hasSupportedViewer("image.png")).toBe(true);
+    expect(hasSupportedViewer("icon.svg")).toBe(true);
+  });
+
+  it("returns true for video files", () => {
+    expect(hasSupportedViewer("movie.mp4")).toBe(true);
+    expect(hasSupportedViewer("clip.webm")).toBe(true);
+    expect(hasSupportedViewer("video.mov")).toBe(true);
+  });
+
+  it("returns true for PDF files", () => {
+    expect(hasSupportedViewer("document.pdf")).toBe(true);
+    expect(hasSupportedViewer("report.PDF")).toBe(true);
+  });
+
+  it("returns true for markdown files", () => {
+    expect(hasSupportedViewer("notes.md")).toBe(true);
+    expect(hasSupportedViewer("README.MD")).toBe(true);
+  });
+
+  it("returns true for JSON files", () => {
+    expect(hasSupportedViewer("data.json")).toBe(true);
+    expect(hasSupportedViewer("config.JSON")).toBe(true);
+  });
+
+  it("returns true for TXT files", () => {
+    expect(hasSupportedViewer("notes.txt")).toBe(true);
+    expect(hasSupportedViewer("log.TXT")).toBe(true);
+  });
+
+  it("returns true for CSV/TSV files", () => {
+    expect(hasSupportedViewer("data.csv")).toBe(true);
+    expect(hasSupportedViewer("table.tsv")).toBe(true);
+  });
+
+  it("returns false for unsupported file types", () => {
+    expect(hasSupportedViewer("archive.zip")).toBe(false);
+    expect(hasSupportedViewer("document.docx")).toBe(false);
+    expect(hasSupportedViewer("spreadsheet.xlsx")).toBe(false);
+    expect(hasSupportedViewer("presentation.pptx")).toBe(false);
+    expect(hasSupportedViewer("executable.exe")).toBe(false);
+    expect(hasSupportedViewer("archive.tar.gz")).toBe(false);
+  });
+
+  it("handles paths with directories", () => {
+    expect(hasSupportedViewer("attachments/photo.jpg")).toBe(true);
+    expect(hasSupportedViewer("docs/archive.zip")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(hasSupportedViewer("")).toBe(false);
+  });
+
+  it("returns false for files without extensions", () => {
+    expect(hasSupportedViewer("README")).toBe(false);
+    expect(hasSupportedViewer("Makefile")).toBe(false);
   });
 });

--- a/frontend/src/utils/file-types.ts
+++ b/frontend/src/utils/file-types.ts
@@ -106,6 +106,24 @@ export function isCsvFile(path: string): boolean {
 }
 
 /**
+ * Checks if a file has a supported viewer in the browser.
+ *
+ * @param path - File path to check
+ * @returns true if the file type has a dedicated viewer
+ */
+export function hasSupportedViewer(path: string): boolean {
+  return (
+    isImageFile(path) ||
+    isVideoFile(path) ||
+    isPdfFile(path) ||
+    isMarkdownFile(path) ||
+    isJsonFile(path) ||
+    isTxtFile(path) ||
+    isCsvFile(path)
+  );
+}
+
+/**
  * Encodes a file path for use in URLs.
  * Encodes each path segment separately to preserve directory structure.
  *


### PR DESCRIPTION
## Summary

- Add `DownloadViewer` component that displays a download button for files without dedicated viewers
- Add `hasSupportedViewer()` utility to check if a file type has a viewer
- Update `BrowseMode` to show `DownloadViewer` for unsupported file types (e.g., .zip, .docx, .xlsx) instead of broken markdown rendering

Closes #218

## Test plan

- [ ] Select a `.zip` file in Browse mode and verify download button appears
- [ ] Click download button and verify file downloads correctly
- [ ] Select a `.docx` or `.xlsx` file and verify download UI appears
- [ ] Verify supported file types (`.md`, `.txt`, `.json`, `.csv`, `.pdf`, images, videos) still show their dedicated viewers
- [ ] Run `./git-hooks/pre-commit.sh` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)