### PR TITLE
fix: correct settingSources order to local, project, user

### DIFF
--- a/backend/src/__tests__/session-manager.test.ts
+++ b/backend/src/__tests__/session-manager.test.ts
@@ -707,7 +707,7 @@ describe("Session Manager", () => {
       expect(callArgs).toBeDefined();
       expect(callArgs!.prompt).toBe("Hello");
       expect(callArgs!.options.cwd).toBe(vault.path);
-      expect(callArgs!.options.settingSources).toEqual(["project", "user", "local"]);
+      expect(callArgs!.options.settingSources).toEqual(["local", "project", "user"]);
       expect(callArgs!.options.resume).toBeUndefined();
     });
 

--- a/backend/src/session-manager.ts
+++ b/backend/src/session-manager.ts
@@ -752,7 +752,7 @@ export async function createSession(
       model, // Set model from vault config
       ...options, // Merge defaults then caller options, then force specific fields below
       cwd: vault.path,
-      settingSources: ["project", "user", "local"],
+      settingSources: ["local", "project", "user"],
       mcpServers: {
         ...options?.mcpServers,
         "vault-transfer": vaultTransferServer, // Always include vault-transfer
@@ -873,7 +873,7 @@ export async function resumeSession(
       ...options, // Merge defaults then caller options, then force specific fields below
       resume: sessionId,
       cwd: metadata.vaultPath,
-      settingSources: ["project", "user", "local"],
+      settingSources: ["local", "project", "user"],
       mcpServers: {
         ...options?.mcpServers,
         "vault-transfer": vaultTransferServer, // Always include vault-transfer


### PR DESCRIPTION
## Summary
- Fixes the order of `settingSources` from `["project", "user", "local"]` to `["local", "project", "user"]`
- The order matters for precedence: local settings should override project settings, which should override user settings

## Test plan
- [x] Existing session-manager tests pass (65 tests)
- [x] Pre-commit hooks pass (typecheck, lint, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)