### PR TITLE
feat: add vault order config for custom display ordering

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,8 +7,8 @@
     "dev": "bun run --watch src/index.ts",
     "build": "tsc --noEmit",
     "start": "bun run src/index.ts",
-    "test": "for f in src/__tests__/*.test.ts; do bun test \"$f\" || exit 1; done",
-    "test:unit": "for f in src/__tests__/*.test.ts; do bun test \"$f\" || exit 1; done",
+    "test": "export LOG_LEVEL=silent && for f in src/__tests__/*.test.ts; do bun test \"$f\" || exit 1; done",
+    "test:unit": "export LOG_LEVEL=silent && for f in src/__tests__/*.test.ts; do bun test \"$f\" || exit 1; done",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ."
   },

--- a/backend/src/__tests__/note-capture.test.ts
+++ b/backend/src/__tests__/note-capture.test.ts
@@ -579,6 +579,7 @@ describe("captureToDaily Integration", () => {
       maxPoolSize: 50,
       quotesPerWeek: 1,
       badges: [],
+      order: 999999,
     };
   });
 
@@ -808,6 +809,7 @@ describe("Edge Cases", () => {
       maxPoolSize: 50,
       quotesPerWeek: 1,
       badges: [],
+      order: 999999,
     };
   });
 

--- a/backend/src/__tests__/session-manager.test.ts
+++ b/backend/src/__tests__/session-manager.test.ts
@@ -53,13 +53,14 @@ function createMockVault(overrides: Partial<VaultInfo> = {}): VaultInfo {
     contentRoot,
     inboxPath: "00_Inbox",
     metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+    attachmentPath: "05_Attachments",
     setupComplete: false,
     promptsPerGeneration: 5,
     maxPoolSize: 50,
     quotesPerWeek: 1,
     badges: [],
     ...overrides,
+    order: overrides.order ?? 999999,
   };
 }
 

--- a/backend/src/__tests__/test-helpers.ts
+++ b/backend/src/__tests__/test-helpers.ts
@@ -29,5 +29,7 @@ export function createMockVault(overrides: Partial<VaultInfo> = {}): VaultInfo {
     quotesPerWeek: 1,
     badges: [],
     ...overrides,
+    // Ensure order is always a number (Partial<VaultInfo> allows undefined)
+    order: overrides.order ?? 999999,
   };
 }

--- a/backend/src/__tests__/vault-manager.test.ts
+++ b/backend/src/__tests__/vault-manager.test.ts
@@ -623,12 +623,13 @@ describe("Filesystem Integration", () => {
         contentRoot: "/vaults/test-vault",
         inboxPath: "00_Inbox",
         metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+        attachmentPath: "05_Attachments",
         setupComplete: false,
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
         badges: [],
+        order: 999999,
       };
 
       expect(getVaultInboxPath(vault)).toBe("/vaults/test-vault/00_Inbox");
@@ -643,12 +644,13 @@ describe("Filesystem Integration", () => {
         contentRoot: "/vaults/test-vault",
         inboxPath: "Custom/Inbox",
         metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+        attachmentPath: "05_Attachments",
         setupComplete: false,
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
         badges: [],
+        order: 999999,
       };
 
       expect(getVaultInboxPath(vault)).toBe("/vaults/test-vault/Custom/Inbox");
@@ -663,12 +665,13 @@ describe("Filesystem Integration", () => {
         contentRoot: "/vaults/test-vault/content",
         inboxPath: "00_Inbox",
         metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+        attachmentPath: "05_Attachments",
         setupComplete: false,
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
         badges: [],
+        order: 999999,
       };
 
       expect(getVaultInboxPath(vault)).toBe("/vaults/test-vault/content/00_Inbox");
@@ -852,13 +855,14 @@ describe("Goals Feature", () => {
         contentRoot: testDir,
         inboxPath: "00_Inbox",
         metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+        attachmentPath: "05_Attachments",
         goalsPath: undefined,
         setupComplete: false,
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
         badges: [],
+        order: 999999,
       };
 
       const goals = await getVaultGoals(vault);
@@ -892,6 +896,7 @@ describe("Goals Feature", () => {
         maxPoolSize: 50,
         quotesPerWeek: 1,
         badges: [],
+        order: 999999,
       };
 
       const content = await getVaultGoals(vault);
@@ -907,13 +912,14 @@ describe("Goals Feature", () => {
         contentRoot: testDir,
         inboxPath: "00_Inbox",
         metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+        attachmentPath: "05_Attachments",
         goalsPath: GOALS_FILE_PATH,
         setupComplete: false,
         promptsPerGeneration: 5,
         maxPoolSize: 50,
         quotesPerWeek: 1,
         badges: [],
+        order: 999999,
       };
 
       const goals = await getVaultGoals(vault);

--- a/backend/src/__tests__/websocket-handler.test.ts
+++ b/backend/src/__tests__/websocket-handler.test.ts
@@ -425,13 +425,14 @@ function createMockVault(overrides: Partial<VaultInfo> = {}): VaultInfo {
     contentRoot,
     inboxPath: "00_Inbox",
     metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+    attachmentPath: "05_Attachments",
     setupComplete: false,
     promptsPerGeneration: 5,
     maxPoolSize: 50,
     quotesPerWeek: 1,
     badges: [],
     ...overrides,
+    order: overrides.order ?? 999999,
   };
 }
 
@@ -1253,7 +1254,8 @@ describe("WebSocket Handler", () => {
         "first-session",
         "Second message",
         undefined, // no extra options
-        expect.any(Function) // tool permission callback
+        expect.any(Function), // tool permission callback
+        expect.any(Function) // askUserQuestion callback
       );
     });
 

--- a/backend/src/vault-config.ts
+++ b/backend/src/vault-config.ts
@@ -135,6 +135,14 @@ export interface VaultConfig {
    * Default: "opus"
    */
   discussionModel?: string;
+
+  /**
+   * Display order for vault selection screen.
+   * Vaults are grouped by order value, then sorted alphabetically within each group.
+   * Lower values appear first. Vaults without order are placed last.
+   * Default: Infinity (sorted last)
+   */
+  order?: number;
 }
 
 /**
@@ -196,6 +204,13 @@ export type DiscussionModel = (typeof VALID_DISCUSSION_MODELS)[number];
  * Default model for Discussion mode.
  */
 export const DEFAULT_DISCUSSION_MODEL: DiscussionModel = "opus";
+
+/**
+ * Default order for vaults without explicit order.
+ * Uses a large number so unordered vaults sort last.
+ * Note: Cannot use Infinity as it's not JSON-serializable.
+ */
+export const DEFAULT_ORDER = 999999;
 
 /**
  * Valid badge color names.
@@ -297,6 +312,11 @@ export async function loadVaultConfig(vaultPath: string): Promise<VaultConfig> {
       VALID_DISCUSSION_MODELS.includes(obj.discussionModel as typeof VALID_DISCUSSION_MODELS[number])
     ) {
       config.discussionModel = obj.discussionModel;
+    }
+
+    // Validate order (must be a finite number)
+    if (typeof obj.order === "number" && Number.isFinite(obj.order)) {
+      config.order = obj.order;
     }
 
     // Validate badges array
@@ -509,6 +529,16 @@ export function resolveRecentDiscussions(config: VaultConfig): number {
  */
 export function resolveDiscussionModel(config: VaultConfig): DiscussionModel {
   return (config.discussionModel as DiscussionModel | undefined) ?? DEFAULT_DISCUSSION_MODEL;
+}
+
+/**
+ * Resolves the display order for vault selection.
+ *
+ * @param config - Vault configuration
+ * @returns Order value (default: Infinity, sorts last)
+ */
+export function resolveOrder(config: VaultConfig): number {
+  return config.order ?? DEFAULT_ORDER;
 }
 
 /**

--- a/backend/src/vault-manager.ts
+++ b/backend/src/vault-manager.ts
@@ -22,6 +22,7 @@ import {
   resolveRecentDiscussions,
   resolveDiscussionModel,
   resolveBadges,
+  resolveOrder,
   type VaultConfig,
 } from "./vault-config";
 
@@ -320,6 +321,7 @@ export async function parseVault(
     recentCaptures: resolveRecentCaptures(config),
     recentDiscussions: resolveRecentDiscussions(config),
     badges: resolveBadges(config),
+    order: resolveOrder(config),
   };
 }
 
@@ -388,8 +390,13 @@ export async function discoverVaults(): Promise<VaultInfo[]> {
     }
   }
 
-  // Sort vaults by name for consistent ordering
-  vaults.sort((a, b) => a.name.localeCompare(b.name));
+  // Sort vaults by order first (lower values first), then alphabetically by name
+  vaults.sort((a, b) => {
+    if (a.order !== b.order) {
+      return a.order - b.order;
+    }
+    return a.name.localeCompare(b.name);
+  });
 
   log.info(`Discovery complete: ${vaults.length} vault(s) found`);
   return vaults;

--- a/frontend/src/components/VaultSelect.tsx
+++ b/frontend/src/components/VaultSelect.tsx
@@ -6,7 +6,7 @@
  * Uses API to check for existing sessions before connecting.
  */
 
-import { useEffect, useState, useRef, useCallback } from "react";
+import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import type { VaultInfo } from "@memory-loop/shared";
 import { useSession, STORAGE_KEY_VAULT } from "../contexts/SessionContext";
 import { useWebSocket } from "../hooks/useWebSocket";
@@ -64,6 +64,17 @@ export function VaultSelect({ onReady }: VaultSelectProps): React.ReactNode {
   const hasAttemptedAutoResumeRef = useRef(false);
   // Track the last processed setup_complete vaultId to prevent re-processing
   const lastProcessedSetupVaultIdRef = useRef<string | null>(null);
+
+  // Sort vaults by order (lower first), then alphabetically by name
+  // This ensures consistent display even if backend doesn't pre-sort
+  const sortedVaults = useMemo(() => {
+    return [...vaults].sort((a, b) => {
+      if (a.order !== b.order) {
+        return a.order - b.order;
+      }
+      return a.name.localeCompare(b.name);
+    });
+  }, [vaults]);
 
   // Fetch vaults on mount
   useEffect(() => {
@@ -451,7 +462,7 @@ export function VaultSelect({ onReady }: VaultSelectProps): React.ReactNode {
       )}
 
       <ul className="vault-select__list" role="listbox" aria-label="Available vaults">
-        {vaults.map((vault) => (
+        {sortedVaults.map((vault) => (
           <li key={vault.id}>
             <div
               className={`vault-select__card ${

--- a/frontend/src/components/__tests__/BrowseMode.images.test.tsx
+++ b/frontend/src/components/__tests__/BrowseMode.images.test.tsx
@@ -67,6 +67,7 @@ const mockVault: VaultInfo = {
   maxPoolSize: 50,
   quotesPerWeek: 1,
   badges: [],
+  order: 999999,
 };
 
 function TestWrapper({ children }: { children: ReactNode }) {

--- a/frontend/src/components/__tests__/Discussion.test.tsx
+++ b/frontend/src/components/__tests__/Discussion.test.tsx
@@ -72,12 +72,13 @@ const testVault: VaultInfo = {
   contentRoot: "/test/vault",
   inboxPath: "inbox",
   metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+  attachmentPath: "05_Attachments",
   setupComplete: false,
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
   badges: [],
+  order: 999999,
 };
 
 function TestWrapper({ children }: { children: ReactNode }) {

--- a/frontend/src/components/__tests__/HealthPanel.test.tsx
+++ b/frontend/src/components/__tests__/HealthPanel.test.tsx
@@ -64,6 +64,7 @@ const testVault: VaultInfo = {
   maxPoolSize: 50,
   quotesPerWeek: 1,
   badges: [],
+  order: 999999,
 };
 
 beforeEach(() => {

--- a/frontend/src/components/__tests__/InspirationCard.test.tsx
+++ b/frontend/src/components/__tests__/InspirationCard.test.tsx
@@ -20,12 +20,13 @@ const testVault: VaultInfo = {
   contentRoot: "/test/vault",
   inboxPath: "inbox",
   metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+  attachmentPath: "05_Attachments",
   setupComplete: false,
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
   badges: [],
+  order: 999999,
 };
 
 const mockContextual: InspirationItem = {

--- a/frontend/src/components/__tests__/NoteCapture.test.tsx
+++ b/frontend/src/components/__tests__/NoteCapture.test.tsx
@@ -72,12 +72,13 @@ const testVault: VaultInfo = {
   contentRoot: "/test/vault",
   inboxPath: "inbox",
   metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+  attachmentPath: "05_Attachments",
   setupComplete: false,
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
   badges: [],
+  order: 999999,
 };
 
 // Wrapper with providers - vault is pre-selected via localStorage

--- a/frontend/src/components/__tests__/RecentActivity.test.tsx
+++ b/frontend/src/components/__tests__/RecentActivity.test.tsx
@@ -31,12 +31,13 @@ const testVault: VaultInfo = {
   contentRoot: "/test/vault",
   inboxPath: "inbox",
   metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+  attachmentPath: "05_Attachments",
   setupComplete: false,
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
   badges: [],
+  order: 999999,
 };
 
 const mockCaptures: RecentNoteEntry[] = [

--- a/frontend/src/components/__tests__/VaultSelect.test.tsx
+++ b/frontend/src/components/__tests__/VaultSelect.test.tsx
@@ -77,6 +77,7 @@ const testVaults: VaultInfo[] = [
     maxPoolSize: 50,
     quotesPerWeek: 1,
     badges: [],
+    order: 999999,
   },
   {
     id: "vault-2",
@@ -92,6 +93,7 @@ const testVaults: VaultInfo[] = [
     maxPoolSize: 50,
     quotesPerWeek: 1,
     badges: [],
+    order: 999999,
   },
 ];
 
@@ -178,7 +180,7 @@ describe("VaultSelect", () => {
           contentRoot: "/home/user/vault",
           inboxPath: "inbox",
           metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+          attachmentPath: "05_Attachments",
           setupComplete: false,
           promptsPerGeneration: 5,
           maxPoolSize: 50,
@@ -187,6 +189,7 @@ describe("VaultSelect", () => {
             { text: "Work", color: "blue" },
             { text: "Personal", color: "green" },
           ],
+          order: 999999,
         },
       ];
       mockFetchResponse = {
@@ -219,12 +222,13 @@ describe("VaultSelect", () => {
           contentRoot: "/home/user/vault",
           inboxPath: "inbox",
           metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+          attachmentPath: "05_Attachments",
           setupComplete: true,
           promptsPerGeneration: 5,
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [{ text: "Custom", color: "purple" }],
+          order: 999999,
         },
       ];
       mockFetchResponse = {
@@ -270,6 +274,7 @@ describe("VaultSelect", () => {
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [],
+          order: 999999,
         },
       ];
       mockFetchResponse = {
@@ -306,6 +311,7 @@ describe("VaultSelect", () => {
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [],
+          order: 999999,
         },
       ];
       mockFetchResponse = {
@@ -592,6 +598,7 @@ describe("VaultSelect", () => {
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [],
+          order: 999999,
         },
       ];
 
@@ -626,6 +633,7 @@ describe("VaultSelect", () => {
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [],
+          order: 999999,
         },
       ];
 
@@ -675,6 +683,7 @@ describe("VaultSelect", () => {
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [],
+          order: 999999,
         },
       ];
 
@@ -717,6 +726,7 @@ describe("VaultSelect", () => {
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [],
+          order: 999999,
         },
       ];
 
@@ -769,6 +779,7 @@ describe("VaultSelect", () => {
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [],
+          order: 999999,
         },
       ];
 
@@ -823,6 +834,7 @@ describe("VaultSelect", () => {
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [],
+          order: 999999,
         },
       ];
 
@@ -897,6 +909,7 @@ describe("VaultSelect", () => {
           maxPoolSize: 50,
           quotesPerWeek: 1,
           badges: [],
+          order: 999999,
         },
       ];
 

--- a/frontend/src/contexts/__tests__/SessionContext.test.tsx
+++ b/frontend/src/contexts/__tests__/SessionContext.test.tsx
@@ -42,12 +42,13 @@ const testVault: VaultInfo = {
   contentRoot: "/path/to/vault",
   inboxPath: "inbox",
   metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+  attachmentPath: "05_Attachments",
   setupComplete: false,
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
   badges: [],
+  order: 999999,
 };
 
 const testVault2: VaultInfo = {
@@ -58,12 +59,13 @@ const testVault2: VaultInfo = {
   contentRoot: "/path/to/vault2",
   inboxPath: "inbox",
   metadataPath: "06_Metadata/memory-loop",
-      attachmentPath: "05_Attachments",
+  attachmentPath: "05_Attachments",
   setupComplete: false,
   promptsPerGeneration: 5,
   maxPoolSize: 50,
   quotesPerWeek: 1,
   badges: [],
+  order: 999999,
 };
 
 describe("SessionContext", () => {

--- a/frontend/src/hooks/__tests__/useWebSocket.test.ts
+++ b/frontend/src/hooks/__tests__/useWebSocket.test.ts
@@ -262,6 +262,7 @@ describe("useWebSocket", () => {
             maxPoolSize: 50,
             quotesPerWeek: 1,
             badges: [],
+            order: 999999,
           },
         ],
       };

--- a/frontend/src/test-helpers.ts
+++ b/frontend/src/test-helpers.ts
@@ -29,5 +29,7 @@ export function createMockVault(overrides: Partial<VaultInfo> = {}): VaultInfo {
     quotesPerWeek: 1,
     badges: [],
     ...overrides,
+    // Ensure order is always a number (Partial<VaultInfo> allows undefined)
+    order: overrides.order ?? 999999,
   };
 }

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -94,6 +94,7 @@ export const VaultInfoSchema = z.object({
   recentCaptures: z.number().int().positive().optional(),
   recentDiscussions: z.number().int().positive().optional(),
   badges: z.array(BadgeSchema),
+  order: z.number(), // Can be Infinity for unset vaults
 });
 
 // =============================================================================

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -48,6 +48,7 @@ export interface Badge {
  * @property maxPoolSize - Maximum items to keep in inspiration pools (default: 50)
  * @property quotesPerWeek - Number of quotes to generate per week (default: 1)
  * @property badges - Custom badges configured in .memory-loop.json
+ * @property order - Display order for vault selection (lower values first, Infinity for unset)
  */
 export interface VaultInfo {
   id: string;
@@ -68,6 +69,7 @@ export interface VaultInfo {
   recentCaptures?: number;
   recentDiscussions?: number;
   badges: Badge[];
+  order: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `order` field to vault configuration (`.memory-loop.yml`) for custom display ordering
- Vaults grouped by order value (lower first), then sorted alphabetically within groups
- Vaults without explicit order default to 999999 (appearing last)
- Add LOG_LEVEL support to logger for cleaner test output

## Test plan
- [x] All backend tests pass
- [x] All frontend tests pass
- [x] Typecheck passes
- [ ] Manual test: Set different order values in vault configs and verify display order

🤖 Generated with [Claude Code](https://claude.ai/code)