### PR TITLE
fix: upgrade zod to v4 and claude-agent-sdk to 0.2.4

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "hono": "^4.6.0",
-    "@anthropic-ai/claude-agent-sdk": "^0.1.69",
-    "zod": "^3.24.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.4",
+    "zod": "^4.0.0",
     "@memory-loop/shared": "workspace:*",
     "minisearch": "^7.1.1"
   },

--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -388,8 +388,8 @@ export class WebSocketHandler {
     const result = safeParseClientMessage(json);
     if (!result.success) {
       const errorMessage =
-        result.error.errors[0]?.message ?? "Invalid message format";
-      log.warn("Message validation failed", { json, errors: result.error.errors });
+        result.error.issues[0]?.message ?? "Invalid message format";
+      log.warn("Message validation failed", { json, errors: result.error.issues });
       this.sendError(ws, "VALIDATION_ERROR", errorMessage);
       return;
     }

--- a/shared/package.json
+++ b/shared/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "zod": "^3.24.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "^5.7.2",


### PR DESCRIPTION
## Summary
- Upgrade `zod` from ^3.24.0 to ^4.0.0 (shared + backend)
- Upgrade `@anthropic-ai/claude-agent-sdk` from ^0.1.69 to ^0.2.4
- Fix ZodError property access: `.errors` → `.issues` per Zod 4 breaking change

## Test plan
- [x] All unit tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.ai/code)