### PR TITLE
fix: upload coverage files separately with flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,29 @@ jobs:
       - name: Run shared tests with coverage
         run: bun run --cwd shared test:coverage
 
-      - uses: codecov/codecov-action@v4
+      - name: Upload backend coverage
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: rjroy/memory-loop
-          files: ./backend/coverage/lcov.info,./frontend/coverage/lcov.info,./shared/coverage/lcov.info
+          files: ./backend/coverage/lcov.info
+          flags: backend
+          fail_ci_if_error: true
+
+      - name: Upload frontend coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: rjroy/memory-loop
+          files: ./frontend/coverage/lcov.info
+          flags: frontend
+          fail_ci_if_error: true
+
+      - name: Upload shared coverage
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: rjroy/memory-loop
+          files: ./shared/coverage/lcov.info
+          flags: shared
           fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,14 +26,8 @@ coverage:
 
 flags:
   backend:
-    paths:
-      - backend/src/**
     carryforward: true
   frontend:
-    paths:
-      - frontend/src/**
     carryforward: true
   shared:
-    paths:
-      - shared/src/**
     carryforward: true


### PR DESCRIPTION
## Summary
- Split single codecov upload into three separate uploads, each tagged with its module flag (backend, frontend, shared)
- Removed redundant `paths` filters from codecov.yml flags since separation happens at upload time

The coverage files contain paths relative to each module (`src/...`) not the repo root (`backend/src/...`). The previous config's path filters couldn't match because of this mismatch. Uploading separately with explicit flags ensures Codecov correctly associates each coverage report with its module.

## Test plan
- [ ] CI passes and codecov uploads succeed
- [ ] Codecov shows separate coverage for backend, frontend, and shared flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)