### PR TITLE
fix: constrain image width in message bubbles

### DIFF
--- a/frontend/src/components/MessageBubble.css
+++ b/frontend/src/components/MessageBubble.css
@@ -150,6 +150,12 @@
   text-underline-offset: 2px;
 }
 
+.message-bubble__text img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+}
+
 .message-bubble__text blockquote {
   margin: 0.5em 0;
   padding-left: 0.75em;


### PR DESCRIPTION
## Summary
- Images rendered via markdown in chat messages could overflow their container
- Added `max-width: 100%` to `.message-bubble__text img` to ensure images scale to fit the bubble
- Included `height: auto` to maintain aspect ratio and `border-radius` for consistent styling

## Test plan
- [ ] Send a message with an attached image wider than the message bubble
- [ ] Verify the image scales down to fit within the bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)