### PR TITLE
feat: display context window usage percentage in assistant messages

### DIFF
--- a/frontend/src/components/MessageBubble.css
+++ b/frontend/src/components/MessageBubble.css
@@ -204,8 +204,10 @@
   }
 }
 
-.message-bubble__time {
-  display: block;
+.message-bubble__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font-size: var(--font-size-xs);
   color: inherit;
   opacity: 0.6;
@@ -213,14 +215,22 @@
   font-variant-numeric: tabular-nums;
 }
 
-.message-bubble--user .message-bubble__time {
-  text-align: right;
+.message-bubble__time {
+  /* Time inherits font-size and color from __meta */
+}
+
+.message-bubble--user .message-bubble__meta {
+  justify-content: flex-end;
   text-transform: uppercase;
 }
 
-.message-bubble--assistant .message-bubble__time {
-  text-align: left;
+.message-bubble--assistant .message-bubble__meta {
   text-transform: lowercase;
+}
+
+.message-bubble__context-usage {
+  opacity: 0.8;
+  font-weight: 500;
 }
 
 /* Mobile adjustments for blur performance */

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -132,9 +132,16 @@ export function MessageBubble({ message, vaultId }: MessageBubbleProps): React.R
             />
           )}
         </div>
-        <span className="message-bubble__time">
-          {formatTime(message.timestamp)}
-        </span>
+        <div className="message-bubble__meta">
+          <span className="message-bubble__time">
+            {formatTime(message.timestamp)}
+          </span>
+          {message.role === "assistant" && message.contextUsage !== undefined && (
+            <span className="message-bubble__context-usage">
+              {message.contextUsage}%
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -127,4 +127,74 @@ describe("MessageBubble", () => {
       expect(container.textContent).toContain("Paragraph text");
     });
   });
+
+  describe("context usage display", () => {
+    it("displays context usage percentage for assistant messages", () => {
+      const message = createMessage({
+        role: "assistant",
+        content: "Response content",
+        contextUsage: 42,
+      });
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      const contextUsage = container.querySelector(".message-bubble__context-usage");
+      expect(contextUsage).not.toBeNull();
+      expect(contextUsage?.textContent).toBe("42%");
+    });
+
+    it("does not display context usage when undefined", () => {
+      const message = createMessage({
+        role: "assistant",
+        content: "Response content",
+        contextUsage: undefined,
+      });
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      const contextUsage = container.querySelector(".message-bubble__context-usage");
+      expect(contextUsage).toBeNull();
+    });
+
+    it("does not display context usage for user messages", () => {
+      const message = createMessage({
+        role: "user",
+        content: "User message",
+        contextUsage: 50,
+      });
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      const contextUsage = container.querySelector(".message-bubble__context-usage");
+      expect(contextUsage).toBeNull();
+    });
+
+    it("displays 0% when context usage is 0", () => {
+      const message = createMessage({
+        role: "assistant",
+        content: "Response content",
+        contextUsage: 0,
+      });
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      const contextUsage = container.querySelector(".message-bubble__context-usage");
+      expect(contextUsage).not.toBeNull();
+      expect(contextUsage?.textContent).toBe("0%");
+    });
+
+    it("displays 100% when context usage is at maximum", () => {
+      const message = createMessage({
+        role: "assistant",
+        content: "Response content",
+        contextUsage: 100,
+      });
+
+      const { container } = render(<MessageBubble message={message} />);
+
+      const contextUsage = container.querySelector(".message-bubble__context-usage");
+      expect(contextUsage).not.toBeNull();
+      expect(contextUsage?.textContent).toBe("100%");
+    });
+  });
 });

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -109,6 +109,8 @@ export interface ConversationMessage {
   isStreaming?: boolean;
   /** Tool invocations for this message (assistant messages only) */
   toolInvocations?: ToolInvocation[];
+  /** Percentage of context window used (0-100, assistant messages only) */
+  contextUsage?: number;
 }
 
 /**

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -172,6 +172,7 @@ export const ConversationMessageSchema = z.object({
   content: z.string(),
   timestamp: z.string().min(1, "Timestamp is required"),
   toolInvocations: z.array(ToolInvocationSchema).optional(),
+  contextUsage: z.number().min(0).max(100).optional(),
 });
 
 // =============================================================================

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -94,6 +94,7 @@ export interface StoredToolInvocation {
  * @property content - Message text content
  * @property timestamp - ISO 8601 timestamp
  * @property toolInvocations - Tool invocations for assistant messages (optional)
+ * @property contextUsage - Percentage of context window used (0-100, assistant messages only)
  */
 export interface ConversationMessage {
   id: string;
@@ -101,6 +102,7 @@ export interface ConversationMessage {
   content: string;
   timestamp: string;
   toolInvocations?: StoredToolInvocation[];
+  contextUsage?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extract token usage (input, output, cache read, cache creation) from SDK result events
- Calculate percentage against model's context window and store in session JSON
- Display usage percentage alongside timestamp in assistant message bubbles
- Handle missing contextUsage gracefully for existing sessions

Closes #227

## Test plan
- [x] All existing tests pass
- [x] New MessageBubble tests cover context usage display scenarios
- [x] Type checking passes across all workspaces
- [ ] Manual test: send messages and verify percentage displays correctly
- [ ] Manual test: resume session and verify historical messages show percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)