### PR TITLE
fix: include vaultId when saving config from within vault

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,7 +77,7 @@ function MainContent(): React.ReactNode {
     setConfigSaveError(null);
     pendingConfigRef.current = config; // Store for local state update on success
     console.log(`[App] Saving config for vault: ${vault.id}`, config);
-    sendMessage({ type: "update_vault_config", config });
+    sendMessage({ type: "update_vault_config", config, vaultId: vault.id });
   }
 
   function handleConfigCancel() {


### PR DESCRIPTION
## Summary
- Fixed config save failing when editing vault settings from within a vault (via gear button in header)
- The `update_vault_config` message was missing `vaultId`, relying on backend state that could be lost on WebSocket reconnection
- VaultSelect already passed `vaultId` explicitly and worked correctly

## Test plan
- [ ] Open a vault and click the gear button in the header
- [ ] Make a change to any setting
- [ ] Click Save and verify it succeeds
- [ ] Verify toast shows "Settings saved"

🤖 Generated with [Claude Code](https://claude.ai/code)