### PR TITLE
refactor: move slash command cache to .memory-loop/slash-commands.json

### DIFF
--- a/backend/src/__tests__/vault-setup.test.ts
+++ b/backend/src/__tests__/vault-setup.test.ts
@@ -721,6 +721,7 @@ cache.db
 cache.db-shm
 cache.db-wal
 sessions/
+slash-commands.json
 `;
     await writeFile(join(vaultPath, MEMORY_LOOP_GITIGNORE_PATH), existingContent);
 
@@ -746,7 +747,7 @@ cache.db
     const result = await updateGitignore(vaultPath);
 
     expect(result.success).toBe(true);
-    expect(result.message).toContain("3 pattern(s)");
+    expect(result.message).toContain("4 pattern(s)");
 
     const content = await readFile(join(vaultPath, MEMORY_LOOP_GITIGNORE_PATH), "utf-8");
 
@@ -758,6 +759,7 @@ cache.db
     expect(content).toContain("cache.db-shm");
     expect(content).toContain("cache.db-wal");
     expect(content).toContain("sessions/");
+    expect(content).toContain("slash-commands.json");
   });
 
   test("handles .gitignore without trailing newline", async () => {
@@ -788,11 +790,12 @@ cache.db.backup
     const result = await updateGitignore(vaultPath);
 
     expect(result.success).toBe(true);
-    expect(result.message).toContain("4 pattern(s)");
+    expect(result.message).toContain("5 pattern(s)");
 
     const content = await readFile(join(vaultPath, MEMORY_LOOP_GITIGNORE_PATH), "utf-8");
     expect(content).toContain("cache.db\n");
     expect(content).toContain("sessions/");
+    expect(content).toContain("slash-commands.json");
   });
 });
 

--- a/backend/src/__tests__/websocket-handler.test.ts
+++ b/backend/src/__tests__/websocket-handler.test.ts
@@ -223,8 +223,13 @@ const mockLoadVaultConfig = mock<
   (vaultPath: string) => Promise<Record<string, unknown>>
 >(() => Promise.resolve({}));
 
+const mockLoadSlashCommands = mock<
+  (vaultPath: string) => Promise<Array<{ name: string; description: string; argumentHint?: string }> | undefined>
+>(() => Promise.resolve(undefined));
+
 void mock.module("../vault-config", () => ({
   loadVaultConfig: mockLoadVaultConfig,
+  loadSlashCommands: mockLoadSlashCommands,
 }));
 
 // Mock vault setup
@@ -2257,9 +2262,7 @@ describe("WebSocket Handler", () => {
         { name: "/recall", description: "Search vault" },
         { name: "/tasks", description: "List tasks" },
       ];
-      mockLoadVaultConfig.mockResolvedValue({
-        slashCommands: cachedCommands,
-      });
+      mockLoadSlashCommands.mockResolvedValue(cachedCommands);
 
       mockCreateSession.mockResolvedValue({
         sessionId: "session-to-clear",

--- a/backend/src/vault-setup.ts
+++ b/backend/src/vault-setup.ts
@@ -129,13 +129,14 @@ export const CLAUDEMD_BACKUP_PATH = ".memory-loop/claude-md-backup.md";
 
 /**
  * Files and directories that should be gitignored within .memory-loop/.
- * Includes SQLite cache files and session data.
+ * Includes SQLite cache files, session data, and slash command cache.
  */
 export const MEMORY_LOOP_IGNORE_PATTERNS = [
   "cache.db",
   "cache.db-shm",
   "cache.db-wal",
   "sessions/",
+  "slash-commands.json",
 ];
 
 /**

--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -50,6 +50,7 @@ import { isMockMode, generateMockResponse, createMockSession } from "./mock-sdk.
 import { wsLog as log } from "./logger.js";
 import {
   loadVaultConfig,
+  loadSlashCommands,
   saveSlashCommands,
   slashCommandsEqual,
   savePinnedAssets,
@@ -228,8 +229,8 @@ export class WebSocketHandler {
       // Update cache if commands changed
       if (this.state.currentVault) {
         try {
-          const vaultConfig = await loadVaultConfig(this.state.currentVault.path);
-          if (!slashCommandsEqual(vaultConfig.slashCommands, commands)) {
+          const cachedCommands = await loadSlashCommands(this.state.currentVault.path);
+          if (!slashCommandsEqual(cachedCommands, commands)) {
             log.info("Slash commands changed, updating cache");
             await saveSlashCommands(this.state.currentVault.path, commands);
           }
@@ -623,8 +624,7 @@ export class WebSocketHandler {
         });
       }
 
-      const vaultConfig = await loadVaultConfig(vault.path);
-      const cachedCommands = vaultConfig.slashCommands;
+      const cachedCommands = await loadSlashCommands(vault.path);
 
       log.info("Sending session_ready");
       this.send(ws, {
@@ -827,8 +827,7 @@ export class WebSocketHandler {
       this.state.currentSessionId = sessionId;
       log.info(`Resuming session ${sessionId} with ${metadata.messages.length} messages`);
 
-      const vaultConfig = await loadVaultConfig(this.state.currentVault.path);
-      const cachedCommands = vaultConfig.slashCommands;
+      const cachedCommands = await loadSlashCommands(this.state.currentVault.path);
 
       this.send(ws, {
         type: "session_ready",
@@ -868,8 +867,7 @@ export class WebSocketHandler {
 
     this.state.currentSessionId = null;
 
-    const vaultConfig = await loadVaultConfig(this.state.currentVault.path);
-    const cachedCommands = vaultConfig.slashCommands;
+    const cachedCommands = await loadSlashCommands(this.state.currentVault.path);
 
     this.send(ws, {
       type: "session_ready",


### PR DESCRIPTION
## Summary
- Move cached slash commands from `.memory-loop.json` to `.memory-loop/slash-commands.json`
- Separates ephemeral cache data from user configuration
- Add `slash-commands.json` to `.memory-loop/.gitignore` patterns

## Test plan
- [x] All existing tests pass
- [x] Verified `loadSlashCommands()` returns undefined when file doesn't exist
- [x] Verified `saveSlashCommands()` creates directory and file
- [x] Verified websocket-handler correctly loads/saves to new location
- [x] Verified gitignore patterns include new file

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)