### PR TITLE
feat: add similarity aggregator for weighted average computation

### DIFF
--- a/backend/src/widgets/__tests__/dependency-graph.test.ts
+++ b/backend/src/widgets/__tests__/dependency-graph.test.ts
@@ -146,6 +146,18 @@ describe("buildDependencyGraph", () => {
     expect(graph.scope.get("avg_val")).toBe("collection");
   });
 
+  test("identifies collection scope for similarity aggregator fields", () => {
+    const fields: Record<string, FieldConfig> = {
+      weighted_rating: {
+        similarity: { ref: "Similar Items", field: "rating" },
+      },
+    };
+
+    const graph = buildDependencyGraph(fields);
+
+    expect(graph.scope.get("weighted_rating")).toBe("collection");
+  });
+
   test("identifies item scope for expression-only fields", () => {
     const fields: Record<string, FieldConfig> = {
       normalized: { expr: "this.value / 100" },

--- a/backend/src/widgets/__tests__/schemas.test.ts
+++ b/backend/src/widgets/__tests__/schemas.test.ts
@@ -82,6 +82,48 @@ describe("FieldConfigSchema", () => {
     const result = FieldConfigSchema.safeParse({ count: false });
     expect(result.success).toBe(false);
   });
+
+  test("accepts similarity aggregator with ref and field", () => {
+    const result = FieldConfigSchema.safeParse({
+      similarity: { ref: "Similar Games", field: "rating" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts similarity aggregator with nested field path", () => {
+    const result = FieldConfigSchema.safeParse({
+      similarity: { ref: "Similar Games", field: "bgg.rating" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects similarity aggregator without ref", () => {
+    const result = FieldConfigSchema.safeParse({
+      similarity: { field: "rating" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects similarity aggregator without field", () => {
+    const result = FieldConfigSchema.safeParse({
+      similarity: { ref: "Similar Games" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects similarity aggregator with empty ref", () => {
+    const result = FieldConfigSchema.safeParse({
+      similarity: { ref: "", field: "rating" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects similarity aggregator with empty field", () => {
+    const result = FieldConfigSchema.safeParse({
+      similarity: { ref: "Similar Games", field: "" },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // =============================================================================

--- a/backend/src/widgets/dependency-graph.ts
+++ b/backend/src/widgets/dependency-graph.ts
@@ -178,7 +178,7 @@ function extractExpressionDependencies(expression: string): string[] {
 /**
  * Determine the scope of a field based on its configuration.
  *
- * - Fields with any aggregator (count, sum, avg, min, max, stddev) are collection-scope
+ * - Fields with any aggregator (count, sum, avg, min, max, stddev, similarity) are collection-scope
  * - Fields with only an expression are item-scope
  *
  * @param config - The field configuration
@@ -194,7 +194,8 @@ function determineFieldScope(config: FieldConfig): FieldScope {
     config.avg !== undefined ||
     config.min !== undefined ||
     config.max !== undefined ||
-    config.stddev !== undefined;
+    config.stddev !== undefined ||
+    config.similarity !== undefined;
 
   return hasAggregator ? "collection" : "item";
 }


### PR DESCRIPTION
## Summary

- Adds a new `similarity` aggregator to aggregate widgets that computes weighted averages using similarity scores as weights
- The formula is: `result = sum(weight * score) / sum(weight)`
- The referenced widget must be a similarity-type widget included via `includes`

### Example Usage

```yaml
name: Weighted Rating
type: aggregate
location: recall
source:
  pattern: "Games/**/*.md"
includes:
  - "Game Similarity"
fields:
  weighted_rating:
    similarity:
      ref: "Game Similarity"
      field: "rating"
```

Closes #279

## Test plan

- [x] Schema validation tests for `similarity` aggregator config
- [x] Integration tests for weighted average calculation
- [x] Edge case tests (missing includes, null scores, zero similarity)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)