### PR TITLE
fix: track cumulative context usage across session turns

### DIFF
--- a/backend/src/__tests__/websocket-handler.test.ts
+++ b/backend/src/__tests__/websocket-handler.test.ts
@@ -5189,4 +5189,23 @@ describe("WebSocket Handler", () => {
       expect(mockSaveVaultConfig).toHaveBeenCalledWith(vault.path, {});
     });
   });
+
+  // ===========================================================================
+  // Cumulative Context Usage Tests
+  // ===========================================================================
+
+  describe("cumulative context usage tracking", () => {
+    test("createConnectionState initializes cumulative tokens to 0", () => {
+      const state = createConnectionState();
+      expect(state.cumulativeTokens).toBe(0);
+      expect(state.contextWindow).toBeNull();
+    });
+
+    test("getState returns cumulative token values", () => {
+      const handler = createTestHandler();
+      const state = handler.getState();
+      expect(state.cumulativeTokens).toBe(0);
+      expect(state.contextWindow).toBeNull();
+    });
+  });
 });

--- a/backend/src/handlers/__tests__/browser-handlers.test.ts
+++ b/backend/src/handlers/__tests__/browser-handlers.test.ts
@@ -50,6 +50,8 @@ beforeEach(() => {
     pendingAskUserQuestions: new Map(),
     searchIndex: null,
     activeModel: null,
+    cumulativeTokens: 0,
+    contextWindow: null,
     widgetEngine: null,
     widgetWatcher: null,
     healthCollector: null,

--- a/backend/src/handlers/__tests__/sync-handlers.test.ts
+++ b/backend/src/handlers/__tests__/sync-handlers.test.ts
@@ -100,6 +100,8 @@ beforeEach(async () => {
     pendingAskUserQuestions: new Map(),
     searchIndex: null,
     activeModel: null,
+    cumulativeTokens: 0,
+    contextWindow: null,
     widgetEngine: null,
     widgetWatcher: null,
     healthCollector: null,

--- a/backend/src/handlers/types.ts
+++ b/backend/src/handlers/types.ts
@@ -188,6 +188,10 @@ export interface ConnectionState {
   searchIndex: SearchIndexManager | null;
   /** Active model captured from SDK system/init event (null if not yet received) */
   activeModel: string | null;
+  /** Cumulative token count across all turns in the session (input + output) */
+  cumulativeTokens: number;
+  /** Context window size for the active model (null if not yet known) */
+  contextWindow: number | null;
   /** Widget engine for computing vault widgets (null if no vault selected) */
   widgetEngine: WidgetEngine | null;
   /** File watcher for widget source files (null if no vault selected) */
@@ -291,6 +295,8 @@ export function createConnectionState(): ConnectionState {
     pendingAskUserQuestions: new Map(),
     searchIndex: null,
     activeModel: null,
+    cumulativeTokens: 0,
+    contextWindow: null,
     widgetEngine: null,
     widgetWatcher: null,
     healthCollector: null,


### PR DESCRIPTION
## Summary

Fixes #276 - The context percentage displayed on message bubbles was showing seemingly random values.

**Root causes identified:**
- Double-counting cache tokens (cache_read and cache_creation tokens are subsets of input_tokens, not additional)
- Not tracking cumulative usage across turns in a session

**Changes:**
- Remove double-counting of cache tokens in context calculation
- Add `cumulativeTokens` and `contextWindow` fields to `ConnectionState`
- Accumulate input + output tokens across all turns in a session
- Handle `compact_boundary` SDK events by estimating post-compact token count (~30%)
- Reset cumulative tracking when a new session starts or is cleared

## Test plan

- [x] All existing tests pass
- [x] Added tests for new `cumulativeTokens` and `contextWindow` state fields
- [x] Manual testing confirmed the percentage now increases sensibly across turns

🤖 Generated with [Claude Code](https://claude.ai/code)