### PR TITLE
docs: add usage documentation for all four tabs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,39 @@ bun run --cwd frontend test src/components/__tests__/Home.test.tsx
 - Run `bun run test` (combined command causes resource conflicts)
 - Run `bun run --cwd <module> test` without a specific file (runs all tests in module)
 - Pipe test output through `head` or `tail` (truncates output, hides results)
+
+## Documentation
+
+Documentation lives in `docs/` and must be kept current with code changes.
+
+### Structure
+
+```
+docs/
+├── usage/           # User-facing "how to" guides for each tab
+│   ├── README.md    # Overview and navigation
+│   ├── ground.md    # Ground tab (home dashboard)
+│   ├── capture.md   # Capture tab (quick notes)
+│   ├── think.md     # Think tab (AI conversation)
+│   └── recall.md    # Recall tab (file browser)
+├── widgets/         # Widget configuration and examples
+├── deployment/      # Self-hosting setup guides
+└── adr/             # Architecture decision records
+```
+
+### Documentation Maintenance (MANDATORY)
+
+When making changes that affect user-facing behavior:
+
+1. **Update the relevant usage doc** in `docs/usage/` if the change affects how a tab works
+2. **Update widget docs** if changing widget behavior or configuration
+3. **Add an ADR** for significant architectural decisions
+
+Documentation is part of the definition of done. A feature is not complete until its documentation is updated.
+
+### Image Placeholders
+
+Usage docs contain image placeholders in the format `[ img: description ]`. These mark where screenshots should be added. When adding screenshots:
+- Save images to an `images/` subdirectory
+- Replace placeholder with standard markdown image syntax
+- Use descriptive alt text

--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ hostname -I | awk '{print $1}'
 http://YOUR_IP:5173
 ```
 
-## Deployment
+## Documentation
 
-For production deployments, see:
+- [Usage Guide](docs/usage/README.md) — How to use each tab (Ground, Capture, Think, Recall)
+- [Widgets](docs/widgets/README.md) — Configure computed widgets for dashboards and file views
+
+### Deployment
 
 - [HTTPS/TLS Setup](docs/deployment/https-setup.md) — Certificate configuration for secure access
 - [systemd Service](docs/deployment/systemd.md) — Run Memory Loop automatically on boot

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,0 +1,64 @@
+# Using Memory Loop
+
+Memory Loop is organized around four tabs, each designed for a specific mode of interaction with your Obsidian vault.
+
+[ img: Mode toggle showing all four tabs ]
+
+## The Four Tabs
+
+| Tab | Icon | Purpose | Use when... |
+|-----|------|---------|-------------|
+| [Ground](./ground.md) | 🪨 | Home dashboard | Starting your session, checking goals, accessing recent activity |
+| [Capture](./capture.md) | 🪶 | Quick note entry | Capturing a thought quickly without friction |
+| [Think](./think.md) | ✨ | AI conversation | Exploring ideas, running commands, analyzing notes |
+| [Recall](./recall.md) | 🪞 | File browsing | Reading notes, searching, editing, reviewing tasks |
+
+## Quick Start
+
+**New to Memory Loop?** Here's a suggested first session:
+
+1. **Ground**: See your vault name and any goals you've set
+2. **Capture**: Jot down a quick thought to test the capture flow
+3. **Ground**: Notice your capture appears in Recent Activity
+4. **Think**: Ask Claude something about your vault
+5. **Recall**: Browse your files and find the daily note with your capture
+
+## Navigation
+
+The tab bar appears at the bottom of the screen (mobile) or top (desktop). Tap any tab to switch views.
+
+[ img: Tab bar at bottom of screen ]
+
+Each tab maintains its state when you switch away. Your draft messages, scroll positions, and selected files persist as you move between tabs.
+
+## Common Patterns
+
+### Capture Then Reflect
+
+1. Throughout the day, use **Capture** for quick thoughts
+2. End the day on **Ground** and tap **Daily Debrief**
+3. **Think** summarizes your captures and surfaces themes
+
+### Read Then Discuss
+
+1. Use **Recall** to find and read a note
+2. Long-press and select "Think about"
+3. **Think** opens with the file path ready for discussion
+
+### Goal-Driven Session
+
+1. Start on **Ground** to see your goals
+2. Tap the goals card to discuss progress in **Think**
+3. Update goals in **Recall** using adjust mode
+
+## Documentation
+
+- [Ground Tab](./ground.md): Dashboard, debriefs, inspiration, goals, recent activity
+- [Capture Tab](./capture.md): Quick note entry, draft preservation, error handling
+- [Think Tab](./think.md): AI chat, slash commands, tool usage, sessions
+- [Recall Tab](./recall.md): File tree, search, viewers, editing, tasks
+
+## Related Documentation
+
+- [Widgets](../widgets/README.md): Configure computed widgets for Ground and Recall
+- [Deployment](../deployment/systemd.md): Self-hosting setup

--- a/docs/usage/capture.md
+++ b/docs/usage/capture.md
@@ -1,0 +1,131 @@
+# Capture Tab
+
+The Capture tab is your quick-entry point for thoughts, observations, and fleeting ideas. Notes go straight to your daily note file with a timestamp.
+
+[ img: Capture tab full view ]
+
+## The Capture Interface
+
+The interface is intentionally minimal: a text area and a submit button. This design optimizes for speed, capturing the thought before it escapes.
+
+[ img: Capture text area with button ]
+
+### Text Area
+
+The text area auto-expands as you type. There's no limit on length, though captures work best for quick thoughts rather than long-form writing (use the Recall tab's editor for that).
+
+### Submit Button
+
+Tap **Capture Note** to save your text. While saving, the button changes to "Saving..." and disables further input until complete.
+
+## How Captures Work
+
+When you submit a capture:
+
+1. The text is appended to today's daily note in your inbox folder
+2. A timestamp is added (e.g., "10:42 AM")
+3. A success toast confirms the save
+4. The text area clears, ready for your next thought
+
+[ img: Success toast after capture ]
+
+### Daily Note Format
+
+Captures append to `{inbox}/{YYYY-MM-DD}.md` in this format:
+
+```markdown
+## 10:42 AM
+
+Your captured thought goes here.
+```
+
+If the daily note doesn't exist, it's created automatically.
+
+### Inbox Location
+
+The inbox path comes from your vault's `CLAUDE.md` configuration. Typically this is `00_Inbox/` or similar. If no inbox is configured, captures go to the vault root.
+
+## Input Behavior
+
+### Desktop
+
+- **Enter**: Submit the capture
+- **Shift+Enter**: Add a new line
+
+This lets you quickly fire off thoughts without reaching for the mouse.
+
+### Mobile
+
+- **Enter**: Add a new line
+- **Tap button**: Submit the capture
+
+On touch devices, Enter always creates a newline since there's no keyboard shortcut expectation. The button is the primary submit mechanism.
+
+## Draft Preservation
+
+Your draft auto-saves to browser storage as you type. If you navigate away or close the app before submitting:
+
+- The draft persists across sessions
+- Reopening Capture restores your text
+- Submitting or clearing the field removes the draft
+
+This ensures you never lose a partial thought due to accidental navigation.
+
+## Error Handling
+
+### Connection Issues
+
+If the server connection drops:
+- The button disables
+- A toast warns "Not connected. Please wait..."
+- Once reconnected, you can retry
+
+### Save Failures
+
+If the save fails:
+- The system retries automatically (up to 3 times)
+- Retries use exponential backoff
+- A toast shows retry progress
+- After 3 failures, you see the error message
+
+Your text is never cleared on failure, so you can retry manually or copy it elsewhere.
+
+[ img: Error toast during retry ]
+
+## Typical Workflows
+
+### Quick Thought Capture
+
+1. Open Capture when an idea strikes
+2. Type the thought
+3. Tap **Capture Note** or press Enter
+4. Return to what you were doing
+
+The whole interaction takes seconds.
+
+### Meeting Notes Stream
+
+1. Keep Capture open during a meeting
+2. Enter key points as they come up
+3. Each capture gets its own timestamp
+4. Review later in Recall or via Daily Debrief
+
+### Reading Notes
+
+1. While reading, switch to Capture to note reactions
+2. Each insight gets captured with context (timestamp)
+3. The daily note becomes a record of your reading session
+
+### Morning Pages
+
+1. Use Capture for stream-of-consciousness writing
+2. Each paragraph can be a separate capture
+3. Timestamps create a natural flow record
+4. Review later to find patterns
+
+## Tips
+
+- **Keep it short**: Capture is for quick notes, not essays
+- **Use Think for analysis**: If you want AI engagement, use Think instead
+- **Review in Recall**: Tap "View" on recent captures to see full context
+- **Use Daily Debrief**: Let the AI summarize your day's captures

--- a/docs/usage/ground.md
+++ b/docs/usage/ground.md
@@ -1,0 +1,119 @@
+# Ground Tab
+
+The Ground tab is your home base. It provides an at-a-glance view of your vault's current state, surfaces timely prompts for reflection, and gives quick access to recent activity.
+
+[ img: Ground tab full view ]
+
+## Vault Card
+
+At the top of the Ground tab, the vault card displays:
+
+- **Vault name**: The display name from your vault's configuration
+- **Subtitle**: Optional description (if configured in `.memory-loop.json`)
+
+[ img: Vault card showing name and subtitle ]
+
+### Debrief Buttons
+
+Below the vault name, contextual debrief buttons appear based on the current date and your recent activity:
+
+| Button | When it appears | What it does |
+|--------|-----------------|--------------|
+| Daily Debrief | When you have a note for today | Opens Think with `/daily-debrief` command |
+| Weekly Debrief | Friday through Sunday | Opens Think with `/weekly-debrief` command |
+| Monthly Summary | Last 3 days or first 3 days of month | Opens Think with `/monthly-summary YYYY MM` command |
+
+[ img: Vault card with debrief buttons visible ]
+
+The buttons trigger AI-assisted reflection workflows. Tap any button to switch to the Think tab with the corresponding command pre-filled.
+
+## Inspiration Section
+
+The inspiration section displays content from your vault's inspiration sources to spark reflection and conversation.
+
+[ img: Inspiration card with quote and prompt ]
+
+### Quote
+
+A daily inspirational quote selected from your vault's configured quote sources. The quote appears with attribution when available.
+
+**Interaction**: Tap the quote to open the Think tab with the quote pre-filled as your message. This lets you explore the quote's meaning or discuss how it relates to your work.
+
+### Contextual Prompt
+
+A context-aware prompt drawn from your vault's prompt sources. These prompts change based on the day and are designed to encourage reflection.
+
+**Interaction**: Tap the prompt to open the Think tab with the prompt pre-filled. The AI will engage with your response in the context of your vault.
+
+## Goals Section
+
+If your vault has a `goals.md` file, its content displays here as rendered markdown. This keeps your current objectives visible whenever you open the app.
+
+[ img: Goals card showing rendered markdown ]
+
+**Interaction**: Tap the goals card to open the Think tab with the `/review-goals` command. The AI will analyze your goals and help you assess progress, identify blockers, or refine priorities.
+
+## Ground Widgets
+
+If you've configured vault widgets with `location: ground`, they appear in this section. Ground widgets show vault-wide aggregations and statistics.
+
+[ img: Ground widgets showing aggregate data ]
+
+See the [Widgets documentation](../widgets/README.md) for configuration details.
+
+## Recent Activity
+
+The bottom section shows your recent captures and discussions, organized into two groups:
+
+### Recent Captures
+
+Each capture card shows:
+- The captured text (truncated if long)
+- Timestamp and relative date
+- **View** button to open the daily note in Recall
+
+[ img: Recent captures section with View buttons ]
+
+**Interaction**: Tap **View** to switch to the Recall tab and open the daily note containing that capture. This lets you see the full context around the note.
+
+### Recent Discussions
+
+Each discussion card shows:
+- A preview of the conversation
+- Timestamp and relative date
+- Message count
+- **Resume** and **Delete** buttons
+
+[ img: Recent discussions section with Resume and Delete buttons ]
+
+**Interactions**:
+- **Resume**: Switch to Think and continue the conversation where you left off
+- **Delete**: Remove the session permanently (requires confirmation)
+
+The currently active session cannot be deleted; you must start a new session first.
+
+## Typical Workflows
+
+### Morning Check-in
+
+1. Open Ground tab to see your goals and today's inspiration
+2. Tap the quote or prompt to start a reflective discussion
+3. If you have yesterday's captures, tap **View** to review them
+
+### End-of-Day Debrief
+
+1. After capturing notes throughout the day, return to Ground
+2. Tap **Daily Debrief** to have the AI summarize your day's notes
+3. The AI will pull themes and suggest what to carry forward
+
+### Weekly Review
+
+1. On Friday through Sunday, the **Weekly Debrief** button appears
+2. Tap it to get an AI-generated summary of your week
+3. Review patterns, accomplishments, and areas for focus
+
+### Goal Tracking
+
+1. Tap your goals card to trigger `/review-goals`
+2. The AI analyzes your goals against recent vault activity
+3. Get suggestions for next actions or goal refinements

--- a/docs/usage/recall.md
+++ b/docs/usage/recall.md
@@ -1,0 +1,239 @@
+# Recall Tab
+
+The Recall tab is your file browser and content viewer. Navigate your vault structure, read files, search across notes, manage tasks, and make quick edits.
+
+[ img: Recall tab split view with file tree and markdown viewer ]
+
+## Layout
+
+The Recall tab uses a split-pane layout:
+- **Left pane**: File tree or task list (collapsible on desktop)
+- **Right pane**: Content viewer
+
+On mobile, the left pane appears as an overlay that slides in when needed.
+
+## File Tree
+
+The file tree shows your vault's folder structure. Navigate by expanding folders and selecting files.
+
+[ img: File tree with expanded folders ]
+
+### Navigation
+
+- **Tap folder**: Expand or collapse to show/hide contents
+- **Tap file**: Open in the viewer pane
+- **Pinned folders**: Starred folders appear at top for quick access
+
+### Pinned Assets
+
+Frequently accessed folders can be pinned. Pinned items appear at the top of the file tree for quick access regardless of their location in the vault hierarchy.
+
+[ img: Pinned folders section at top of file tree ]
+
+### Context Menu
+
+Long-press (mobile) or right-click (desktop) a file to see context actions:
+
+| Action | Description |
+|--------|-------------|
+| Think about | Opens Think with file path pre-filled for AI discussion |
+| Delete | Removes the file (requires confirmation) |
+
+[ img: Context menu on file ]
+
+### Reload
+
+Tap the refresh icon (♻) in the header to reload the file tree. This fetches the latest state from your vault, useful if files changed outside the app.
+
+## View Modes
+
+The left pane has two modes, toggled by tapping the header title:
+
+### Files Mode
+
+The default view showing your vault's folder structure. Use this to browse and navigate.
+
+### Tasks Mode
+
+Shows a consolidated list of tasks (checkboxes) from across your vault.
+
+[ img: Tasks view showing checkboxes from multiple files ]
+
+Each task shows:
+- The task text (checkbox state indicated visually)
+- Source file path
+
+**Interaction**: Tap a task to toggle its checkbox state. The change writes back to the source file. Tap the file path to open that file in the viewer.
+
+## Search
+
+Tap the search icon (magnifying glass) to enter search mode.
+
+[ img: Search header with mode toggle ]
+
+### File Search
+
+Search by filename. Results show matching file paths. Tap a result to open the file.
+
+[ img: File search results ]
+
+### Content Search
+
+Search within file contents. Results show files containing matches with expandable snippets.
+
+[ img: Content search results with snippets ]
+
+- **Tap result**: Open the file in viewer
+- **Expand arrow**: Show matched text snippets from that file
+
+### Clearing Search
+
+Tap the X button to exit search mode and return to the file tree.
+
+## Content Viewer
+
+The right pane displays file content based on file type.
+
+### Markdown Files
+
+Markdown renders with full formatting: headers, lists, bold, italic, code blocks, tables, and more.
+
+[ img: Markdown viewer with formatted content ]
+
+**Wiki-links**: Tap `[[wiki-style links]]` to navigate to the linked file.
+
+**Images**: Embedded images (`![[image.png]]`) display inline.
+
+### Adjust Mode
+
+For markdown files, tap the **Adjust** button to enter edit mode.
+
+[ img: Adjust mode with editor ]
+
+- The content becomes editable
+- Make your changes
+- Tap **Save** to write changes back to the file
+- Tap **Cancel** to discard changes
+
+Changes are saved directly to your vault. If the save fails, your changes are preserved so you can retry.
+
+### Images
+
+Image files display with pan and zoom controls.
+
+[ img: Image viewer with zoom controls ]
+
+### Videos
+
+Video files play in an embedded player with standard controls.
+
+### PDFs
+
+PDF files render page by page with navigation controls.
+
+### JSON Files
+
+JSON displays with syntax highlighting and proper indentation. Adjust mode is available for editing.
+
+### Plain Text
+
+`.txt` files display as plain text. Adjust mode is available for editing.
+
+### CSV Files
+
+CSV files render as tables for easy reading.
+
+### Other Files
+
+Unsupported file types show a download button to save the file locally.
+
+## Recall Widgets
+
+When viewing a file that matches a widget's source pattern, contextual widgets appear in a collapsible panel below the viewer.
+
+[ img: Recall widgets panel expanded ]
+
+These widgets show data related to the current file, such as:
+- Similarity scores to other items
+- Aggregated statistics for the collection
+- Editable fields for frontmatter updates
+
+See the [Widgets documentation](../widgets/README.md) for configuration details.
+
+### Editing via Widgets
+
+Some widgets support inline editing. For example, a rating widget might show a slider to adjust a file's rating directly without opening the markdown editor.
+
+[ img: Widget with editable slider ]
+
+## Mobile Navigation
+
+On mobile, the file tree is hidden by default to maximize viewer space.
+
+[ img: Mobile view with menu button ]
+
+- **Menu button** (three lines): Opens the file tree as a slide-in overlay
+- **Tap outside**: Closes the overlay
+- **Select file**: Opens in viewer and closes overlay automatically
+
+[ img: Mobile file tree overlay ]
+
+## Header Bar
+
+The header shows the current file path and provides quick actions.
+
+[ img: Header bar with file path and actions ]
+
+- **File path**: Shows which file is currently displayed
+- **Collapse/expand**: Toggle the file tree visibility (desktop)
+
+## Typical Workflows
+
+### Finding a Specific Note
+
+1. Use file search to find by name
+2. Or navigate the folder structure
+3. Tap to open in viewer
+4. Use wiki-links to navigate related notes
+
+### Reviewing Daily Notes
+
+1. From Ground, tap **View** on a recent capture
+2. Recall opens with that daily note
+3. Read through your timestamped captures
+4. Navigate to linked notes as needed
+
+### Quick Edit
+
+1. Find and open the file
+2. Tap **Adjust** to enter edit mode
+3. Make your changes
+4. Tap **Save** to persist
+
+### Task Review
+
+1. Switch to Tasks mode via header
+2. See all uncompleted tasks across vault
+3. Toggle tasks as you complete them
+4. Tap file paths to see context
+
+### Content Discovery
+
+1. Use content search with a keyword
+2. Expand results to see matching snippets
+3. Open promising files
+4. Follow wiki-links to explore connections
+
+### Image Review
+
+1. Navigate to an image in the file tree
+2. View renders with zoom capability
+3. Pan and zoom to examine details
+
+## Tips
+
+- **Pin frequently used folders**: Speeds up navigation
+- **Use content search for ideas**: Find where concepts appear across notes
+- **Wiki-links are powerful**: Build a connected vault and navigate freely
+- **Tasks mode for accountability**: See all your commitments in one place
+- **Adjust mode for quick fixes**: No need to open Obsidian for small edits

--- a/docs/usage/think.md
+++ b/docs/usage/think.md
@@ -1,0 +1,185 @@
+# Think Tab
+
+The Think tab is your conversation space with Claude AI, grounded in the context of your Obsidian vault. Ask questions, explore ideas, run commands, and let the AI read and analyze your notes.
+
+[ img: Think tab with conversation ]
+
+## The Chat Interface
+
+The interface follows a familiar chat pattern: your messages on one side, Claude's responses on the other, with an input area at the bottom.
+
+[ img: Chat interface showing user and assistant messages ]
+
+### Message History
+
+Messages display in chronological order with clear visual distinction between your messages and Claude's responses. The view auto-scrolls to the latest message as the conversation progresses.
+
+### Streaming Responses
+
+Claude's responses stream in real-time. You see text appear as it's generated rather than waiting for the complete response. This provides immediate feedback and lets you follow the AI's reasoning.
+
+[ img: Streaming response in progress ]
+
+## Input Area
+
+The input area sits at the bottom of the screen, always accessible.
+
+[ img: Input area with attachment and send buttons ]
+
+### Text Input
+
+The text field expands when focused to give you more writing room. On mobile, this expansion is particularly helpful for longer messages.
+
+### Send Button
+
+Tap the send icon (arrow) to submit your message. While Claude is responding, this button transforms into a stop button (square) that lets you abort the response if needed.
+
+[ img: Stop button during response ]
+
+### File Attachment
+
+The paperclip button lets you attach files from your device. Attached files are uploaded to your vault and their path is added to your message. Claude can then read and analyze the file content.
+
+[ img: File attachment button ]
+
+## Slash Commands
+
+Type `/` to see available commands. These are predefined prompts that trigger specific AI behaviors.
+
+[ img: Slash command autocomplete dropdown ]
+
+### Autocomplete
+
+As you type after the `/`, the dropdown filters to matching commands. Each command shows:
+- Command name
+- Brief description of what it does
+
+Navigate with arrow keys and press Enter to select, or tap the command directly.
+
+### Built-in Commands
+
+Your vault's `CLAUDE.md` file defines available commands. Common examples:
+
+| Command | Purpose |
+|---------|---------|
+| `/daily-debrief` | Summarize today's captures and identify themes |
+| `/weekly-debrief` | Review the past week's activity |
+| `/monthly-summary YYYY MM` | Generate a monthly overview |
+| `/review-goals` | Analyze goals against recent progress |
+
+### Command Arguments
+
+Some commands accept arguments. After selecting a command, a placeholder hint appears showing expected input format. For example, `/monthly-summary` expects `YYYY MM` format.
+
+## Tool Usage
+
+Claude has access to tools for reading your vault, searching files, and performing other operations. When Claude uses a tool, you see it inline in the response.
+
+[ img: Tool invocation display showing Read tool ]
+
+### Tool Display
+
+Each tool invocation shows:
+- Tool name (e.g., "Read", "Glob", "Grep")
+- Input parameters (the arguments passed to the tool)
+- Output (the result, often truncated for readability)
+
+This transparency lets you understand how Claude is gathering information from your vault.
+
+### Tool Permissions
+
+Certain operations require your approval before proceeding. When Claude attempts a sensitive action (like writing to a file), a permission dialog appears.
+
+[ img: Tool permission dialog ]
+
+**Allow**: Let the operation proceed
+**Deny**: Block the operation and continue the conversation
+
+This gives you control over what changes Claude can make to your vault.
+
+## Session Management
+
+Conversations persist across app sessions. You can maintain ongoing discussions or start fresh as needed.
+
+### New Session
+
+Tap the **+** button in the top corner to start a new conversation. A confirmation dialog appears since this clears the current session's context.
+
+[ img: New session button and confirmation dialog ]
+
+### Resume Session
+
+From the Ground tab, tap **Resume** on any recent discussion to continue where you left off. The full conversation history loads, and Claude retains context from previous messages.
+
+### Delete Session
+
+From the Ground tab, tap **Delete** on a discussion to remove it permanently. Active sessions cannot be deleted; start a new session first if you want to remove the current one.
+
+## Input Behavior
+
+### Desktop
+
+- **Enter**: Send message
+- **Shift+Enter**: Add a new line
+- **Arrow keys**: Navigate slash command autocomplete
+- **Escape**: Close autocomplete dropdown
+
+### Mobile
+
+- **Enter**: Add a new line
+- **Tap send button**: Send message
+- **Tap command**: Select from autocomplete
+
+## Draft Preservation
+
+Like Capture, your draft auto-saves as you type:
+- Navigate away and your draft persists
+- Return to Think and it's restored
+- Sending clears the draft
+
+This ensures you don't lose partially composed messages.
+
+## Typical Workflows
+
+### Exploring an Idea
+
+1. Type your question or thought
+2. Claude responds with analysis grounded in your vault
+3. Follow up with clarifying questions
+4. Let the conversation develop organically
+
+### Running a Debrief
+
+1. Tap a debrief button on Ground (or type the command)
+2. Claude reads your recent notes
+3. Receive a summary with themes and insights
+4. Discuss specific points that interest you
+
+### Analyzing a File
+
+1. Use the attachment button to upload a file
+2. Ask Claude to analyze, summarize, or critique it
+3. The file path in your message lets Claude read the content
+4. Discuss findings in follow-up messages
+
+### Goal Review
+
+1. Tap the goals card on Ground (or type `/review-goals`)
+2. Claude reads your goals.md and recent activity
+3. Get assessment of progress and blockers
+4. Refine goals based on the discussion
+
+### Research Assistance
+
+1. Ask Claude about a topic
+2. Claude searches your vault for relevant notes
+3. Get synthesis of your existing knowledge
+4. Identify gaps and areas for further exploration
+
+## Tips
+
+- **Be specific**: Claude works better with focused questions than vague ones
+- **Use slash commands**: They're designed for common patterns
+- **Check tool output**: See what Claude is reading to understand its reasoning
+- **Continue conversations**: Context builds over a session
+- **Start fresh when stuck**: Sometimes a new session perspective helps


### PR DESCRIPTION
## Summary

- Add comprehensive user-facing documentation for each mode (Ground, Capture, Think, Recall)
- Update CLAUDE.md with mandatory documentation maintenance requirement
- Add documentation links to main README

## New Files

| File | Description |
|------|-------------|
| `docs/usage/README.md` | Usage guide index with quick start |
| `docs/usage/ground.md` | Ground tab: dashboard, debriefs, inspiration, goals |
| `docs/usage/capture.md` | Capture tab: quick notes, drafts, error handling |
| `docs/usage/think.md` | Think tab: AI chat, slash commands, sessions |
| `docs/usage/recall.md` | Recall tab: file tree, search, viewers, tasks |

## Image Placeholders

Docs contain `[ img: description ]` placeholders for future screenshots.

## Test plan

- [x] All files render correctly as markdown
- [x] Links between docs work
- [x] README links to new documentation

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)