### PR TITLE
feat: configurable recent activity limits and per-vault session storage

### DIFF
--- a/backend/src/__tests__/vault-setup.test.ts
+++ b/backend/src/__tests__/vault-setup.test.ts
@@ -28,7 +28,7 @@ import {
   SETUP_MARKER_PATH,
   COMMANDS_DEST_PATH,
   CLAUDEMD_BACKUP_PATH,
-  SQLITE_IGNORE_PATTERNS,
+  MEMORY_LOOP_IGNORE_PATTERNS,
   MEMORY_LOOP_GITIGNORE_PATH,
   type SetupCompleteMarker,
   type QueryFunction,
@@ -679,17 +679,17 @@ describe("updateGitignore", () => {
 
     const content = await readFile(join(vaultPath, MEMORY_LOOP_GITIGNORE_PATH), "utf-8");
 
-    for (const pattern of SQLITE_IGNORE_PATTERNS) {
+    for (const pattern of MEMORY_LOOP_IGNORE_PATTERNS) {
       expect(content).toContain(pattern);
     }
   });
 
-  test("includes SQLite cache section header", async () => {
+  test("includes Memory Loop section header", async () => {
     await updateGitignore(vaultPath);
 
     const content = await readFile(join(vaultPath, MEMORY_LOOP_GITIGNORE_PATH), "utf-8");
 
-    expect(content).toContain("# SQLite cache");
+    expect(content).toContain("# Memory Loop cache and session files");
   });
 
   test("adds patterns to existing .gitignore", async () => {
@@ -709,17 +709,18 @@ describe("updateGitignore", () => {
     expect(content).toContain("*.tmp");
 
     // New patterns added
-    for (const pattern of SQLITE_IGNORE_PATTERNS) {
+    for (const pattern of MEMORY_LOOP_IGNORE_PATTERNS) {
       expect(content).toContain(pattern);
     }
   });
 
   test("does not duplicate patterns if already present", async () => {
     await mkdir(join(vaultPath, ".memory-loop"), { recursive: true });
-    const existingContent = `# SQLite cache files
+    const existingContent = `# Memory Loop cache and session files
 cache.db
 cache.db-shm
 cache.db-wal
+sessions/
 `;
     await writeFile(join(vaultPath, MEMORY_LOOP_GITIGNORE_PATH), existingContent);
 
@@ -745,7 +746,7 @@ cache.db
     const result = await updateGitignore(vaultPath);
 
     expect(result.success).toBe(true);
-    expect(result.message).toContain("2 pattern(s)");
+    expect(result.message).toContain("3 pattern(s)");
 
     const content = await readFile(join(vaultPath, MEMORY_LOOP_GITIGNORE_PATH), "utf-8");
 
@@ -753,9 +754,10 @@ cache.db
     const cacheDbMatches = content.match(/^cache\.db$/gm);
     expect(cacheDbMatches?.length).toBe(1);
 
-    // Should have the other two patterns
+    // Should have the other patterns
     expect(content).toContain("cache.db-shm");
     expect(content).toContain("cache.db-wal");
+    expect(content).toContain("sessions/");
   });
 
   test("handles .gitignore without trailing newline", async () => {
@@ -786,10 +788,11 @@ cache.db.backup
     const result = await updateGitignore(vaultPath);
 
     expect(result.success).toBe(true);
-    expect(result.message).toContain("3 pattern(s)");
+    expect(result.message).toContain("4 pattern(s)");
 
     const content = await readFile(join(vaultPath, MEMORY_LOOP_GITIGNORE_PATH), "utf-8");
     expect(content).toContain("cache.db\n");
+    expect(content).toContain("sessions/");
   });
 });
 

--- a/backend/src/handlers/home-handlers.ts
+++ b/backend/src/handlers/home-handlers.ts
@@ -18,7 +18,11 @@ import { getVaultGoals } from "../vault-manager.js";
 import { getInspiration } from "../inspiration-manager.js";
 import { getAllTasks, toggleTask } from "../task-manager.js";
 import { getRecentSessions } from "../session-manager.js";
-import { loadVaultConfig } from "../vault-config.js";
+import {
+  loadVaultConfig,
+  resolveRecentCaptures,
+  resolveRecentDiscussions,
+} from "../vault-config.js";
 import { FileBrowserError } from "../file-browser.js";
 import { wsLog as log } from "../logger.js";
 
@@ -97,9 +101,13 @@ export async function handleGetRecentActivity(ctx: HandlerContext): Promise<void
   }
 
   try {
+    const config = await loadVaultConfig(ctx.state.currentVault.path);
+    const capturesLimit = resolveRecentCaptures(config);
+    const discussionsLimit = resolveRecentDiscussions(config);
+
     const [captures, discussions] = await Promise.all([
-      getRecentNotes(ctx.state.currentVault, 5),
-      getRecentSessions(ctx.state.currentVault.id, 5),
+      getRecentNotes(ctx.state.currentVault, capturesLimit),
+      getRecentSessions(ctx.state.currentVault.path, discussionsLimit),
     ]);
     log.info(`Found ${captures.length} captures and ${discussions.length} discussions`);
     ctx.send({

--- a/backend/src/vault-config.ts
+++ b/backend/src/vault-config.ts
@@ -116,6 +116,18 @@ export interface VaultConfig {
    * Paths are relative to content root.
    */
   pinnedAssets?: string[];
+
+  /**
+   * Number of recent captures to display on the home screen.
+   * Default: 5
+   */
+  recentCaptures?: number;
+
+  /**
+   * Number of recent discussions to display on the home screen.
+   * Default: 5
+   */
+  recentDiscussions?: number;
 }
 
 /**
@@ -152,6 +164,16 @@ export const DEFAULT_MAX_POOL_SIZE = 50;
  * Default number of quotes to generate per week.
  */
 export const DEFAULT_QUOTES_PER_WEEK = 1;
+
+/**
+ * Default number of recent captures to display.
+ */
+export const DEFAULT_RECENT_CAPTURES = 5;
+
+/**
+ * Default number of recent discussions to display.
+ */
+export const DEFAULT_RECENT_DISCUSSIONS = 5;
 
 /**
  * Valid badge color names.
@@ -256,6 +278,14 @@ export async function loadVaultConfig(vaultPath: string): Promise<VaultConfig> {
 
     if (typeof obj.quotesPerWeek === "number" && obj.quotesPerWeek > 0) {
       config.quotesPerWeek = Math.floor(obj.quotesPerWeek);
+    }
+
+    if (typeof obj.recentCaptures === "number" && obj.recentCaptures > 0) {
+      config.recentCaptures = Math.floor(obj.recentCaptures);
+    }
+
+    if (typeof obj.recentDiscussions === "number" && obj.recentDiscussions > 0) {
+      config.recentDiscussions = Math.floor(obj.recentDiscussions);
     }
 
     // Validate badges array
@@ -438,6 +468,26 @@ export function resolveBadges(config: VaultConfig): Badge[] {
  */
 export function resolvePinnedAssets(config: VaultConfig): string[] {
   return config.pinnedAssets ?? [];
+}
+
+/**
+ * Resolves the number of recent captures to display.
+ *
+ * @param config - Vault configuration
+ * @returns Number of recent captures (default: 5)
+ */
+export function resolveRecentCaptures(config: VaultConfig): number {
+  return config.recentCaptures ?? DEFAULT_RECENT_CAPTURES;
+}
+
+/**
+ * Resolves the number of recent discussions to display.
+ *
+ * @param config - Vault configuration
+ * @returns Number of recent discussions (default: 5)
+ */
+export function resolveRecentDiscussions(config: VaultConfig): number {
+  return config.recentDiscussions ?? DEFAULT_RECENT_DISCUSSIONS;
 }
 
 /**

--- a/backend/src/vault-setup.ts
+++ b/backend/src/vault-setup.ts
@@ -128,10 +128,15 @@ export const DEFAULT_ARCHIVES_PATH = "04_Archive";
 export const CLAUDEMD_BACKUP_PATH = ".memory-loop/claude-md-backup.md";
 
 /**
- * SQLite cache files that should be gitignored.
- * These are placed in .memory-loop/ directory.
+ * Files and directories that should be gitignored within .memory-loop/.
+ * Includes SQLite cache files and session data.
  */
-export const SQLITE_IGNORE_PATTERNS = ["cache.db", "cache.db-shm", "cache.db-wal"];
+export const MEMORY_LOOP_IGNORE_PATTERNS = [
+  "cache.db",
+  "cache.db-shm",
+  "cache.db-wal",
+  "sessions/",
+];
 
 /**
  * Path to .gitignore for Memory Loop files (relative to vault root).
@@ -614,14 +619,14 @@ export async function updateGitignore(
   }
 
   // Check which patterns are missing
-  const missingPatterns = SQLITE_IGNORE_PATTERNS.filter((pattern) => {
+  const missingPatterns = MEMORY_LOOP_IGNORE_PATTERNS.filter((pattern) => {
     // Check if the pattern exists as a line (not as part of another pattern)
-    const regex = new RegExp(`^${pattern.replace(".", "\\.")}$`, "m");
+    const regex = new RegExp(`^${pattern.replace(".", "\\.").replace("/", "\\/")}$`, "m");
     return !regex.test(existingContent);
   });
 
   if (missingPatterns.length === 0) {
-    log.debug("All SQLite patterns already present in .memory-loop/.gitignore");
+    log.debug("All patterns already present in .memory-loop/.gitignore");
     return {
       success: true,
       message: ".memory-loop/.gitignore already up to date",
@@ -629,7 +634,7 @@ export async function updateGitignore(
   }
 
   // Build the gitignore content
-  const gitignoreSection = `# SQLite cache files
+  const gitignoreSection = `# Memory Loop cache and session files
 ${missingPatterns.join("\n")}
 `;
 


### PR DESCRIPTION
## Summary
- Add `recentCaptures` and `recentDiscussions` config options to `.memory-loop.json` (defaults to 5)
- Move session storage from global `~/.memory-loop/sessions/` to per-vault `{vault}/.memory-loop/sessions/`
- Add `sessions/` to `.memory-loop/.gitignore` during vault setup

## Breaking Change
Session resume now requires vault selection first, since sessions are stored per-vault rather than globally.

## Test plan
- [x] All backend unit tests pass (session-manager, vault-setup, websocket-handler)
- [x] All frontend unit tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [ ] Manual test: verify recent activity respects configured limits
- [ ] Manual test: verify sessions are stored in vault directory

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)