### PR TITLE
fix: add paths to codecov flags for proper coverage isolation

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -26,8 +26,14 @@ coverage:
 
 flags:
   backend:
+    paths:
+      - backend/
     carryforward: true
   frontend:
+    paths:
+      - frontend/
     carryforward: true
   shared:
+    paths:
+      - shared/
     carryforward: true


### PR DESCRIPTION
## Summary
- Add `paths:` configuration to each flag in codecov.yml (backend, frontend, shared)
- Without paths, Codecov doesn't know which files belong to which flag, causing carryforward and flag-specific coverage reporting to be unreliable

## Test plan
- [ ] Verify CI passes
- [ ] Check Codecov PR comment shows correct per-flag coverage

🤖 Generated with [Claude Code](https://claude.ai/code)