### PR TITLE
feat: add AskUserQuestion tool for clarifying questions

### DIFF
--- a/backend/src/handlers/types.ts
+++ b/backend/src/handlers/types.ts
@@ -28,6 +28,14 @@ export interface PendingPermissionRequest {
 }
 
 /**
+ * Pending AskUserQuestion request, waiting for user answers.
+ */
+export interface PendingAskUserQuestionRequest {
+  resolve: (answers: Record<string, string>) => void;
+  reject: (error: Error) => void;
+}
+
+/**
  * Connection state for a WebSocket client.
  * Each connection tracks its selected vault and active session.
  */
@@ -40,6 +48,8 @@ export interface ConnectionState {
   activeQuery: SessionQueryResult | null;
   /** Pending tool permission requests, keyed by toolUseId */
   pendingPermissions: Map<string, PendingPermissionRequest>;
+  /** Pending AskUserQuestion requests, keyed by toolUseId */
+  pendingAskUserQuestions: Map<string, PendingAskUserQuestionRequest>;
   /** Search index manager for the current vault (null if no vault selected) */
   searchIndex: SearchIndexManager | null;
   /** Active model captured from SDK system/init event (null if not yet received) */
@@ -74,6 +84,7 @@ export function createConnectionState(): ConnectionState {
     currentSessionId: null,
     activeQuery: null,
     pendingPermissions: new Map(),
+    pendingAskUserQuestions: new Map(),
     searchIndex: null,
     activeModel: null,
     widgetEngine: null,

--- a/frontend/src/components/AskUserQuestionDialog.css
+++ b/frontend/src/components/AskUserQuestionDialog.css
@@ -1,0 +1,268 @@
+/**
+ * AskUserQuestionDialog Component Styles
+ *
+ * Glassmorphism dialog for AskUserQuestion tool.
+ * Displays 1-4 questions with multiple choice options.
+ */
+
+.ask-question__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-md);
+  background-color: var(--color-black-a60);
+  animation: ask-question-fade-in 0.2s ease;
+}
+
+@keyframes ask-question-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.ask-question {
+  width: 100%;
+  max-width: 560px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
+  border: 1px solid var(--glass-border-hover);
+  border-radius: var(--radius-xl);
+  box-shadow:
+    0 8px 40px var(--color-black-a50),
+    0 0 30px var(--color-accent-primary-a15),
+    inset 0 1px 0 var(--color-white-a10);
+  animation: ask-question-slide-up 0.2s ease;
+  overflow: hidden;
+}
+
+@keyframes ask-question-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.ask-question__header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-lg);
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.ask-question__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background: var(--gradient-primary);
+  border-radius: 50%;
+  font-size: 1.25rem;
+  font-weight: var(--font-weight-bold);
+  color: white;
+}
+
+.ask-question__title {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+}
+
+.ask-question__content {
+  flex: 1;
+  padding: var(--spacing-lg);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+/* Fieldset for each question */
+.ask-question__fieldset {
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.ask-question__legend {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-md);
+  width: 100%;
+}
+
+.ask-question__header-chip {
+  display: inline-block;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--color-accent-primary-a15);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  width: fit-content;
+}
+
+.ask-question__question-text {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  line-height: var(--line-height-relaxed);
+}
+
+/* Options container */
+.ask-question__options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+/* Individual option */
+.ask-question__option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.ask-question__option:hover {
+  background: var(--color-bg-tertiary);
+  border-color: var(--glass-border-hover);
+}
+
+.ask-question__option--selected {
+  background: var(--color-accent-primary-a15);
+  border-color: var(--color-accent-primary);
+}
+
+.ask-question__option--selected:hover {
+  background: var(--color-accent-primary-a15);
+}
+
+/* Hide native input, use custom styling */
+.ask-question__input {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin: 0;
+  margin-top: 0.125rem;
+  accent-color: var(--color-accent-primary);
+  cursor: pointer;
+}
+
+.ask-question__option-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  flex: 1;
+  min-width: 0;
+}
+
+.ask-question__option-label {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.ask-question__option-desc {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+}
+
+/* "Other" option specific styles */
+.ask-question__option--other .ask-question__option-content {
+  flex-direction: column;
+}
+
+.ask-question__other-input {
+  width: 100%;
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: var(--color-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.ask-question__other-input:focus {
+  border-color: var(--color-accent-primary);
+}
+
+.ask-question__other-input::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+/* Actions */
+.ask-question__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: flex-end;
+  padding: var(--spacing-lg);
+  border-top: 1px solid var(--glass-border);
+}
+
+.ask-question__btn {
+  min-height: 44px;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ask-question__btn--cancel {
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text);
+}
+
+.ask-question__btn--cancel:hover {
+  background-color: var(--color-border);
+}
+
+.ask-question__btn--submit {
+  background: var(--gradient-primary);
+  color: white;
+  transition: box-shadow 0.3s ease, transform 0.2s ease;
+}
+
+.ask-question__btn--submit:hover:not(:disabled) {
+  box-shadow: var(--glow-primary);
+}
+
+.ask-question__btn--submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.ask-question__btn:active:not(:disabled) {
+  transform: scale(0.98);
+}

--- a/frontend/src/components/AskUserQuestionDialog.tsx
+++ b/frontend/src/components/AskUserQuestionDialog.tsx
@@ -1,0 +1,336 @@
+/**
+ * AskUserQuestionDialog Component
+ *
+ * Displays a dialog for Claude's AskUserQuestion tool.
+ * Presents 1-4 questions with multiple choice options.
+ * Users can select from predefined options or enter custom text via "Other".
+ */
+
+import React, { useState, useId, useCallback, useEffect } from "react";
+import type { AskUserQuestionItem, AskUserQuestionOption } from "@memory-loop/shared";
+import "./AskUserQuestionDialog.css";
+
+export interface AskUserQuestionRequest {
+  toolUseId: string;
+  questions: AskUserQuestionItem[];
+}
+
+export interface AskUserQuestionDialogProps {
+  request: AskUserQuestionRequest | null;
+  onSubmit: (answers: Record<string, string>) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Tracks the selected answer(s) for a single question.
+ * For single-select: string value or empty
+ * For multi-select: comma-separated values or empty
+ */
+interface QuestionAnswer {
+  selectedOptions: string[];
+  otherText: string;
+  isOtherSelected: boolean;
+}
+
+/**
+ * Creates initial answer state for all questions.
+ */
+function createInitialAnswers(questions: AskUserQuestionItem[]): Record<string, QuestionAnswer> {
+  const answers: Record<string, QuestionAnswer> = {};
+  for (const q of questions) {
+    answers[q.question] = {
+      selectedOptions: [],
+      otherText: "",
+      isOtherSelected: false,
+    };
+  }
+  return answers;
+}
+
+/**
+ * Checks if a question has been answered.
+ */
+function isQuestionAnswered(answer: QuestionAnswer): boolean {
+  if (answer.isOtherSelected) {
+    return answer.otherText.trim().length > 0;
+  }
+  return answer.selectedOptions.length > 0;
+}
+
+/**
+ * Converts answer state to the format expected by the backend.
+ */
+function formatAnswers(answers: Record<string, QuestionAnswer>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [question, answer] of Object.entries(answers)) {
+    if (answer.isOtherSelected && answer.otherText.trim()) {
+      // Include "Other" selection with custom text
+      const otherParts = [...answer.selectedOptions, answer.otherText.trim()];
+      result[question] = otherParts.join(", ");
+    } else {
+      result[question] = answer.selectedOptions.join(", ");
+    }
+  }
+  return result;
+}
+
+export function AskUserQuestionDialog({
+  request,
+  onSubmit,
+  onCancel,
+}: AskUserQuestionDialogProps): React.ReactNode {
+  const titleId = useId();
+  const [answers, setAnswers] = useState<Record<string, QuestionAnswer>>({});
+
+  // Initialize answers when request changes
+  useEffect(() => {
+    if (request) {
+      setAnswers(createInitialAnswers(request.questions));
+    }
+  }, [request]);
+
+  const handleOptionChange = useCallback((
+    question: string,
+    optionLabel: string,
+    multiSelect: boolean
+  ) => {
+    setAnswers(prev => {
+      const current = prev[question];
+      if (!current) return prev;
+
+      let newSelectedOptions: string[];
+      if (multiSelect) {
+        // Toggle the option in multi-select mode
+        if (current.selectedOptions.includes(optionLabel)) {
+          newSelectedOptions = current.selectedOptions.filter(o => o !== optionLabel);
+        } else {
+          newSelectedOptions = [...current.selectedOptions, optionLabel];
+        }
+      } else {
+        // Replace selection in single-select mode
+        newSelectedOptions = [optionLabel];
+      }
+
+      return {
+        ...prev,
+        [question]: {
+          ...current,
+          selectedOptions: newSelectedOptions,
+          isOtherSelected: false, // Deselect "Other" when selecting a predefined option
+        },
+      };
+    });
+  }, []);
+
+  const handleOtherToggle = useCallback((question: string, multiSelect: boolean) => {
+    setAnswers(prev => {
+      const current = prev[question];
+      if (!current) return prev;
+
+      if (multiSelect) {
+        // Toggle "Other" in multi-select mode
+        return {
+          ...prev,
+          [question]: {
+            ...current,
+            isOtherSelected: !current.isOtherSelected,
+          },
+        };
+      } else {
+        // Select only "Other" in single-select mode
+        return {
+          ...prev,
+          [question]: {
+            ...current,
+            selectedOptions: [],
+            isOtherSelected: true,
+          },
+        };
+      }
+    });
+  }, []);
+
+  const handleOtherTextChange = useCallback((question: string, text: string) => {
+    setAnswers(prev => {
+      const current = prev[question];
+      if (!current) return prev;
+
+      return {
+        ...prev,
+        [question]: {
+          ...current,
+          otherText: text,
+        },
+      };
+    });
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    onSubmit(formatAnswers(answers));
+  }, [answers, onSubmit]);
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onCancel();
+    }
+  }, [onCancel]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      onCancel();
+    }
+  }, [onCancel]);
+
+  if (!request) return null;
+
+  // Check if all questions have been answered
+  const allAnswered = request.questions.every(q => {
+    const answer = answers[q.question];
+    return answer && isQuestionAnswered(answer);
+  });
+
+  return (
+    <div
+      className="ask-question__backdrop"
+      onClick={handleBackdropClick}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        className="ask-question"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+      >
+        <div className="ask-question__header">
+          <span className="ask-question__icon" aria-hidden="true">?</span>
+          <h2 id={titleId} className="ask-question__title">
+            Claude needs your input
+          </h2>
+        </div>
+
+        <div className="ask-question__content">
+          {request.questions.map((q, qIndex) => (
+            <QuestionSection
+              key={qIndex}
+              question={q}
+              answer={answers[q.question]}
+              onOptionChange={handleOptionChange}
+              onOtherToggle={handleOtherToggle}
+              onOtherTextChange={handleOtherTextChange}
+            />
+          ))}
+        </div>
+
+        <div className="ask-question__actions">
+          <button
+            type="button"
+            className="ask-question__btn ask-question__btn--cancel"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="ask-question__btn ask-question__btn--submit"
+            onClick={handleSubmit}
+            disabled={!allAnswered}
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renders a single question with its options.
+ */
+interface QuestionSectionProps {
+  question: AskUserQuestionItem;
+  answer: QuestionAnswer | undefined;
+  onOptionChange: (question: string, optionLabel: string, multiSelect: boolean) => void;
+  onOtherToggle: (question: string, multiSelect: boolean) => void;
+  onOtherTextChange: (question: string, text: string) => void;
+}
+
+function QuestionSection({
+  question,
+  answer,
+  onOptionChange,
+  onOtherToggle,
+  onOtherTextChange,
+}: QuestionSectionProps): React.ReactNode {
+  const groupId = useId();
+
+  if (!answer) return null;
+
+  const inputType = question.multiSelect ? "checkbox" : "radio";
+
+  return (
+    <fieldset className="ask-question__fieldset">
+      <legend className="ask-question__legend">
+        <span className="ask-question__header-chip">{question.header}</span>
+        <span className="ask-question__question-text">{question.question}</span>
+      </legend>
+
+      <div className="ask-question__options" role="group" aria-labelledby={groupId}>
+        {question.options.map((option: AskUserQuestionOption, optIndex: number) => {
+          const isSelected = answer.selectedOptions.includes(option.label);
+          const inputId = `${groupId}-opt-${optIndex}`;
+
+          return (
+            <label
+              key={optIndex}
+              className={`ask-question__option ${isSelected ? "ask-question__option--selected" : ""}`}
+              htmlFor={inputId}
+            >
+              <input
+                type={inputType}
+                id={inputId}
+                name={groupId}
+                checked={isSelected}
+                onChange={() => onOptionChange(question.question, option.label, question.multiSelect)}
+                className="ask-question__input"
+              />
+              <span className="ask-question__option-content">
+                <span className="ask-question__option-label">{option.label}</span>
+                {option.description && (
+                  <span className="ask-question__option-desc">{option.description}</span>
+                )}
+              </span>
+            </label>
+          );
+        })}
+
+        {/* "Other" option */}
+        <label
+          className={`ask-question__option ask-question__option--other ${answer.isOtherSelected ? "ask-question__option--selected" : ""}`}
+          htmlFor={`${groupId}-other`}
+        >
+          <input
+            type={inputType}
+            id={`${groupId}-other`}
+            name={groupId}
+            checked={answer.isOtherSelected}
+            onChange={() => onOtherToggle(question.question, question.multiSelect)}
+            className="ask-question__input"
+          />
+          <span className="ask-question__option-content">
+            <span className="ask-question__option-label">Other</span>
+            {answer.isOtherSelected && (
+              <input
+                type="text"
+                className="ask-question__other-input"
+                value={answer.otherText}
+                onChange={(e) => onOtherTextChange(question.question, e.target.value)}
+                placeholder="Enter your answer..."
+                autoFocus
+              />
+            )}
+          </span>
+        </label>
+      </div>
+    </fieldset>
+  );
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -134,6 +134,11 @@ export type {
   HealthIssue,
   HealthReportMessage,
   DismissHealthIssueMessage,
+  // AskUserQuestion types
+  AskUserQuestionOption,
+  AskUserQuestionItem,
+  AskUserQuestionResponseMessage,
+  AskUserQuestionRequestMessage,
   // Client message types
   SelectVaultMessage,
   CaptureNoteMessage,

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -521,6 +521,46 @@ export const ToolPermissionResponseMessageSchema = z.object({
   allowed: z.boolean(),
 });
 
+// =============================================================================
+// AskUserQuestion Schemas
+// =============================================================================
+
+/**
+ * Schema for a single option in an AskUserQuestion question
+ */
+export const AskUserQuestionOptionSchema = z.object({
+  /** Display text for this option */
+  label: z.string().min(1, "Option label is required"),
+  /** Description explaining what this option means */
+  description: z.string(),
+});
+
+/**
+ * Schema for a single question in an AskUserQuestion request
+ */
+export const AskUserQuestionItemSchema = z.object({
+  /** The full question text to display */
+  question: z.string().min(1, "Question text is required"),
+  /** Short label for the question (max 12 chars) */
+  header: z.string().max(12, "Header must be 12 characters or less"),
+  /** Available choices (2-4 options) */
+  options: z.array(AskUserQuestionOptionSchema).min(2).max(4),
+  /** If true, users can select multiple options */
+  multiSelect: z.boolean(),
+});
+
+/**
+ * Client responds to an AskUserQuestion request
+ * Sent in response to ask_user_question_request from server
+ */
+export const AskUserQuestionResponseMessageSchema = z.object({
+  type: z.literal("ask_user_question_response"),
+  /** The tool use ID from the request */
+  toolUseId: z.string().min(1, "Tool use ID is required"),
+  /** Map of question text to selected answer(s) */
+  answers: z.record(z.string(), z.string()),
+});
+
 /**
  * Client requests to run vault setup (install commands, create PARA dirs, update CLAUDE.md)
  */
@@ -666,6 +706,7 @@ export const ClientMessageSchema = z.discriminatedUnion("type", [
   ToggleTaskMessageSchema,
   DeleteSessionMessageSchema,
   ToolPermissionResponseMessageSchema,
+  AskUserQuestionResponseMessageSchema,
   SetupVaultMessageSchema,
   SearchFilesMessageSchema,
   SearchContentMessageSchema,
@@ -901,6 +942,18 @@ export const ToolPermissionRequestMessageSchema = z.object({
 });
 
 /**
+ * Server requests user input via AskUserQuestion tool
+ * The client should display a multi-question dialog and respond with ask_user_question_response
+ */
+export const AskUserQuestionRequestMessageSchema = z.object({
+  type: z.literal("ask_user_question_request"),
+  /** Unique identifier for this tool invocation */
+  toolUseId: z.string().min(1, "Tool use ID is required"),
+  /** Array of questions to present to the user (1-4 questions) */
+  questions: z.array(AskUserQuestionItemSchema).min(1).max(4),
+});
+
+/**
  * Server reports vault setup completion (commands installed, PARA created, CLAUDE.md updated)
  */
 export const SetupCompleteMessageSchema = z.object({
@@ -1115,6 +1168,7 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
   TaskToggledMessageSchema,
   SessionDeletedMessageSchema,
   ToolPermissionRequestMessageSchema,
+  AskUserQuestionRequestMessageSchema,
   SetupCompleteMessageSchema,
   SearchResultsMessageSchema,
   SnippetsMessageSchema,
@@ -1203,6 +1257,9 @@ export type GetTasksMessage = z.infer<typeof GetTasksMessageSchema>;
 export type ToggleTaskMessage = z.infer<typeof ToggleTaskMessageSchema>;
 export type DeleteSessionMessage = z.infer<typeof DeleteSessionMessageSchema>;
 export type ToolPermissionResponseMessage = z.infer<typeof ToolPermissionResponseMessageSchema>;
+export type AskUserQuestionOption = z.infer<typeof AskUserQuestionOptionSchema>;
+export type AskUserQuestionItem = z.infer<typeof AskUserQuestionItemSchema>;
+export type AskUserQuestionResponseMessage = z.infer<typeof AskUserQuestionResponseMessageSchema>;
 export type SetupVaultMessage = z.infer<typeof SetupVaultMessageSchema>;
 export type SearchFilesMessage = z.infer<typeof SearchFilesMessageSchema>;
 export type SearchContentMessage = z.infer<typeof SearchContentMessageSchema>;
@@ -1241,6 +1298,7 @@ export type TasksMessage = z.infer<typeof TasksMessageSchema>;
 export type TaskToggledMessage = z.infer<typeof TaskToggledMessageSchema>;
 export type SessionDeletedMessage = z.infer<typeof SessionDeletedMessageSchema>;
 export type ToolPermissionRequestMessage = z.infer<typeof ToolPermissionRequestMessageSchema>;
+export type AskUserQuestionRequestMessage = z.infer<typeof AskUserQuestionRequestMessageSchema>;
 export type SetupCompleteMessage = z.infer<typeof SetupCompleteMessageSchema>;
 export type SearchResultsMessage = z.infer<typeof SearchResultsMessageSchema>;
 export type SnippetsMessage = z.infer<typeof SnippetsMessageSchema>;


### PR DESCRIPTION
## Summary
- Implements Claude's AskUserQuestion tool allowing Claude to present 1-4 multiple-choice questions during conversations
- Users can select from predefined options or provide custom "Other" text input
- Supports both single-select (radio) and multi-select (checkbox) modes

## Changes
- **Protocol**: Added schemas for `ask_user_question_request` (server→client) and `ask_user_question_response` (client→server)
- **Backend**: Route AskUserQuestion tool calls through session-manager with Promise-based WebSocket callback
- **Frontend**: New `AskUserQuestionDialog` component with glassmorphism styling matching existing patterns
- **Tests**: 44 new unit tests for schema validation

## Test plan
- [x] All AskUserQuestion schema tests pass (44 tests)
- [x] TypeScript compilation passes
- [x] ESLint passes
- [ ] Manual testing with Claude invoking AskUserQuestion tool

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)