### PR TITLE
fix: pass order field to config editor initialConfig

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -189,6 +189,7 @@ function MainContent(): React.ReactNode {
             recentCaptures: vault.recentCaptures,
             recentDiscussions: vault.recentDiscussions,
             badges: vault.badges,
+            order: vault.order === Infinity ? undefined : vault.order,
           }}
           onSave={handleConfigSave}
           onCancel={handleConfigCancel}

--- a/frontend/src/components/VaultSelect.tsx
+++ b/frontend/src/components/VaultSelect.tsx
@@ -572,6 +572,7 @@ export function VaultSelect({ onReady }: VaultSelectProps): React.ReactNode {
             recentCaptures: configEditorVault.recentCaptures,
             recentDiscussions: configEditorVault.recentDiscussions,
             badges: configEditorVault.badges,
+            order: configEditorVault.order === Infinity ? undefined : configEditorVault.order,
           }}
           onSave={handleConfigSave}
           onCancel={handleConfigCancel}


### PR DESCRIPTION
## Summary
- Fixed the display order field not loading from saved config in the vault settings editor
- The `order` field was missing from `initialConfig` prop in both `App.tsx` and `VaultSelect.tsx`
- Converts `Infinity` (sentinel for "unset") to `undefined` so the UI shows "Auto" placeholder correctly

## Test plan
- [ ] Open vault settings for a vault with a saved display order value
- [ ] Verify the order field shows the saved number instead of "Auto"
- [ ] Verify vaults without a saved order still show "Auto"

🤖 Generated with [Claude Code](https://claude.com/claude-code)