### PR TITLE
fix: skip image transformation for paths inside inline code

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -49,16 +49,17 @@ function formatTime(date: Date): string {
 /**
  * Pattern to detect image paths in user messages.
  * Matches paths in common attachment directories.
- * Uses negative lookbehind to avoid matching paths inside markdown or URLs.
+ * Uses negative lookbehind to avoid matching paths inside markdown, URLs, or inline code.
  */
 const IMAGE_PATH_PATTERN =
-  /(?<![a-zA-Z0-9_\-/[])(?:05_Attachments|Attachments|attachments|assets|images)\/[\w.-]+\.(png|jpg|jpeg|gif|webp)/gi;
+  /(?<![a-zA-Z0-9_\-/[`])(?:05_Attachments|Attachments|attachments|assets|images)\/[\w.-]+\.(png|jpg|jpeg|gif|webp)/gi;
 
 /**
  * Pattern to detect Obsidian wiki-link image syntax.
  * Matches ![[path/to/image.ext]] format for images in any directory.
+ * Uses negative lookbehind to avoid matching syntax inside inline code.
  */
-const OBSIDIAN_IMAGE_PATTERN = /!\[\[([^\]]+\.(png|jpg|jpeg|gif|webp))\]\]/gi;
+const OBSIDIAN_IMAGE_PATTERN = /(?<!`)!\[\[([^\]]+\.(png|jpg|jpeg|gif|webp))\]\]/gi;
 
 /**
  * Transforms image references in content to markdown image syntax.

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -295,5 +295,37 @@ describe("MessageBubble", () => {
         expect(container.textContent).toContain("![[some/image.png]]");
       });
     });
+
+    describe("paths inside inline code", () => {
+      it("does not transform attachment paths inside backticks", () => {
+        const message = createMessage({
+          role: "assistant",
+          content: "The file is at `05_Attachments/screenshot.png`",
+        });
+
+        const { container } = render(<MessageBubble message={message} vaultId="test-vault" />);
+
+        const img = container.querySelector("img:not(.message-bubble__hr)");
+        expect(img).toBeNull();
+        const code = container.querySelector("code");
+        expect(code).not.toBeNull();
+        expect(code?.textContent).toBe("05_Attachments/screenshot.png");
+      });
+
+      it("does not transform wiki-link syntax inside backticks", () => {
+        const message = createMessage({
+          role: "assistant",
+          content: "Use `![[path/to/image.png]]` syntax",
+        });
+
+        const { container } = render(<MessageBubble message={message} vaultId="test-vault" />);
+
+        const img = container.querySelector("img:not(.message-bubble__hr)");
+        expect(img).toBeNull();
+        const code = container.querySelector("code");
+        expect(code).not.toBeNull();
+        expect(code?.textContent).toBe("![[path/to/image.png]]");
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Added backtick to negative lookbehind in `IMAGE_PATH_PATTERN` to skip attachment paths inside inline code
- Added negative lookbehind to `OBSIDIAN_IMAGE_PATTERN` to skip wiki-link syntax inside inline code
- Added test cases verifying paths inside backticks are not transformed

## Test plan
- [x] Existing MessageBubble tests pass (22 tests)
- [x] Full test suite passes (lint, typecheck, unit tests)
- [ ] Manual verification: AI response with backtick-wrapped path renders as code, not broken image

Fixes #297

🤖 Generated with [Claude Code](https://claude.ai/code)