### PR TITLE
fix: add paragraph break between text blocks separated by tool use

### DIFF
--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -1356,6 +1356,12 @@ export class WebSocketHandler {
         });
       } else if (contentBlock.type === "text") {
         contentBlocks.set(blockIndex, { type: "text" });
+
+        // If tools have been used, add a paragraph break before continuing text
+        // to prevent "...got saved.Looks solid!" running together
+        if (toolsMap.size > 0) {
+          return "\n\n";
+        }
       }
 
       return "";


### PR DESCRIPTION
## Summary
- Fixes text running together in transcripts when Claude generates text before and after tool use
- Adds paragraph break (`\n\n`) when a new text content block starts after tools have been used
- Example: "Let me take a look at what got saved.Looks solid!" → properly separated paragraphs

## Test plan
- [x] All existing tests pass (websocket-handler, transcript-manager, session-manager)
- [ ] Manual test: start discussion, trigger tool use, verify transcript has proper spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)