### PR TITLE
feat: add file creation from FileTree context menu

### DIFF
--- a/backend/src/handlers/__tests__/browser-handlers.test.ts
+++ b/backend/src/handlers/__tests__/browser-handlers.test.ts
@@ -71,6 +71,7 @@ function createMockDeps(
     deleteFile: () => Promise.resolve(),
     archiveFile: () => Promise.resolve({ originalPath: "", archivePath: "" }),
     createDirectory: createDirectoryFn,
+    createFile: () => Promise.resolve(""),
     getInspiration: () => Promise.resolve({ contextual: null, quote: { text: "", attribution: "" } }),
     getAllTasks: () => Promise.resolve({ tasks: [], incomplete: 0, total: 0 }),
     toggleTask: () => Promise.resolve({ success: true }),

--- a/backend/src/handlers/__tests__/sync-handlers.test.ts
+++ b/backend/src/handlers/__tests__/sync-handlers.test.ts
@@ -145,6 +145,7 @@ const stubHandlerDeps: RequiredHandlerDependencies = {
   deleteFile: () => Promise.resolve(),
   archiveFile: () => Promise.resolve({ originalPath: "", archivePath: "" }),
   createDirectory: () => Promise.resolve(""),
+  createFile: () => Promise.resolve(""),
   getInspiration: () => Promise.resolve({ contextual: null, quote: { text: "", attribution: "" } }),
   getAllTasks: () => Promise.resolve({ tasks: [], incomplete: 0, total: 0 }),
   toggleTask: () => Promise.resolve({ success: true }),

--- a/backend/src/handlers/browser-handlers.ts
+++ b/backend/src/handlers/browser-handlers.ts
@@ -223,3 +223,38 @@ export async function handleCreateDirectory(
     }
   }
 }
+
+/**
+ * Handles create_file message.
+ * Creates a new empty markdown file in the selected vault.
+ */
+export async function handleCreateFile(
+  ctx: HandlerContext,
+  parentPath: string,
+  name: string
+): Promise<void> {
+  log.info(`Creating file: ${name}.md in ${parentPath || "/"}`);
+
+  if (!requireVault(ctx)) {
+    log.warn("No vault selected for file creation");
+    return;
+  }
+
+  try {
+    const createdPath = await ctx.deps.createFile(ctx.state.currentVault.contentRoot, parentPath, name);
+    log.info(`File created: ${createdPath}`);
+    ctx.send({
+      type: "file_created",
+      path: createdPath,
+    });
+  } catch (error) {
+    log.error("File creation failed", error);
+    if (isFileBrowserError(error)) {
+      ctx.sendError(error.code, error.message);
+    } else {
+      const message =
+        error instanceof Error ? error.message : "Failed to create file";
+      ctx.sendError("INTERNAL_ERROR", message);
+    }
+  }
+}

--- a/backend/src/handlers/types.ts
+++ b/backend/src/handlers/types.ts
@@ -110,6 +110,7 @@ export interface HandlerDependencies {
   deleteFile?: (vaultPath: string, relativePath: string) => Promise<void>;
   archiveFile?: (vaultPath: string, relativePath: string, archiveRoot: string) => Promise<ArchiveResult>;
   createDirectory?: (vaultPath: string, parentPath: string, name: string) => Promise<string>;
+  createFile?: (vaultPath: string, parentPath: string, name: string) => Promise<string>;
 
   // Inspiration manager
   getInspiration?: (vault: VaultInfo) => Promise<InspirationResult>;
@@ -222,6 +223,7 @@ export interface RequiredHandlerDependencies {
   deleteFile: (vaultPath: string, relativePath: string) => Promise<void>;
   archiveFile: (vaultPath: string, relativePath: string, archiveRoot: string) => Promise<ArchiveResult>;
   createDirectory: (vaultPath: string, parentPath: string, name: string) => Promise<string>;
+  createFile: (vaultPath: string, parentPath: string, name: string) => Promise<string>;
   getInspiration: (vault: VaultInfo) => Promise<InspirationResult>;
   getAllTasks: (
     vaultPath: string,

--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -93,6 +93,7 @@ import {
   deleteFile as defaultDeleteFile,
   archiveFile as defaultArchiveFile,
   createDirectory as defaultCreateDirectory,
+  createFile as defaultCreateFile,
 } from "./file-browser.js";
 import { getInspiration as defaultGetInspiration } from "./inspiration-manager.js";
 import {
@@ -163,6 +164,7 @@ import {
   handleDeleteFile,
   handleArchiveFile,
   handleCreateDirectory,
+  handleCreateFile,
 } from "./handlers/browser-handlers.js";
 
 import {
@@ -292,6 +294,7 @@ export class WebSocketHandler {
       deleteFile: hd.deleteFile ?? defaultDeleteFile,
       archiveFile: hd.archiveFile ?? defaultArchiveFile,
       createDirectory: hd.createDirectory ?? defaultCreateDirectory,
+      createFile: hd.createFile ?? defaultCreateFile,
       getInspiration: hd.getInspiration ?? defaultGetInspiration,
       getAllTasks: hd.getAllTasks ?? defaultGetAllTasks,
       toggleTask: hd.toggleTask ?? defaultToggleTask,
@@ -654,6 +657,9 @@ export class WebSocketHandler {
         break;
       case "create_directory":
         await handleCreateDirectory(ctx, message.path, message.name);
+        break;
+      case "create_file":
+        await handleCreateFile(ctx, message.path, message.name);
         break;
 
       // Search handlers (extracted)

--- a/frontend/src/components/BrowseMode.tsx
+++ b/frontend/src/components/BrowseMode.tsx
@@ -292,6 +292,17 @@ export function BrowseMode(): React.ReactNode {
         break;
       }
 
+      case "file_created": {
+        // File created - refresh the parent directory where it was created
+        const createdPath = lastMessage.path;
+        const parentPath = createdPath.includes("/")
+          ? createdPath.substring(0, createdPath.lastIndexOf("/"))
+          : "";
+        // Refresh the parent directory listing
+        sendMessage({ type: "list_directory", path: parentPath });
+        break;
+      }
+
       case "tasks":
         // Task list received from server
         setTasks(lastMessage.tasks);
@@ -352,6 +363,14 @@ export function BrowseMode(): React.ReactNode {
   const handleCreateDirectory = useCallback(
     (parentPath: string, name: string) => {
       sendMessage({ type: "create_directory", path: parentPath, name });
+    },
+    [sendMessage]
+  );
+
+  // Handle file creation from FileTree context menu
+  const handleCreateFile = useCallback(
+    (parentPath: string, name: string) => {
+      sendMessage({ type: "create_file", path: parentPath, name });
     },
     [sendMessage]
   );
@@ -648,7 +667,7 @@ export function BrowseMode(): React.ReactNode {
                 onRequestSnippets={handleRequestSnippets}
               />
             ) : viewMode === "files" ? (
-              <FileTree onFileSelect={handleFileSelect} onLoadDirectory={handleLoadDirectory} onDeleteFile={handleDeleteFile} onArchiveFile={handleArchiveFile} onThinkAbout={handleThinkAbout} onPinnedAssetsChange={handlePinnedAssetsChange} onCreateDirectory={handleCreateDirectory} />
+              <FileTree onFileSelect={handleFileSelect} onLoadDirectory={handleLoadDirectory} onDeleteFile={handleDeleteFile} onArchiveFile={handleArchiveFile} onThinkAbout={handleThinkAbout} onPinnedAssetsChange={handlePinnedAssetsChange} onCreateDirectory={handleCreateDirectory} onCreateFile={handleCreateFile} />
             ) : (
               <TaskList onToggleTask={handleToggleTask} onFileSelect={handleFileSelect} />
             )}
@@ -811,7 +830,7 @@ export function BrowseMode(): React.ReactNode {
                   onRequestSnippets={handleRequestSnippets}
                 />
               ) : viewMode === "files" ? (
-                <FileTree onFileSelect={handleFileSelect} onLoadDirectory={handleLoadDirectory} onDeleteFile={handleDeleteFile} onArchiveFile={handleArchiveFile} onThinkAbout={handleThinkAbout} onPinnedAssetsChange={handlePinnedAssetsChange} onCreateDirectory={handleCreateDirectory} />
+                <FileTree onFileSelect={handleFileSelect} onLoadDirectory={handleLoadDirectory} onDeleteFile={handleDeleteFile} onArchiveFile={handleArchiveFile} onThinkAbout={handleThinkAbout} onPinnedAssetsChange={handlePinnedAssetsChange} onCreateDirectory={handleCreateDirectory} onCreateFile={handleCreateFile} />
               ) : (
                 <TaskList onToggleTask={handleToggleTask} onFileSelect={handleFileSelect} />
               )}

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -682,6 +682,17 @@ export const CreateDirectoryMessageSchema = z.object({
 });
 
 /**
+ * Client requests to create a new markdown file in the vault
+ * Path is relative to vault content root (parent directory)
+ * Name must be alphanumeric with - and _ only (extension added automatically)
+ */
+export const CreateFileMessageSchema = z.object({
+  type: z.literal("create_file"),
+  path: z.string(), // Parent directory path (empty string for root)
+  name: z.string().min(1, "File name is required").regex(/^[a-zA-Z0-9_-]+$/, "File name must be alphanumeric with - and _ only"),
+});
+
+/**
  * Client requests ground widgets for current vault (REQ-F-16).
  * Ground widgets appear on the Home/Ground view.
  */
@@ -798,6 +809,7 @@ export const ClientMessageSchema = z.discriminatedUnion("type", [
   DeleteFileMessageSchema,
   ArchiveFileMessageSchema,
   CreateDirectoryMessageSchema,
+  CreateFileMessageSchema,
   GetGroundWidgetsMessageSchema,
   GetRecallWidgetsMessageSchema,
   WidgetEditMessageSchema,
@@ -1171,6 +1183,15 @@ export const DirectoryCreatedMessageSchema = z.object({
 });
 
 /**
+ * Server confirms file was created successfully
+ */
+export const FileCreatedMessageSchema = z.object({
+  type: z.literal("file_created"),
+  /** Full path of the created file (relative to content root) */
+  path: z.string().min(1, "File path is required"),
+});
+
+/**
  * Server sends ground widgets for the current vault (REQ-F-16).
  * Response to get_ground_widgets request.
  */
@@ -1376,6 +1397,7 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
   FileDeletedMessageSchema,
   FileArchivedMessageSchema,
   DirectoryCreatedMessageSchema,
+  FileCreatedMessageSchema,
   GroundWidgetsMessageSchema,
   RecallWidgetsMessageSchema,
   WidgetUpdateMessageSchema,
@@ -1476,6 +1498,7 @@ export type GetSnippetsMessage = z.infer<typeof GetSnippetsMessageSchema>;
 export type DeleteFileMessage = z.infer<typeof DeleteFileMessageSchema>;
 export type ArchiveFileMessage = z.infer<typeof ArchiveFileMessageSchema>;
 export type CreateDirectoryMessage = z.infer<typeof CreateDirectoryMessageSchema>;
+export type CreateFileMessage = z.infer<typeof CreateFileMessageSchema>;
 export type GetGroundWidgetsMessage = z.infer<typeof GetGroundWidgetsMessageSchema>;
 export type GetRecallWidgetsMessage = z.infer<typeof GetRecallWidgetsMessageSchema>;
 export type WidgetEditMessage = z.infer<typeof WidgetEditMessageSchema>;
@@ -1521,6 +1544,7 @@ export type IndexProgressMessage = z.infer<typeof IndexProgressMessageSchema>;
 export type FileDeletedMessage = z.infer<typeof FileDeletedMessageSchema>;
 export type FileArchivedMessage = z.infer<typeof FileArchivedMessageSchema>;
 export type DirectoryCreatedMessage = z.infer<typeof DirectoryCreatedMessageSchema>;
+export type FileCreatedMessage = z.infer<typeof FileCreatedMessageSchema>;
 export type GroundWidgetsMessage = z.infer<typeof GroundWidgetsMessageSchema>;
 export type RecallWidgetsMessage = z.infer<typeof RecallWidgetsMessageSchema>;
 export type WidgetUpdateMessage = z.infer<typeof WidgetUpdateMessageSchema>;


### PR DESCRIPTION
## Summary

- Add "Create File" option to directory context menu in FileTree
- Opens dialog for entering file name (alphanumeric with `-` and `_` only)
- Creates empty markdown file with `.md` extension added automatically
- Follows same pattern as existing "Add Directory" feature

Closes #332

## Test plan

- [ ] Right-click a directory in Recall tab, select "Create File"
- [ ] Enter a valid file name (e.g., `my-new-note`)
- [ ] Verify empty `.md` file is created in the selected directory
- [ ] Verify directory listing refreshes to show new file
- [ ] Test validation rejects names with spaces or special characters
- [ ] Test duplicate file name shows error

🤖 Generated with [Claude Code](https://claude.ai/code)