### PR TITLE
fix: apply holiday theming to portaled dialogs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -105,6 +105,18 @@ function AppShell(): React.ReactNode {
   const [isReady, setIsReady] = useState(false);
   const holiday = useHoliday();
 
+  // Set holiday attribute on <html> so it covers portaled dialogs
+  React.useEffect(() => {
+    if (holiday) {
+      document.documentElement.setAttribute("data-holiday", holiday);
+    } else {
+      document.documentElement.removeAttribute("data-holiday");
+    }
+    return () => {
+      document.documentElement.removeAttribute("data-holiday");
+    };
+  }, [holiday]);
+
   // Reset isReady when vault is cleared
   React.useEffect(() => {
     if (!vault) {
@@ -115,14 +127,14 @@ function AppShell(): React.ReactNode {
   // Show vault selection until a vault is selected and session is ready
   if (!vault || !isReady) {
     return (
-      <div className="app" data-holiday={holiday ?? undefined}>
+      <div className="app">
         <VaultSelect onReady={() => setIsReady(true)} />
       </div>
     );
   }
 
   return (
-    <div className="app" data-holiday={holiday ?? undefined}>
+    <div className="app">
       <MainContent />
     </div>
   );


### PR DESCRIPTION
## Summary

- Move `data-holiday` attribute from `.app` div to `<html>` element via `useEffect`
- Ensures `ConfirmDialog` and other portaled components inherit holiday CSS variables
- Fixes confirmation dialogs (vault change, file delete) not showing holiday colors

## Test plan

- [ ] During a holiday period, open the app and trigger a confirmation dialog (e.g., click vault name to change vaults)
- [ ] Verify the dialog has the holiday color theme applied
- [ ] Verify the dialog backdrop and buttons match the holiday palette

🤖 Generated with [Claude Code](https://claude.ai/code)