### PR TITLE
feat: make VAULTS_DIR optional with default to ./vaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-# Directory containing your vaults (required)
+# Directory containing your vaults (optional, defaults to ./vaults)
 # Each subdirectory with a CLAUDE.md file will appear as a vault
-VAULTS_DIR=/path/to/your/vaults
+# VAULTS_DIR=/path/to/your/vaults
 
 # Server port (optional, default: 3000)
 PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 
 # Application data
 .memory-loop/
+vaults/
 # Exception for test fixtures (keep widget configs, not cache)
 !backend/__fixtures__/**/.memory-loop/
 backend/__fixtures__/**/.memory-loop/cache.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Each vault needs a `CLAUDE.md` at root. Optional structure:
 ## Environment Variables
 
 ```bash
-VAULTS_DIR=/path/to/vaults  # Required: directory containing vaults
+VAULTS_DIR=/path/to/vaults  # Optional: defaults to ./vaults at project root
 PORT=3000                   # Backend port
 HOST=0.0.0.0               # Bind address
 MOCK_SDK=true              # Test without API calls

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cd memory-loop
 bun install
 
 cp .env.example .env
-# Edit .env with your VAULTS_DIR path
+# Optionally edit .env to set VAULTS_DIR (defaults to ./vaults)
 
 bun run dev
 ```
@@ -60,7 +60,7 @@ Open http://localhost:5173 in your browser.
 ### Environment Variables
 
 ```bash
-VAULTS_DIR=/path/to/vaults  # Required: directory containing your vaults
+VAULTS_DIR=/path/to/vaults  # Optional: defaults to ./vaults at project root
 PORT=3000                   # Backend port (default: 3000)
 HOST=0.0.0.0                # Bind address (default: 0.0.0.0)
 MOCK_SDK=true               # Test without API calls

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -32,17 +32,16 @@ log_error() {
     echo "$msg" >&2
 }
 
-# Check required environment variables
+# Set VAULTS_DIR to default if not provided
 if [[ -z "${VAULTS_DIR:-}" ]]; then
-    log_error "VAULTS_DIR environment variable is not set"
-    log_error "Set it to the directory containing your Obsidian vaults"
-    log_error "Example: export VAULTS_DIR=~/Documents/Vaults"
-    exit 1
+    export VAULTS_DIR="$PROJECT_ROOT/vaults"
+    log "VAULTS_DIR not set, using default: $VAULTS_DIR"
 fi
 
+# Create vaults directory if it doesn't exist
 if [[ ! -d "$VAULTS_DIR" ]]; then
-    log_error "VAULTS_DIR does not exist: $VAULTS_DIR"
-    exit 1
+    log "Creating vaults directory: $VAULTS_DIR"
+    mkdir -p "$VAULTS_DIR"
 fi
 
 log "Starting Memory Loop..."


### PR DESCRIPTION
## Summary

- Make `VAULTS_DIR` environment variable optional, defaulting to `./vaults` at project root
- Automatically create the vaults directory if it doesn't exist
- Add `vaults/` to `.gitignore` to prevent accidental commits of user data
- Update documentation to reflect the new optional behavior

This simplifies initial setup by removing the requirement to configure `VAULTS_DIR` before running the application.

Closes #331

## Test plan

- [x] Run full test suite (`./git-hooks/pre-commit.sh`) - all 2724 tests pass
- [x] Verify `getVaultsDir()` returns default path when env var not set
- [x] Verify `ensureVaultsDir()` creates directory when missing
- [x] Verify `discoverVaults()` creates directory and returns empty array for new installs
- [x] Verify API endpoint `/api/vaults` returns 200 (not 500) when VAULTS_DIR unset

🤖 Generated with [Claude Code](https://claude.ai/claude-code)