### PR TITLE
fix: prevent span wrappers on plain text in list items with links

### DIFF
--- a/frontend/src/components/MarkdownViewer.tsx
+++ b/frontend/src/components/MarkdownViewer.tsx
@@ -100,11 +100,13 @@ function processChildren(
     const processed: ReactNode[] = children.map((child, i): ReactNode => {
       if (typeof child === "string") {
         const parsed = parseWikiLinks(child, onLinkClick);
-        return parsed.length === 1 ? (
-          <span key={i}>{parsed[0]}</span>
-        ) : (
-          <span key={i}>{parsed}</span>
-        );
+        // If no wiki-links found (single string element), return string directly
+        // to avoid unnecessary span wrappers that can break list item layouts
+        if (parsed.length === 1 && typeof parsed[0] === "string") {
+          return parsed[0];
+        }
+        // Wiki-links found - wrap in span for proper keying of mixed content
+        return <span key={i}>{parsed}</span>;
       }
       return child as ReactNode;
     });

--- a/frontend/src/components/__tests__/MarkdownViewer.test.tsx
+++ b/frontend/src/components/__tests__/MarkdownViewer.test.tsx
@@ -175,6 +175,24 @@ describe("MarkdownViewer", () => {
       expect(screen.getByText("Item 3")).toBeDefined();
     });
 
+    it("renders list items with markdown links without extra span wrappers", () => {
+      const content = "- [08:25] Check [this link](https://example.com) for details";
+      const { container } = render(<MarkdownViewer />, {
+        wrapper: createTestWrapper({
+          currentPath: "test.md",
+          currentFileContent: content,
+        }),
+      });
+
+      const li = container.querySelector("li");
+      expect(li).toBeDefined();
+      // The li should contain text nodes and an anchor, not spans wrapping plain text
+      // Text before the link should be a text node, not wrapped in span
+      const spans = li?.querySelectorAll("span");
+      // Should have no spans (plain text is not wrapped)
+      expect(spans?.length ?? 0).toBe(0);
+    });
+
     it("renders code blocks", () => {
       const content = "```\nconst x = 1;\n```";
       render(<MarkdownViewer />, {


### PR DESCRIPTION
## Summary

- Fix list item rendering issue where plain text was incorrectly wrapped in `<span>` elements
- When list items contained markdown links, `processChildren` wrapped every string in a span for React keying, even when no wiki-links were found
- This caused layout issues where list content appeared on separate lines

## Test plan

- [x] Added unit test verifying list items with markdown links don't have extra span wrappers
- [x] All existing MarkdownViewer tests pass (62 tests)
- [x] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.ai/code)