### PR TITLE
feat: add order field to vault config editor

### DIFF
--- a/backend/src/vault-config.ts
+++ b/backend/src/vault-config.ts
@@ -594,7 +594,8 @@ function isAllDefaults(config: EditableVaultConfig): boolean {
     config.quotesPerWeek === undefined &&
     config.recentCaptures === undefined &&
     config.recentDiscussions === undefined &&
-    (config.badges === undefined || config.badges.length === 0)
+    (config.badges === undefined || config.badges.length === 0) &&
+    config.order === undefined
   );
 }
 
@@ -670,6 +671,9 @@ export async function saveVaultConfig(
     }
     if (editableConfig.badges !== undefined) {
       mergedConfig.badges = editableConfig.badges;
+    }
+    if (editableConfig.order !== undefined) {
+      mergedConfig.order = editableConfig.order;
     }
 
     // Write merged config back to file

--- a/frontend/src/components/ConfigEditorDialog.css
+++ b/frontend/src/components/ConfigEditorDialog.css
@@ -277,6 +277,17 @@
   color: var(--color-text-accent-secondary);
 }
 
+.config-editor__input--narrow {
+  width: 120px;
+}
+
+.config-editor__field-hint {
+  margin: 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-accent-secondary);
+  line-height: var(--line-height-normal);
+}
+
 .config-editor__select {
   width: 100%;
   min-height: 44px;

--- a/frontend/src/components/ConfigEditorDialog.tsx
+++ b/frontend/src/components/ConfigEditorDialog.tsx
@@ -53,6 +53,7 @@ export interface EditableVaultConfig {
   recentCaptures?: number; // 1-20
   recentDiscussions?: number; // 1-20
   badges?: Badge[]; // max 5
+  order?: number; // display order on vault selection screen
 }
 
 export interface ConfigEditorDialogProps {
@@ -83,6 +84,7 @@ function hasConfigChanged(
   if (initial.quotesPerWeek !== current.quotesPerWeek) return true;
   if (initial.recentCaptures !== current.recentCaptures) return true;
   if (initial.recentDiscussions !== current.recentDiscussions) return true;
+  if (initial.order !== current.order) return true;
 
   // Compare badges array
   const initialBadges = initial.badges ?? [];
@@ -328,6 +330,7 @@ export function ConfigEditorDialog({
   const dialogTitleId = useId();
   const titleInputId = useId();
   const subtitleInputId = useId();
+  const orderInputId = useId();
   const discussionModelId = useId();
 
   // Slider field IDs for accessibility
@@ -492,6 +495,31 @@ export function ConfigEditorDialog({
                   }
                   placeholder="A brief description"
                 />
+              </div>
+              <div className="config-editor__field">
+                <label
+                  htmlFor={orderInputId}
+                  className="config-editor__label"
+                >
+                  Display Order
+                </label>
+                <input
+                  id={orderInputId}
+                  type="number"
+                  className="config-editor__input config-editor__input--narrow"
+                  value={formState.order ?? ""}
+                  onChange={(e) =>
+                    setFormState((prev) => ({
+                      ...prev,
+                      order: e.target.value ? parseInt(e.target.value, 10) : undefined,
+                    }))
+                  }
+                  placeholder="Auto"
+                  min={1}
+                />
+                <p className="config-editor__field-hint">
+                  Lower numbers appear first. Leave empty to sort last.
+                </p>
               </div>
               <div className="config-editor__field">
                 <label className="config-editor__label">Badges</label>

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -66,6 +66,7 @@ export const EditableVaultConfigSchema = z.object({
   recentCaptures: z.number().int().min(1).max(20).optional(),
   recentDiscussions: z.number().int().min(1).max(20).optional(),
   badges: z.array(EditableBadgeSchema).max(5).optional(),
+  order: z.number().int().min(1).optional(),
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds `order` field to ConfigEditorDialog for editing vault display order
- Updates shared protocol schema with validation (integer, min 1)
- Updates backend to persist and load `order` field in vault config

## Test plan
- [x] TypeScript type checking passes across all workspaces
- [x] Backend vault-config tests pass (153 tests)
- [x] Frontend ConfigEditorDialog tests pass (59 tests)
- [ ] Manual: Open vault settings, set order value, verify it saves and affects sort order

🤖 Generated with [Claude Code](https://claude.ai/code)