### PR TITLE
feat: enable "Think about" context menu for directories

### DIFF
--- a/frontend/src/components/FileTree.tsx
+++ b/frontend/src/components/FileTree.tsx
@@ -629,7 +629,7 @@ export function FileTree({ onFileSelect, onLoadDirectory, onDeleteFile, onThinkA
             <PinIcon />
             <span>{isPinned ? "Unpin folder" : "Pin to top"}</span>
           </button>
-          {!contextMenu.isDirectory && onThinkAbout && (
+          {onThinkAbout && (
             <button
               type="button"
               className="file-tree__context-menu-item"

--- a/frontend/src/components/__tests__/FileTree.test.tsx
+++ b/frontend/src/components/__tests__/FileTree.test.tsx
@@ -674,7 +674,7 @@ describe("FileTree", () => {
       expect(screen.getByText("Think about")).toBeDefined();
     });
 
-    it("does not show think about option for directories", () => {
+    it("shows think about option for directories", () => {
       const cache = new Map<string, FileEntry[]>([["", testFiles]]);
       const onThinkAbout = mock(() => {});
       render(<FileTree onThinkAbout={onThinkAbout} />, { wrapper: createTestWrapper(cache) });
@@ -683,8 +683,22 @@ describe("FileTree", () => {
       const dirButton = screen.getByText("docs").closest("button");
       fireEvent.contextMenu(dirButton!);
 
-      // Should not show think about option
-      expect(screen.queryByText("Think about")).toBeNull();
+      // Should show think about option
+      expect(screen.getByText("Think about")).toBeDefined();
+    });
+
+    it("calls onThinkAbout when think about is clicked on a directory", () => {
+      const cache = new Map<string, FileEntry[]>([["", testFiles]]);
+      const onThinkAbout = mock(() => {});
+      render(<FileTree onThinkAbout={onThinkAbout} />, { wrapper: createTestWrapper(cache) });
+
+      // Right-click on a directory and click think about
+      const dirButton = screen.getByText("docs").closest("button");
+      fireEvent.contextMenu(dirButton!);
+      fireEvent.click(screen.getByText("Think about"));
+
+      // Should call onThinkAbout with the directory path
+      expect(onThinkAbout).toHaveBeenCalledWith("docs");
     });
 
     it("calls onThinkAbout when think about is clicked", () => {


### PR DESCRIPTION
## Summary
- Extends the "Think about" context menu option to work on directories, not just files
- When selected on a directory, appends the directory path to the discussion draft and navigates to the Think tab
- Updates tests to verify the new behavior

## Test plan
- [x] Unit tests updated and passing
- [ ] Manual test: right-click a directory in the file tree, verify "Think about" option appears
- [ ] Manual test: click "Think about" on a directory, verify it navigates to Think tab with directory path in draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)