### PR TITLE
docs: add meeting capture mode documentation

### DIFF
--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -9,7 +9,7 @@ Memory Loop is organized around four tabs, each designed for a specific mode of 
 | Tab | Icon | Purpose | Use when... |
 |-----|------|---------|-------------|
 | [Ground](./ground.md) | 🪨 | Home dashboard | Starting your session, checking goals, accessing recent activity |
-| [Capture](./capture.md) | 🪶 | Quick note entry | Capturing a thought quickly without friction |
+| [Capture](./capture.md) | 🪶 | Quick note entry | Capturing thoughts, running meeting sessions |
 | [Think](./think.md) | ✨ | AI conversation | Exploring ideas, running commands, analyzing notes |
 | [Recall](./recall.md) | 🪞 | File browsing | Reading notes, searching, editing, reviewing tasks |
 
@@ -38,6 +38,13 @@ Each tab maintains its state when you switch away. Your draft messages, scroll p
 1. Throughout the day, use **Capture** for quick thoughts
 2. End the day on **Ground** and tap **Daily Debrief**
 3. **Think** summarizes your captures and surfaces themes
+
+### Meeting Notes Flow
+
+1. Start a meeting in **Capture** with a title
+2. Capture notes throughout the meeting
+3. Stop the meeting to auto-transition to **Think**
+4. Run `/expand-note` to transform raw notes into coherent documentation
 
 ### Read Then Discuss
 

--- a/docs/usage/capture.md
+++ b/docs/usage/capture.md
@@ -123,9 +123,107 @@ The whole interaction takes seconds.
 3. Timestamps create a natural flow record
 4. Review later to find patterns
 
+## Meeting Capture Mode
+
+For focused sessions like meetings, 1-on-1s, or brainstorming, you can start a **Meeting** that routes all captures to a dedicated file instead of your daily note.
+
+[ img: Start Meeting button next to Capture Note button ]
+
+### Starting a Meeting
+
+1. Tap **Start Meeting** on the Capture tab
+2. Enter a descriptive title (e.g., "Q3 Planning with Sarah")
+3. Tap **Start Meeting** to confirm
+
+The title becomes part of the filename and appears in the file's frontmatter.
+
+[ img: Meeting title prompt dialog ]
+
+### Capturing During a Meeting
+
+Once a meeting starts:
+
+- The interface shows a **meeting status bar** with the title and a pulsing indicator
+- The placeholder text changes to "Capturing to: [title]"
+- The submit button changes to **Add Note**
+- All captures go to the meeting file with `[HH:MM]` timestamps
+
+[ img: Capture tab during active meeting with status bar ]
+
+Capture entries appear as timestamped bullets in the meeting file:
+
+```markdown
+## Capture
+
+- [10:42] Sarah raised concern about QA capacity
+- [10:45] May need to push timeline
+- [10:52] Decided to check with Mark first
+```
+
+### Meeting State Persistence
+
+Meeting state persists across tab switches and reconnections. You can:
+
+- Switch to other tabs and return to Capture
+- Have the connection drop and reconnect
+- Close and reopen the browser
+
+The meeting remains active until you explicitly stop it.
+
+### Stopping a Meeting
+
+Tap **Stop Meeting** in the status bar. This:
+
+1. Finalizes the meeting file
+2. Shows how many notes were captured
+3. Automatically switches to the **Think** tab
+4. Pre-fills `/expand-note [path]` ready to run
+
+The `/expand-note` command helps transform your raw captures into coherent meeting notes. See [Think Tab](./think.md) for details on this command.
+
+[ img: Think tab with expand-note command pre-filled ]
+
+### Meeting File Format
+
+Meeting files are stored in `{inbox}/meetings/` with this structure:
+
+**Filename:** `YYYY-MM-DD-title-slug.md`
+
+**Content:**
+```markdown
+---
+date: 2026-01-15
+title: "Q3 Planning with Sarah"
+attendees: []
+---
+
+# Q3 Planning with Sarah
+
+## Capture
+
+- [10:42] Sarah raised concern about QA capacity
+- [10:45] May need to push timeline
+...
+```
+
+The `attendees` field in frontmatter starts empty. You can populate it later when expanding notes or via direct editing in Recall.
+
+### When to Use Meeting Mode
+
+**Use meeting mode when:**
+- Notes belong together as one logical session
+- You'll want to expand or summarize them afterward
+- Attendees or meeting metadata matter
+
+**Use regular capture when:**
+- Thoughts are independent, not part of a session
+- You just want them in your daily note stream
+- No need for post-meeting processing
+
 ## Tips
 
 - **Keep it short**: Capture is for quick notes, not essays
 - **Use Think for analysis**: If you want AI engagement, use Think instead
 - **Review in Recall**: Tap "View" on recent captures to see full context
 - **Use Daily Debrief**: Let the AI summarize your day's captures
+- **Use Meeting mode for sessions**: Keep related notes together in one file

--- a/docs/usage/think.md
+++ b/docs/usage/think.md
@@ -66,6 +66,7 @@ Your vault's `CLAUDE.md` file defines available commands. Common examples:
 | `/weekly-debrief` | Review the past week's activity |
 | `/monthly-summary YYYY MM` | Generate a monthly overview |
 | `/review-goals` | Analyze goals against recent progress |
+| `/expand-note <path>` | Transform raw meeting notes into coherent documentation |
 
 ### Command Arguments
 
@@ -175,6 +176,18 @@ This ensures you don't lose partially composed messages.
 2. Claude searches your vault for relevant notes
 3. Get synthesis of your existing knowledge
 4. Identify gaps and areas for further exploration
+
+### Expanding Meeting Notes
+
+After a meeting capture session ends, you're automatically brought here with `/expand-note` pre-filled:
+
+1. Run the command (it already has the meeting file path)
+2. Claude reads your raw timestamped captures
+3. Answer 2-4 clarifying questions about unclear references
+4. Claude transforms raw notes into coherent meeting documentation
+5. Review and approve before saving
+
+This workflow bridges the gap between quick captures and polished meeting notes. See [Capture Tab](./capture.md#meeting-capture-mode) for how to start a meeting session.
 
 ## Tips
 


### PR DESCRIPTION
## Summary

- Add comprehensive "Meeting Capture Mode" section to capture.md covering start/stop flow, state persistence, and file format
- Update README.md with meeting notes workflow pattern
- Add `/expand-note` command and workflow to think.md

Documents the meeting capture feature from #306.

## Test plan

- [ ] Review capture.md meeting section for accuracy
- [ ] Verify cross-references between capture.md and think.md work
- [ ] Check image placeholders are appropriately placed for future screenshots

🤖 Generated with [Claude Code](https://claude.ai/code)