### PR TITLE
feat: group task list by Inbox, Projects, Areas categories

### DIFF
--- a/backend/src/__tests__/task-manager.test.ts
+++ b/backend/src/__tests__/task-manager.test.ts
@@ -410,20 +410,20 @@ describe("parseTasksFromFile", () => {
   });
 
   test("returns empty array for non-existent file", async () => {
-    const tasks = await parseTasksFromFile(testDir, "nonexistent.md");
+    const tasks = await parseTasksFromFile(testDir, "nonexistent.md", "inbox");
     expect(tasks).toEqual([]);
   });
 
   test("returns empty array for file with no tasks", async () => {
     await writeFile(join(testDir, "note.md"), "# Just a heading\n\nSome text");
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toEqual([]);
   });
 
   test("parses single task", async () => {
     await writeFile(join(testDir, "note.md"), "- [ ] Buy groceries");
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0]).toMatchObject({
       text: "Buy groceries",
@@ -443,7 +443,7 @@ describe("parseTasksFromFile", () => {
 `;
     await writeFile(join(testDir, "note.md"), content);
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(3);
     expect(tasks[0].text).toBe("Task one");
     expect(tasks[0].state).toBe(" ");
@@ -466,7 +466,7 @@ describe("parseTasksFromFile", () => {
 `;
     await writeFile(join(testDir, "note.md"), content);
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(6);
     expect(tasks.map((t) => t.state)).toEqual([" ", "x", "/", "?", "b", "f"]);
   });
@@ -478,7 +478,7 @@ describe("parseTasksFromFile", () => {
 `;
     await writeFile(join(testDir, "note.md"), content);
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(3);
     // All tasks should be found regardless of indentation
     expect(tasks[0].text).toBe("Root task");
@@ -495,7 +495,7 @@ Line 4
 `;
     await writeFile(join(testDir, "note.md"), content);
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(2);
     expect(tasks[0].lineNumber).toBe(3);
     expect(tasks[1].lineNumber).toBe(5);
@@ -505,7 +505,7 @@ Line 4
     await mkdir(join(testDir, "folder"));
     await writeFile(join(testDir, "folder", "note.md"), "- [ ] Task");
 
-    const tasks = await parseTasksFromFile(testDir, "folder/note.md");
+    const tasks = await parseTasksFromFile(testDir, "folder/note.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].filePath).toBe("folder/note.md");
   });
@@ -513,14 +513,14 @@ Line 4
   test("handles empty file", async () => {
     await writeFile(join(testDir, "empty.md"), "");
 
-    const tasks = await parseTasksFromFile(testDir, "empty.md");
+    const tasks = await parseTasksFromFile(testDir, "empty.md", "inbox");
     expect(tasks).toEqual([]);
   });
 
   test("handles file with only whitespace", async () => {
     await writeFile(join(testDir, "whitespace.md"), "   \n\n\t\n   ");
 
-    const tasks = await parseTasksFromFile(testDir, "whitespace.md");
+    const tasks = await parseTasksFromFile(testDir, "whitespace.md", "inbox");
     expect(tasks).toEqual([]);
   });
 
@@ -530,7 +530,7 @@ Line 4
       '- [ ] Task with *bold*, _italic_, `code`, and "quotes"'
     );
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].text).toBe('Task with *bold*, _italic_, `code`, and "quotes"');
   });
@@ -541,7 +541,7 @@ Line 4
       "- [ ] Task with emoji \u{1F525} and Japanese \u65E5\u672C\u8A9E"
     );
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].text).toContain("\u{1F525}");
     expect(tasks[0].text).toContain("\u65E5\u672C\u8A9E");
@@ -556,20 +556,20 @@ Line 4
 `;
     await writeFile(join(testDir, "note.md"), content);
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].text).toBe("Actual task");
   });
 
   test("returns empty array for path traversal", async () => {
-    const tasks = await parseTasksFromFile(testDir, "../outside.md");
+    const tasks = await parseTasksFromFile(testDir, "../outside.md", "inbox");
     expect(tasks).toEqual([]);
   });
 
   test("handles task at end of file without newline", async () => {
     await writeFile(join(testDir, "note.md"), "- [ ] No trailing newline");
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].text).toBe("No trailing newline");
   });
@@ -580,7 +580,7 @@ Line 4
 `;
     await writeFile(join(testDir, "note.md"), content);
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].lineNumber).toBe(2);
   });
@@ -591,7 +591,7 @@ Line 4
       "- [ ] Task with comment <!-- comment -->"
     );
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].text).toBe("Task with comment <!-- comment -->");
   });
@@ -603,7 +603,7 @@ Line 4
 `;
     await writeFile(join(testDir, "note.md"), content);
 
-    const tasks = await parseTasksFromFile(testDir, "note.md");
+    const tasks = await parseTasksFromFile(testDir, "note.md", "inbox");
     expect(tasks).toHaveLength(3);
     expect(tasks[0].lineNumber).toBe(1);
     expect(tasks[1].lineNumber).toBe(2);
@@ -872,7 +872,7 @@ describe("Edge Cases", () => {
       "- [ ] Task 1\r\n- [ ] Task 2\r\n"
     );
 
-    const tasks = await parseTasksFromFile(testDir, "00_Inbox/windows.md");
+    const tasks = await parseTasksFromFile(testDir, "00_Inbox/windows.md", "inbox");
     expect(tasks).toHaveLength(2);
   });
 
@@ -882,7 +882,7 @@ describe("Edge Cases", () => {
       "- [ ] Task 1\n- [ ] Task 2\r\n- [ ] Task 3\r"
     );
 
-    const tasks = await parseTasksFromFile(testDir, "00_Inbox/mixed.md");
+    const tasks = await parseTasksFromFile(testDir, "00_Inbox/mixed.md", "inbox");
     // Should find tasks regardless of line endings
     expect(tasks.length).toBeGreaterThanOrEqual(2);
   });
@@ -891,7 +891,7 @@ describe("Edge Cases", () => {
     const longText = "A".repeat(1000);
     await writeFile(join(testDir, "00_Inbox", "long.md"), `- [ ] ${longText}`);
 
-    const tasks = await parseTasksFromFile(testDir, "00_Inbox/long.md");
+    const tasks = await parseTasksFromFile(testDir, "00_Inbox/long.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].text).toBe(longText);
   });
@@ -899,7 +899,7 @@ describe("Edge Cases", () => {
   test("handles task with only emoji text", async () => {
     await writeFile(join(testDir, "00_Inbox", "emoji.md"), "- [ ] \u{1F389}\u{1F525}\u{2728}");
 
-    const tasks = await parseTasksFromFile(testDir, "00_Inbox/emoji.md");
+    const tasks = await parseTasksFromFile(testDir, "00_Inbox/emoji.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].text).toBe("\u{1F389}\u{1F525}\u{2728}");
   });
@@ -917,7 +917,7 @@ describe("Edge Cases", () => {
     // Parse all concurrently
     const files = await scanTasksFromDirectory(testDir, "00_Inbox");
     const results = await Promise.all(
-      files.map((f) => parseTasksFromFile(testDir, f))
+      files.map((f) => parseTasksFromFile(testDir, f, "inbox"))
     );
 
     const allTasks = results.flat();
@@ -936,7 +936,7 @@ date: 2025-01-01
 `;
     await writeFile(join(testDir, "00_Inbox", "frontmatter.md"), content);
 
-    const tasks = await parseTasksFromFile(testDir, "00_Inbox/frontmatter.md");
+    const tasks = await parseTasksFromFile(testDir, "00_Inbox/frontmatter.md", "inbox");
     expect(tasks).toHaveLength(1);
     expect(tasks[0].text).toBe("Task after frontmatter");
   });
@@ -952,7 +952,7 @@ date: 2025-01-01
 `;
     await writeFile(join(testDir, "00_Inbox", "codeblock.md"), content);
 
-    const tasks = await parseTasksFromFile(testDir, "00_Inbox/codeblock.md");
+    const tasks = await parseTasksFromFile(testDir, "00_Inbox/codeblock.md", "inbox");
     // Both match because we don't track code block context
     expect(tasks.length).toBeGreaterThanOrEqual(1);
     // The real task should definitely be found

--- a/frontend/src/components/TaskList.css
+++ b/frontend/src/components/TaskList.css
@@ -96,6 +96,35 @@
 }
 
 /* ============================================
+   Category Section
+   ============================================ */
+
+.task-list__category {
+  margin-bottom: var(--spacing-md);
+}
+
+.task-list__category-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin: 0 var(--spacing-xs) var(--spacing-xs);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--glass-border);
+
+  /* Sticky category header */
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+}
+
+/* ============================================
    Task Group
    ============================================ */
 

--- a/frontend/src/components/__tests__/BrowseMode.test.tsx
+++ b/frontend/src/components/__tests__/BrowseMode.test.tsx
@@ -325,7 +325,7 @@ describe("BrowseMode", () => {
       ws.simulateMessage({
         type: "tasks",
         tasks: [
-          { text: "Test task", state: " ", filePath: "test.md", lineNumber: 1, fileMtime: 1000 },
+          { text: "Test task", state: " ", filePath: "test.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
         ],
         incomplete: 1,
         total: 1,

--- a/frontend/src/components/__tests__/TaskList.test.tsx
+++ b/frontend/src/components/__tests__/TaskList.test.tsx
@@ -76,9 +76,9 @@ describe("TaskList", () => {
   describe("task grouping", () => {
     it("groups tasks by file path", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task 1", state: " ", filePath: "folder/file1.md", lineNumber: 1, fileMtime: 1000 },
-        { text: "Task 2", state: " ", filePath: "folder/file1.md", lineNumber: 2, fileMtime: 1000 },
-        { text: "Task 3", state: " ", filePath: "folder/file2.md", lineNumber: 1, fileMtime: 2000 },
+        { text: "Task 1", state: " ", filePath: "folder/file1.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
+        { text: "Task 2", state: " ", filePath: "folder/file1.md", lineNumber: 2, fileMtime: 1000, category: "inbox" },
+        { text: "Task 3", state: " ", filePath: "folder/file2.md", lineNumber: 1, fileMtime: 2000, category: "inbox" },
       ];
 
       render(
@@ -94,9 +94,9 @@ describe("TaskList", () => {
 
     it("displays rollup count (completed / total) per file", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
-        { text: "Task 2", state: "x", filePath: "file.md", lineNumber: 2, fileMtime: 1000 },
-        { text: "Task 3", state: " ", filePath: "file.md", lineNumber: 3, fileMtime: 1000 },
+        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
+        { text: "Task 2", state: "x", filePath: "file.md", lineNumber: 2, fileMtime: 1000, category: "inbox" },
+        { text: "Task 3", state: " ", filePath: "file.md", lineNumber: 3, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -116,7 +116,7 @@ describe("TaskList", () => {
   describe("state indicators", () => {
     it("shows empty checkbox for incomplete tasks (state=' ')", () => {
       const tasks: TaskEntry[] = [
-        { text: "Incomplete task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Incomplete task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -132,7 +132,7 @@ describe("TaskList", () => {
 
     it("shows checked checkbox for complete tasks (state='x')", () => {
       const tasks: TaskEntry[] = [
-        { text: "Complete task", state: "x", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Complete task", state: "x", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -150,7 +150,7 @@ describe("TaskList", () => {
   describe("task toggle", () => {
     it("calls onToggleTask when toggle button is clicked", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task to toggle", state: " ", filePath: "file.md", lineNumber: 5, fileMtime: 1000 },
+        { text: "Task to toggle", state: " ", filePath: "file.md", lineNumber: 5, fileMtime: 1000, category: "inbox" },
       ];
 
       let toggledFilePath = "";
@@ -187,7 +187,7 @@ describe("TaskList", () => {
 
     it("rolls back optimistic update when onToggleTask returns false", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task to rollback", state: " ", filePath: "file.md", lineNumber: 5, fileMtime: 1000 },
+        { text: "Task to rollback", state: " ", filePath: "file.md", lineNumber: 5, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -215,7 +215,7 @@ describe("TaskList", () => {
   describe("touch targets", () => {
     it("has 44px minimum touch target class applied (REQ-NF-2)", () => {
       const tasks: TaskEntry[] = [
-        { text: "Touch target test", state: " ", filePath: "touch.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Touch target test", state: " ", filePath: "touch.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -237,7 +237,7 @@ describe("TaskList", () => {
   describe("accessibility", () => {
     it("provides aria-label for toggle buttons with task state", () => {
       const tasks: TaskEntry[] = [
-        { text: "Accessible task", state: "x", filePath: "access.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Accessible task", state: "x", filePath: "access.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -256,7 +256,7 @@ describe("TaskList", () => {
   describe("hide completed toggle", () => {
     it("renders hide completed checkbox in header", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -272,8 +272,8 @@ describe("TaskList", () => {
 
     it("filters out completed tasks when toggle is active", () => {
       const tasks: TaskEntry[] = [
-        { text: "Incomplete task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
-        { text: "Complete task", state: "x", filePath: "file.md", lineNumber: 2, fileMtime: 1000 },
+        { text: "Incomplete task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
+        { text: "Complete task", state: "x", filePath: "file.md", lineNumber: 2, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -297,9 +297,9 @@ describe("TaskList", () => {
 
     it("displays total count as completed / total in header", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
-        { text: "Task 2", state: "x", filePath: "file.md", lineNumber: 2, fileMtime: 1000 },
-        { text: "Task 3", state: " ", filePath: "file.md", lineNumber: 3, fileMtime: 1000 },
+        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
+        { text: "Task 2", state: "x", filePath: "file.md", lineNumber: 2, fileMtime: 1000, category: "inbox" },
+        { text: "Task 3", state: " ", filePath: "file.md", lineNumber: 3, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -315,8 +315,8 @@ describe("TaskList", () => {
 
     it("keeps total count unchanged when hide toggle is active", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
-        { text: "Task 2", state: "x", filePath: "file.md", lineNumber: 2, fileMtime: 1000 },
+        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
+        { text: "Task 2", state: "x", filePath: "file.md", lineNumber: 2, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -338,9 +338,9 @@ describe("TaskList", () => {
   describe("sort by modification time", () => {
     it("sorts files by mtime descending (newest first)", () => {
       const tasks: TaskEntry[] = [
-        { text: "Old file task", state: " ", filePath: "old.md", lineNumber: 1, fileMtime: 1000 },
-        { text: "New file task", state: " ", filePath: "new.md", lineNumber: 1, fileMtime: 3000 },
-        { text: "Mid file task", state: " ", filePath: "mid.md", lineNumber: 1, fileMtime: 2000 },
+        { text: "Old file task", state: " ", filePath: "old.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
+        { text: "New file task", state: " ", filePath: "new.md", lineNumber: 1, fileMtime: 3000, category: "inbox" },
+        { text: "Mid file task", state: " ", filePath: "mid.md", lineNumber: 1, fileMtime: 2000, category: "inbox" },
       ];
 
       render(
@@ -361,8 +361,8 @@ describe("TaskList", () => {
 
     it("handles files with mtime=0 (sorted last)", () => {
       const tasks: TaskEntry[] = [
-        { text: "No mtime task", state: " ", filePath: "unknown.md", lineNumber: 1, fileMtime: 0 },
-        { text: "Has mtime task", state: " ", filePath: "known.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "No mtime task", state: " ", filePath: "unknown.md", lineNumber: 1, fileMtime: 0, category: "inbox" },
+        { text: "Has mtime task", state: " ", filePath: "known.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -383,7 +383,7 @@ describe("TaskList", () => {
   describe("left-click toggle behavior", () => {
     it("toggles from incomplete to complete on left-click", () => {
       const tasks: TaskEntry[] = [
-        { text: "Incomplete task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Incomplete task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -405,7 +405,7 @@ describe("TaskList", () => {
 
     it("toggles from complete to incomplete on left-click", () => {
       const tasks: TaskEntry[] = [
-        { text: "Complete task", state: "x", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Complete task", state: "x", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -427,7 +427,7 @@ describe("TaskList", () => {
 
     it("toggles from special state to incomplete on left-click", () => {
       const tasks: TaskEntry[] = [
-        { text: "Partial task", state: "/", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Partial task", state: "/", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -451,7 +451,7 @@ describe("TaskList", () => {
   describe("context menu", () => {
     it("opens context menu on right-click", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task with menu", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task with menu", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -472,7 +472,7 @@ describe("TaskList", () => {
 
     it("displays special state options in context menu", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task with menu", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task with menu", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -495,7 +495,7 @@ describe("TaskList", () => {
 
     it("selects state from context menu", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task to update", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task to update", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       let toggledFilePath = "";
@@ -540,7 +540,7 @@ describe("TaskList", () => {
 
     it("closes context menu on escape key", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task with menu", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task with menu", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(
@@ -566,7 +566,7 @@ describe("TaskList", () => {
 
     it("closes context menu on click outside", () => {
       const tasks: TaskEntry[] = [
-        { text: "Task with menu", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task with menu", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" },
       ];
 
       render(

--- a/frontend/src/contexts/__tests__/SessionContext.test.tsx
+++ b/frontend/src/contexts/__tests__/SessionContext.test.tsx
@@ -1719,8 +1719,8 @@ describe("SessionContext", () => {
       });
 
       const tasks = [
-        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1, fileMtime: 1000 },
-        { text: "Task 2", state: "x", filePath: "folder/file.md", lineNumber: 2, fileMtime: 1000 },
+        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" as const },
+        { text: "Task 2", state: "x", filePath: "folder/file.md", lineNumber: 2, fileMtime: 1000, category: "inbox" as const },
       ];
 
       act(() => {
@@ -1805,9 +1805,9 @@ describe("SessionContext", () => {
       });
 
       const tasks = [
-        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1, fileMtime: 1000 },
-        { text: "Task 2", state: " ", filePath: "folder/file.md", lineNumber: 2, fileMtime: 1000 },
-        { text: "Task 3", state: " ", filePath: "other/file.md", lineNumber: 1, fileMtime: 2000 },
+        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" as const },
+        { text: "Task 2", state: " ", filePath: "folder/file.md", lineNumber: 2, fileMtime: 1000, category: "inbox" as const },
+        { text: "Task 3", state: " ", filePath: "other/file.md", lineNumber: 1, fileMtime: 2000, category: "inbox" as const },
       ];
 
       act(() => {
@@ -1830,7 +1830,7 @@ describe("SessionContext", () => {
       });
 
       const tasks = [
-        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task 1", state: " ", filePath: "folder/file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" as const },
       ];
 
       act(() => {
@@ -1851,7 +1851,7 @@ describe("SessionContext", () => {
       });
 
       const tasks = [
-        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+        { text: "Task 1", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" as const },
       ];
 
       act(() => {
@@ -1878,7 +1878,7 @@ describe("SessionContext", () => {
         result.current.selectVault(testVault);
         result.current.setViewMode("tasks");
         result.current.setTasks([
-          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" as const },
         ]);
       });
 
@@ -1902,7 +1902,7 @@ describe("SessionContext", () => {
       act(() => {
         result.current.selectVault(testVault);
         result.current.setTasks([
-          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" as const },
         ]);
       });
 
@@ -1924,7 +1924,7 @@ describe("SessionContext", () => {
       // Set up task state
       act(() => {
         result.current.setTasks([
-          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000 },
+          { text: "Task", state: " ", filePath: "file.md", lineNumber: 1, fileMtime: 1000, category: "inbox" as const },
         ]);
         result.current.setTasksError("Some error");
       });

--- a/shared/src/__tests__/protocol.test.ts
+++ b/shared/src/__tests__/protocol.test.ts
@@ -226,6 +226,7 @@ describe("TaskEntrySchema", () => {
       filePath: "00_Inbox/2025-01-01.md",
       lineNumber: 5,
       fileMtime: 1704067200000,
+      category: "inbox",
     };
     const result = TaskEntrySchema.parse(task);
     expect(result.text).toBe("Buy groceries");
@@ -241,6 +242,7 @@ describe("TaskEntrySchema", () => {
       filePath: "01_Projects/project.md",
       lineNumber: 10,
       fileMtime: 1704067200000,
+      category: "inbox",
     };
     const result = TaskEntrySchema.parse(task);
     expect(result.state).toBe("x");
@@ -255,6 +257,7 @@ describe("TaskEntrySchema", () => {
         filePath: "test.md",
         lineNumber: 1,
         fileMtime: 1704067200000,
+        category: "inbox",
       };
       expect(() => TaskEntrySchema.parse(task)).not.toThrow();
     }
@@ -268,6 +271,7 @@ describe("TaskEntrySchema", () => {
       filePath: "test.md",
       lineNumber: 1,
       fileMtime: 1704067200000,
+      category: "inbox",
     };
     const result = TaskEntrySchema.parse(task);
     expect(result.text).toBe("");
@@ -280,6 +284,7 @@ describe("TaskEntrySchema", () => {
       filePath: "test.md",
       lineNumber: 1,
       fileMtime: 1704067200000,
+      category: "inbox",
     };
     const result = TaskEntrySchema.parse(task);
     expect(result.text).toContain("\u{1F525}");
@@ -292,6 +297,7 @@ describe("TaskEntrySchema", () => {
       filePath: "test.md",
       lineNumber: 1,
       fileMtime: 1704067200000,
+      category: "inbox",
     };
     expect(() => TaskEntrySchema.parse(task)).toThrow(ZodError);
   });
@@ -1456,6 +1462,7 @@ describe("Server -> Client Messages", () => {
             filePath: "00_Inbox/today.md",
             lineNumber: 5,
             fileMtime: 1704067200000,
+            category: "inbox" as const,
           },
           {
             text: "Finish report",
@@ -1463,6 +1470,7 @@ describe("Server -> Client Messages", () => {
             filePath: "01_Projects/work.md",
             lineNumber: 10,
             fileMtime: 1704067200000,
+            category: "projects" as const,
           },
         ],
         incomplete: 1,
@@ -1498,6 +1506,7 @@ describe("Server -> Client Messages", () => {
         filePath: "test.md",
         lineNumber: i + 1,
         fileMtime: 1704067200000,
+        category: "inbox" as const,
       }));
       const msg = {
         type: "tasks" as const,
@@ -1512,7 +1521,7 @@ describe("Server -> Client Messages", () => {
     test("rejects invalid task in tasks array", () => {
       const msg = {
         type: "tasks",
-        tasks: [{ text: "Valid", state: "xx", filePath: "test.md", lineNumber: 1, fileMtime: 1704067200000 }], // invalid state
+        tasks: [{ text: "Valid", state: "xx", filePath: "test.md", lineNumber: 1, fileMtime: 1704067200000, category: "inbox" }], // invalid state
         incomplete: 0,
         total: 1,
       };
@@ -2153,7 +2162,7 @@ describe("Server -> Client Messages", () => {
         {
           type: "tasks",
           tasks: [
-            { text: "Buy milk", state: " ", filePath: "inbox.md", lineNumber: 1, fileMtime: 1704067200000 },
+            { text: "Buy milk", state: " ", filePath: "inbox.md", lineNumber: 1, fileMtime: 1704067200000, category: "inbox" },
           ],
           incomplete: 1,
           total: 1,

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -20,6 +20,7 @@ export {
   // File browser schemas
   FileEntrySchema,
   // Task schemas
+  TaskCategorySchema,
   TaskEntrySchema,
   // Recent notes schemas
   RecentNoteEntrySchema,
@@ -97,6 +98,7 @@ export type {
   // File browser types
   FileEntry,
   // Task types
+  TaskCategory,
   TaskEntry,
   // Recent notes types
   RecentNoteEntry,

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -94,6 +94,11 @@ export const FileEntrySchema = z.object({
 });
 
 /**
+ * Schema for task category - indicates which directory the task was found in
+ */
+export const TaskCategorySchema = z.enum(["inbox", "projects", "areas"]);
+
+/**
  * Schema for a task entry parsed from markdown files
  * Tasks are lines matching /^\s*- \[(.)\] (.+)$/
  */
@@ -108,6 +113,8 @@ export const TaskEntrySchema = z.object({
   lineNumber: z.number().int().min(1, "Line number must be at least 1"),
   /** File modification time (Unix timestamp in ms) for sorting */
   fileMtime: z.number().int().min(0),
+  /** Category indicating source directory (inbox, projects, or areas) */
+  category: TaskCategorySchema,
 });
 
 /**
@@ -1066,6 +1073,7 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
 export type FileEntry = z.infer<typeof FileEntrySchema>;
 
 // Task types
+export type TaskCategory = z.infer<typeof TaskCategorySchema>;
 export type TaskEntry = z.infer<typeof TaskEntrySchema>;
 
 // Recent notes types


### PR DESCRIPTION
## Summary
- Add `category` field to TaskEntry schema to track source directory (inbox/projects/areas)
- Update backend task-manager to tag tasks with their source category
- Restructure frontend TaskList to group tasks by category first, then by modification time
- Add sticky category section headers with styling

## Test plan
- [x] All existing tests pass (typecheck, lint, unit tests)
- [x] Tasks from Inbox directory display under "INBOX" header
- [x] Tasks from Projects directory display under "PROJECTS" header
- [x] Tasks from Areas directory display under "AREAS" header
- [x] Within each category, files are sorted by modification time (newest first)

Closes #270

🤖 Generated with [Claude Code](https://claude.ai/code)