### PR TITLE
fix: resume session after vault selection for per-vault storage

### DIFF
--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -583,6 +583,10 @@ export function useServerMessageHandler(): (message: ServerMessage) => void {
         case "session_ready":
           if (message.sessionId) {
             setSessionId(message.sessionId);
+            // Only clear pendingSessionId when a session is actually established.
+            // Empty sessionId means vault was selected but no session yet (e.g., from select_vault).
+            // We need to preserve pendingSessionId so Discussion can send resume_session.
+            setPendingSessionId(null);
           }
           if (message.createdAt) {
             setSessionStartTime(new Date(message.createdAt));
@@ -591,7 +595,6 @@ export function useServerMessageHandler(): (message: ServerMessage) => void {
             setMessages(message.messages);
           }
           setSlashCommands(message.slashCommands ?? []);
-          setPendingSessionId(null);
           break;
 
         case "response_start": {


### PR DESCRIPTION
## Summary
- Fixes session resume failing with "Please select a vault first" error
- After f37c747 moved sessions to per-vault storage, the backend requires vault selection before resume
- Frontend now sends `select_vault` first, then `resume_session` after receiving acknowledgment

## Test plan
- [x] All existing tests pass (39 Discussion tests, 155 SessionContext tests, 22 RecentActivity tests)
- [x] Full pre-commit checks pass (typecheck, lint, unit tests)
- [ ] Manual test: Click "Resume" on a discussion from HomeView and verify it resumes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)