### PR TITLE
feat: add collapsible category headers in task list

### DIFF
--- a/frontend/src/components/TaskList.css
+++ b/frontend/src/components/TaskList.css
@@ -106,7 +106,8 @@
 .task-list__category-header {
   display: flex;
   align-items: center;
-  gap: var(--spacing-sm);
+  gap: var(--spacing-xs);
+  width: calc(100% - var(--spacing-xs) * 2);
   padding: var(--spacing-sm) var(--spacing-md);
   margin: 0 var(--spacing-xs) var(--spacing-xs);
   font-size: var(--text-sm);
@@ -114,7 +115,11 @@
   color: var(--color-text-accent);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  border: none;
   border-bottom: 1px solid var(--glass-border);
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.2s ease;
 
   /* Sticky category header */
   position: sticky;
@@ -122,6 +127,29 @@
   z-index: 2;
   background: var(--glass-bg);
   backdrop-filter: blur(var(--glass-blur));
+}
+
+.task-list__category-header:hover {
+  background: var(--glass-bg-primary-hover);
+}
+
+.task-list__category-header:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.task-list__category-name {
+  flex: 1;
+}
+
+.task-list__category-count {
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: var(--color-accent-primary-a15);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
 }
 
 /* ============================================
@@ -150,9 +178,9 @@
   text-align: left;
   transition: background-color 0.2s ease;
 
-  /* Sticky header - sticks to top when scrolling within group */
+  /* Sticky header - stacks below category header */
   position: sticky;
-  top: 0;
+  top: 40px;
   z-index: 1;
 }
 
@@ -335,7 +363,8 @@
 /* Disable hover effects on touch devices */
 @media (hover: none) {
   .task-list__toggle:hover,
-  .task-list__group-header:hover {
+  .task-list__group-header:hover,
+  .task-list__category-header:hover {
     background: var(--color-accent-primary-a08);
   }
 
@@ -351,7 +380,8 @@
     padding: var(--spacing-sm);
   }
 
-  .task-list__group-header {
+  .task-list__group-header,
+  .task-list__category-header {
     padding: var(--spacing-sm);
   }
 }

--- a/frontend/src/components/__tests__/TaskList.test.tsx
+++ b/frontend/src/components/__tests__/TaskList.test.tsx
@@ -106,10 +106,11 @@ describe("TaskList", () => {
       );
 
       // 1 completed (x), 3 total - appears in both header and per-group count
-      // Find the group header button by its aria-expanded attribute
-      const groupHeader = screen.getByRole("button", { expanded: true });
-      expect(groupHeader.textContent).toContain("1 / 3");
-      expect(groupHeader.textContent).toContain("file.md");
+      // Find the file group header button by its class (not the category header)
+      const groupHeader = document.querySelector(".task-list__group-header");
+      expect(groupHeader).not.toBeNull();
+      expect(groupHeader!.textContent).toContain("1 / 3");
+      expect(groupHeader!.textContent).toContain("file.md");
     });
   });
 
@@ -349,9 +350,9 @@ describe("TaskList", () => {
         </SessionProvider>
       );
 
-      // Get all group headers in order
-      const headers = screen.getAllByRole("button", { expanded: true });
-      const fileNames = headers.map((h) => h.textContent);
+      // Get all file group headers in order (not category headers)
+      const headers = document.querySelectorAll(".task-list__group-header");
+      const fileNames = Array.from(headers).map((h) => h.textContent);
 
       // Should be newest first: new.md, mid.md, old.md
       expect(fileNames[0]).toContain("new.md");
@@ -371,8 +372,9 @@ describe("TaskList", () => {
         </SessionProvider>
       );
 
-      const headers = screen.getAllByRole("button", { expanded: true });
-      const fileNames = headers.map((h) => h.textContent);
+      // Get all file group headers (not category headers)
+      const headers = document.querySelectorAll(".task-list__group-header");
+      const fileNames = Array.from(headers).map((h) => h.textContent);
 
       // File with mtime should come first, mtime=0 last
       expect(fileNames[0]).toContain("known.md");


### PR DESCRIPTION
## Summary
- Category headers (Inbox, Projects, Areas) are now clickable buttons that collapse/expand their file groups
- Each category header displays a rollup count showing completed/total tasks within that category
- Matches existing file group collapse behavior with chevron rotation animation

## Test plan
- [x] Click category header to collapse/expand file groups
- [x] Verify chevron rotates when collapsed
- [x] Verify rollup count shows correct completed/total for each category
- [x] All existing TaskList tests pass
- [x] Pre-commit hooks pass (typecheck, lint, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)