### PR TITLE
feat: persist pinned assets in vault config instead of localStorage

### DIFF
--- a/frontend/src/contexts/session/types.ts
+++ b/frontend/src/contexts/session/types.ts
@@ -246,6 +246,8 @@ export interface SessionActions {
   pinFolder: (path: string) => void;
   /** Unpin a folder */
   unpinFolder: (path: string) => void;
+  /** Set all pinned assets (from server response) */
+  setPinnedAssets: (paths: string[]) => void;
   /** Set recent discussions */
   setRecentDiscussions: (discussions: RecentDiscussionEntry[]) => void;
   /** Remove a discussion from the recent list (after deletion) */

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -570,6 +570,24 @@ export const DismissHealthIssueMessageSchema = z.object({
 });
 
 /**
+ * Client requests pinned assets for current vault
+ * Returns paths stored in .memory-loop.json
+ */
+export const GetPinnedAssetsMessageSchema = z.object({
+  type: z.literal("get_pinned_assets"),
+});
+
+/**
+ * Client updates pinned assets for current vault
+ * Saves paths to .memory-loop.json
+ */
+export const SetPinnedAssetsMessageSchema = z.object({
+  type: z.literal("set_pinned_assets"),
+  /** Array of paths (relative to content root) to pin */
+  paths: z.array(z.string()),
+});
+
+/**
  * Discriminated union of all client message types
  */
 export const ClientMessageSchema = z.discriminatedUnion("type", [
@@ -600,6 +618,8 @@ export const ClientMessageSchema = z.discriminatedUnion("type", [
   GetRecallWidgetsMessageSchema,
   WidgetEditMessageSchema,
   DismissHealthIssueMessageSchema,
+  GetPinnedAssetsMessageSchema,
+  SetPinnedAssetsMessageSchema,
 ]);
 
 // =============================================================================
@@ -990,6 +1010,16 @@ export const HealthReportMessageSchema = z.object({
 });
 
 /**
+ * Server sends pinned assets for the current vault.
+ * Response to get_pinned_assets or set_pinned_assets request.
+ */
+export const PinnedAssetsMessageSchema = z.object({
+  type: z.literal("pinned_assets"),
+  /** Array of pinned asset paths (relative to content root) */
+  paths: z.array(z.string()),
+});
+
+/**
  * Discriminated union of all server message types
  */
 export const ServerMessageSchema = z.discriminatedUnion("type", [
@@ -1025,6 +1055,7 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
   WidgetUpdateMessageSchema,
   WidgetErrorMessageSchema,
   HealthReportMessageSchema,
+  PinnedAssetsMessageSchema,
 ]);
 
 // =============================================================================
@@ -1100,6 +1131,8 @@ export type GetGroundWidgetsMessage = z.infer<typeof GetGroundWidgetsMessageSche
 export type GetRecallWidgetsMessage = z.infer<typeof GetRecallWidgetsMessageSchema>;
 export type WidgetEditMessage = z.infer<typeof WidgetEditMessageSchema>;
 export type DismissHealthIssueMessage = z.infer<typeof DismissHealthIssueMessageSchema>;
+export type GetPinnedAssetsMessage = z.infer<typeof GetPinnedAssetsMessageSchema>;
+export type SetPinnedAssetsMessage = z.infer<typeof SetPinnedAssetsMessageSchema>;
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;
 
 // Server message types
@@ -1135,6 +1168,7 @@ export type GroundWidgetsMessage = z.infer<typeof GroundWidgetsMessageSchema>;
 export type RecallWidgetsMessage = z.infer<typeof RecallWidgetsMessageSchema>;
 export type WidgetUpdateMessage = z.infer<typeof WidgetUpdateMessageSchema>;
 export type WidgetErrorMessage = z.infer<typeof WidgetErrorMessageSchema>;
+export type PinnedAssetsMessage = z.infer<typeof PinnedAssetsMessageSchema>;
 export type ServerMessage = z.infer<typeof ServerMessageSchema>;
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Pinned folders/files in the Recall tab are now stored in `.memory-loop.json` rather than browser localStorage
- Ensures pins persist across devices and browser changes
- Adds `get_pinned_assets`/`set_pinned_assets` WebSocket messages for syncing

## Test plan

- [ ] Pin a folder in the Recall tab
- [ ] Verify `.memory-loop.json` contains `pinnedAssets` array with the pinned path
- [ ] Refresh the page and confirm pins are restored
- [ ] Unpin a folder and verify it's removed from the config file
- [ ] Test on a different browser/device to confirm pins sync

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)