### PR TITLE
refactor: simplify GoalsCard to render raw markdown

### DIFF
--- a/backend/src/handlers/home-handlers.ts
+++ b/backend/src/handlers/home-handlers.ts
@@ -127,11 +127,11 @@ export async function handleGetGoals(ctx: HandlerContext): Promise<void> {
   }
 
   try {
-    const sections = await getVaultGoals(ctx.state.currentVault);
-    log.info(`Found ${sections?.length ?? 0} goal sections`);
+    const content = await getVaultGoals(ctx.state.currentVault);
+    log.info(`Goals content: ${content ? `${content.length} chars` : "null"}`);
     ctx.send({
       type: "goals",
-      sections,
+      content,
     });
   } catch (error) {
     log.error("Failed to get goals", error);

--- a/frontend/src/components/GoalsCard.css
+++ b/frontend/src/components/GoalsCard.css
@@ -1,7 +1,7 @@
 /**
  * GoalsCard Component Styles
  *
- * Displays goals with glassmorphism styling consistent with HomeView.
+ * Displays goals markdown with glassmorphism styling consistent with HomeView.
  */
 
 .goals-card::before {
@@ -55,15 +55,20 @@
   }
 }
 
-.goals-card__section {
-  margin-bottom: var(--spacing-md);
+/* Markdown content container */
+.goals-card__content {
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  line-height: var(--line-height-normal);
 }
 
-.goals-card__section:last-child {
-  margin-bottom: 0;
-}
-
-.goals-card__heading {
+/* Markdown headings */
+.goals-card__content h1,
+.goals-card__content h2,
+.goals-card__content h3,
+.goals-card__content h4,
+.goals-card__content h5,
+.goals-card__content h6 {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-bold);
   color: var(--color-text-accent-secondary);
@@ -72,41 +77,74 @@
   margin: 0 0 var(--spacing-sm) 0;
 }
 
-.goals-card__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xs);
+.goals-card__content h1:not(:first-child),
+.goals-card__content h2:not(:first-child),
+.goals-card__content h3:not(:first-child),
+.goals-card__content h4:not(:first-child),
+.goals-card__content h5:not(:first-child),
+.goals-card__content h6:not(:first-child) {
+  margin-top: var(--spacing-md);
 }
 
-.goals-card__item {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--spacing-sm);
-  font-size: var(--text-sm);
+/* Markdown paragraphs */
+.goals-card__content p {
+  margin: 0 0 var(--spacing-sm) 0;
+}
+
+.goals-card__content p:last-child {
+  margin-bottom: 0;
+}
+
+/* Markdown lists */
+.goals-card__content ul,
+.goals-card__content ol {
+  margin: 0 0 var(--spacing-sm) 0;
+  padding-left: var(--spacing-lg);
+}
+
+.goals-card__content ul:last-child,
+.goals-card__content ol:last-child {
+  margin-bottom: 0;
+}
+
+.goals-card__content li {
+  margin-bottom: var(--spacing-xs);
+}
+
+.goals-card__content li:last-child {
+  margin-bottom: 0;
+}
+
+/* Task list checkboxes (GFM) */
+.goals-card__content input[type="checkbox"] {
+  margin-right: var(--spacing-xs);
+  pointer-events: none;
+}
+
+/* Strong and emphasis */
+.goals-card__content strong {
+  font-weight: var(--font-weight-bold);
   color: var(--color-text);
-  line-height: var(--line-height-normal);
 }
 
-.goals-card__bullet {
-  flex-shrink: 0;
-  font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  line-height: var(--line-height-normal);
-}
-
-.goals-card__text {
-  flex: 1;
-}
-
-.goals-card__item--more {
-  color: var(--color-text-muted);
-}
-
-.goals-card__text--more {
+.goals-card__content em {
   font-style: italic;
+}
+
+/* Links (non-interactive in button context) */
+.goals-card__content a {
+  color: var(--color-accent-secondary);
+  text-decoration: none;
+  pointer-events: none;
+}
+
+/* Code */
+.goals-card__content code {
+  font-family: var(--font-family-mono);
+  font-size: 0.9em;
+  background: var(--color-surface-elevated);
+  padding: 0.1em 0.3em;
+  border-radius: var(--radius-sm);
 }
 
 /* Mobile adjustments for blur performance */

--- a/frontend/src/components/GoalsCard.tsx
+++ b/frontend/src/components/GoalsCard.tsx
@@ -1,21 +1,21 @@
 /**
  * GoalsCard Component
  *
- * Displays goals from the vault's goals.md file.
- * Shows sections with headers and items parsed from markdown.
+ * Displays goals from the vault's goals.md file as rendered markdown.
  * Clickable to trigger /review-goals command.
  */
 
-import React, { useCallback } from "react";
+import { useCallback } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { useSession } from "../contexts/SessionContext";
 import "./GoalsCard.css";
 
 /**
- * GoalsCard displays goals from goals.md organized by sections.
+ * GoalsCard displays goals.md content as rendered markdown.
  *
- * - Shows goals from the vault's 06_Metadata/memory-loop/goals.md file
- * - Displays sections with their markdown headers as titles
- * - Shows "..." if a section has more than 9 items
+ * - Shows full markdown content from the vault's goals.md file
+ * - Supports all markdown formatting (headers, lists, bold, etc.)
  * - Returns null if no goals file exists in the vault
  * - Clicking the card triggers /review-goals command
  */
@@ -27,13 +27,8 @@ export function GoalsCard(): React.ReactNode {
     setMode("discussion");
   }, [setDiscussionPrefill, setMode]);
 
-  // Don't render if no goals data (either no goals file or not yet loaded)
-  if (goals === null) {
-    return null;
-  }
-
-  // Don't render if there are no sections
-  if (goals.length === 0) {
+  // Don't render if no goals content
+  if (!goals) {
     return null;
   }
 
@@ -44,35 +39,9 @@ export function GoalsCard(): React.ReactNode {
       onClick={handleClick}
       aria-label="Review goals"
     >
-      {goals.map((section, sectionIndex) => (
-        <div key={sectionIndex} className="goals-card__section">
-          <h3 className="goals-card__heading">{section.title}</h3>
-          <ul className="goals-card__list" role="list">
-            {section.items.map((item, itemIndex) => (
-              <li
-                key={itemIndex}
-                className="goals-card__item"
-                aria-label={item}
-              >
-                <span className="goals-card__bullet" aria-hidden="true">
-                  •
-                </span>
-                <span className="goals-card__text">{item}</span>
-              </li>
-            ))}
-            {section.hasMore && (
-              <li className="goals-card__item goals-card__item--more">
-                <span className="goals-card__bullet" aria-hidden="true">
-                  &nbsp;
-                </span>
-                <span className="goals-card__text goals-card__text--more">
-                  ...
-                </span>
-              </li>
-            )}
-          </ul>
-        </div>
-      ))}
+      <div className="goals-card__content">
+        <Markdown remarkPlugins={[remarkGfm]}>{goals}</Markdown>
+      </div>
     </button>
   );
 }

--- a/frontend/src/components/HomeView.tsx
+++ b/frontend/src/components/HomeView.tsx
@@ -176,7 +176,7 @@ export function HomeView(): React.ReactNode {
           break;
 
         case "goals":
-          setGoals(message.sections);
+          setGoals(message.content);
           break;
 
         case "inspiration":

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -21,7 +21,6 @@ import type {
   RecentNoteEntry,
   RecentDiscussionEntry,
   ConversationMessageProtocol,
-  GoalSection,
   TaskEntry,
   SlashCommand,
   FileSearchResult,
@@ -82,8 +81,8 @@ export interface SessionProviderProps {
   initialRecentNotes?: RecentNoteEntry[];
   /** Optional initial recent discussions (for testing) */
   initialRecentDiscussions?: RecentDiscussionEntry[];
-  /** Optional initial goals (for testing) */
-  initialGoals?: GoalSection[] | null;
+  /** Optional initial goals markdown content (for testing) */
+  initialGoals?: string | null;
   /** Optional initial session ID (for testing) */
   initialSessionId?: string | null;
   /** Optional initial health issues (for testing) */
@@ -292,7 +291,7 @@ export function SessionProvider({
     dispatch({ type: "REMOVE_DISCUSSION", sessionId });
   }, []);
 
-  const setGoals = useCallback((goals: GoalSection[] | null) => {
+  const setGoals = useCallback((goals: string | null) => {
     dispatch({ type: "SET_GOALS", goals });
   }, []);
 

--- a/frontend/src/contexts/session/reducer.ts
+++ b/frontend/src/contexts/session/reducer.ts
@@ -8,7 +8,6 @@ import type {
   FileEntry,
   RecentNoteEntry,
   RecentDiscussionEntry,
-  GoalSection,
   TaskEntry,
   SlashCommand,
   FileSearchResult,
@@ -66,7 +65,7 @@ export type SessionAction =
   | { type: "PIN_FOLDER"; path: string }
   | { type: "UNPIN_FOLDER"; path: string }
   | { type: "SET_PINNED_FOLDERS"; paths: string[] }
-  | { type: "SET_GOALS"; goals: GoalSection[] | null }
+  | { type: "SET_GOALS"; goals: string | null }
   | { type: "SET_DISCUSSION_PREFILL"; text: string | null }
   | { type: "SET_PENDING_SESSION_ID"; sessionId: string | null }
   | { type: "SET_SHOW_NEW_SESSION_DIALOG"; show: boolean }

--- a/frontend/src/contexts/session/types.ts
+++ b/frontend/src/contexts/session/types.ts
@@ -8,7 +8,6 @@ import type {
   FileEntry,
   RecentNoteEntry,
   RecentDiscussionEntry,
-  GoalSection,
   TaskEntry,
   ToolInvocation,
   SlashCommand,
@@ -183,8 +182,8 @@ export interface SessionState {
   recentNotes: RecentNoteEntry[];
   /** Recent discussion sessions for note mode */
   recentDiscussions: RecentDiscussionEntry[];
-  /** Goals from vault's goals.md file (null if no goals file exists) */
-  goals: GoalSection[] | null;
+  /** Goals markdown content from vault's goals.md file (null if no goals file exists) */
+  goals: string | null;
   /** Pre-filled text for discussion mode (from inspiration click) */
   discussionPrefill: string | null;
   /** Session ID pending resume (set by RecentActivity, consumed by Discussion) */
@@ -251,8 +250,8 @@ export interface SessionActions {
   setRecentDiscussions: (discussions: RecentDiscussionEntry[]) => void;
   /** Remove a discussion from the recent list (after deletion) */
   removeDiscussion: (sessionId: string) => void;
-  /** Set goals from vault's goals.md file */
-  setGoals: (goals: GoalSection[] | null) => void;
+  /** Set goals markdown content from vault's goals.md file */
+  setGoals: (goals: string | null) => void;
   /** Set discussion prefill text (from inspiration click) */
   setDiscussionPrefill: (text: string | null) => void;
   /** Set pending session ID for resume (called by RecentActivity) */

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -27,8 +27,6 @@ export {
   RecentDiscussionEntrySchema,
   // Tool invocation schema
   ToolInvocationSchema,
-  // Goals schemas
-  GoalSectionSchema,
   // Inspiration schemas
   InspirationItemSchema,
   GetInspirationMessageSchema,
@@ -106,8 +104,6 @@ export type {
   RecentDiscussionEntry,
   // Tool invocation type
   ToolInvocation,
-  // Goal types
-  GoalSection,
   // Inspiration types
   InspirationItem,
   GetInspirationMessage,

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -742,22 +742,12 @@ export const RecentActivityMessageSchema = z.object({
 });
 
 /**
- * Schema for a section of goals parsed from goals.md
- * Sections are created from markdown headers at any level
- */
-export const GoalSectionSchema = z.object({
-  title: z.string(),
-  items: z.array(z.string()),
-  hasMore: z.boolean(),
-});
-
-/**
  * Server sends goals from the vault's goals.md file
- * Returns null for sections if the file doesn't exist
+ * Returns null for content if the file doesn't exist
  */
 export const GoalsMessageSchema = z.object({
   type: z.literal("goals"),
-  sections: z.array(GoalSectionSchema).nullable(),
+  content: z.string().nullable(),
 });
 
 /**
@@ -1128,7 +1118,6 @@ export type DirectoryListingMessage = z.infer<typeof DirectoryListingMessageSche
 export type FileContentMessage = z.infer<typeof FileContentMessageSchema>;
 export type RecentNotesMessage = z.infer<typeof RecentNotesMessageSchema>;
 export type RecentActivityMessage = z.infer<typeof RecentActivityMessageSchema>;
-export type GoalSection = z.infer<typeof GoalSectionSchema>;
 export type GoalsMessage = z.infer<typeof GoalsMessageSchema>;
 export type InspirationItem = z.infer<typeof InspirationItemSchema>;
 export type InspirationMessage = z.infer<typeof InspirationMessageSchema>;


### PR DESCRIPTION
## Summary

- Replace overengineered goals parsing with direct markdown rendering
- Backend sends raw `goals.md` content instead of parsed `GoalSection[]`
- Frontend uses `react-markdown` to display full markdown formatting
- Net reduction of ~280 lines of code

## Test plan

- [x] `bun run typecheck` passes
- [x] `./git-hooks/pre-commit.sh` passes (all tests green)
- [ ] Manual test: verify goals display renders markdown correctly (headers, lists, checkboxes, bold)
- [ ] Manual test: clicking goals card still triggers `/review-goals` discussion

🤖 Generated with [Claude Code](https://claude.ai/code)