### PR TITLE
fix: use SDK system/init event for reliable context usage calculation

### DIFF
--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -117,6 +117,7 @@ export interface ConversationMessage {
  * @property createdAt - ISO 8601 timestamp of session creation
  * @property lastActiveAt - ISO 8601 timestamp of last activity
  * @property messages - Conversation history for this session
+ * @property activeModel - Model identifier captured from SDK (optional)
  */
 export interface SessionMetadata {
   id: string;
@@ -125,6 +126,7 @@ export interface SessionMetadata {
   createdAt: string;
   lastActiveAt: string;
   messages: ConversationMessage[];
+  activeModel?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Captures the authoritative model name from the SDK's `system/init` event at the start of streaming
- Stores it in `ConnectionState.activeModel` for use during context usage calculation
- Uses the stored model name to look up the correct `contextWindow` in `modelUsage` instead of guessing with `Object.keys()[0]`
- Falls back to previous behavior if the model wasn't captured

## Problem
The context usage calculation was using `Object.keys(modelUsage)[0]` to guess which model was used. This was unreliable because object key order isn't guaranteed to match the active model, especially when multiple models are tracked (e.g., from subagents), resulting in inconsistent contextUsage values.

## Test plan
- [x] TypeScript type checking passes
- [x] ESLint linting passes
- [x] All unit tests pass (backend, frontend, shared)
- [ ] Manual test: Start a new session and verify contextUsage values are consistent
- [ ] Manual test: Check backend logs show "Active model: ..." message

🤖 Generated with [Claude Code](https://claude.com/claude-code)