### PR TITLE
fix: update holiday background selectors for root-level attribute

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -34,32 +34,32 @@
   z-index: 0;
 }
 
-/* Holiday-specific backgrounds */
-.app[data-holiday="christmas"]::before {
+/* Holiday-specific backgrounds (data-holiday is on <html> for portal support) */
+[data-holiday="christmas"] .app::before {
   background-image: url('/images/holiday/christmas-bg-vault.webp');
 }
 
-.app[data-holiday="valentine"]::before {
+[data-holiday="valentine"] .app::before {
   background-image: url('/images/holiday/valentine-bg-vault.webp');
 }
 
-.app[data-holiday="stpatricks"]::before {
+[data-holiday="stpatricks"] .app::before {
   background-image: url('/images/holiday/stpatricks-bg-vault.webp');
 }
 
-.app[data-holiday="easter"]::before {
+[data-holiday="easter"] .app::before {
   background-image: url('/images/holiday/easter-bg-vault.webp');
 }
 
-.app[data-holiday="summer"]::before {
+[data-holiday="summer"] .app::before {
   background-image: url('/images/holiday/summer-bg-vault.webp');
 }
 
-.app[data-holiday="halloween"]::before {
+[data-holiday="halloween"] .app::before {
   background-image: url('/images/holiday/halloween-bg-vault.webp');
 }
 
-.app[data-holiday="thanksgiving"]::before {
+[data-holiday="thanksgiving"] .app::before {
   background-image: url('/images/holiday/thanksgiving-bg-vault.webp');
 }
 


### PR DESCRIPTION
## Summary
- Updates CSS selectors for holiday background images to work with `data-holiday` attribute on `<html>` instead of `.app`
- Fixes regression from #225 where moving the holiday attribute to root broke background images
- Changes selectors from `.app[data-holiday]::before` to `[data-holiday] .app::before`

## Test plan
- [ ] Verify holiday backgrounds display correctly when a holiday theme is active
- [ ] Confirm portaled dialogs still receive holiday color theming

🤖 Generated with [Claude Code](https://claude.com/claude-code)