### PR TITLE
fix: send turn duration in response_end message (#342)

### DIFF
--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -1014,6 +1014,7 @@ export class WebSocketHandler {
         type: "response_end",
         messageId,
         contextUsage: streamResult.contextUsage,
+        durationMs,
       });
 
       if (streamResult.content.length > 0 || streamResult.toolInvocations.length > 0) {

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -362,6 +362,10 @@ export function SessionProvider({
     dispatch({ type: "SET_LAST_MESSAGE_CONTEXT_USAGE", contextUsage });
   }, []);
 
+  const setLastMessageDuration = useCallback((durationMs: number) => {
+    dispatch({ type: "SET_LAST_MESSAGE_DURATION", durationMs });
+  }, []);
+
   // Search actions
   const setSearchActive = useCallback((isActive: boolean) => {
     dispatch({ type: "SET_SEARCH_ACTIVE", isActive });
@@ -536,6 +540,7 @@ export function SessionProvider({
     completeToolInvocation,
     setSlashCommands,
     setLastMessageContextUsage,
+    setLastMessageDuration,
     setSearchActive,
     setSearchMode,
     setSearchQuery,
@@ -594,6 +599,7 @@ export function useServerMessageHandler(): (message: ServerMessage) => void {
     setPendingSessionId,
     setSlashCommands,
     setLastMessageContextUsage,
+    setLastMessageDuration,
     setSearchResults,
     setSnippets,
     setSearchLoading,
@@ -673,6 +679,9 @@ export function useServerMessageHandler(): (message: ServerMessage) => void {
           updateLastMessage("", false);
           if (message.contextUsage !== undefined) {
             setLastMessageContextUsage(message.contextUsage);
+          }
+          if (message.durationMs !== undefined) {
+            setLastMessageDuration(message.durationMs);
           }
           break;
 
@@ -768,6 +777,7 @@ export function useServerMessageHandler(): (message: ServerMessage) => void {
       setPendingSessionId,
       setSlashCommands,
       setLastMessageContextUsage,
+      setLastMessageDuration,
       setSearchResults,
       setSnippets,
       setSearchLoading,

--- a/frontend/src/contexts/__tests__/SessionContext.test.tsx
+++ b/frontend/src/contexts/__tests__/SessionContext.test.tsx
@@ -695,6 +695,44 @@ describe("SessionContext", () => {
       expect(result.current.session.messages[0].isStreaming).toBe(false);
     });
 
+    it("handles response_end with durationMs", () => {
+      const { result } = renderHook(
+        () => ({
+          session: useSession(),
+          handler: useServerMessageHandler(),
+        }),
+        { wrapper: createWrapper() }
+      );
+
+      act(() => {
+        result.current.handler({
+          type: "response_start",
+          messageId: "msg-1",
+        });
+      });
+
+      act(() => {
+        result.current.handler({
+          type: "response_chunk",
+          messageId: "msg-1",
+          content: "Done!",
+        });
+      });
+
+      act(() => {
+        result.current.handler({
+          type: "response_end",
+          messageId: "msg-1",
+          contextUsage: 42,
+          durationMs: 1500,
+        });
+      });
+
+      expect(result.current.session.messages[0].isStreaming).toBe(false);
+      expect(result.current.session.messages[0].contextUsage).toBe(42);
+      expect(result.current.session.messages[0].durationMs).toBe(1500);
+    });
+
     it("updateLastMessage does not corrupt user message (race condition fix)", () => {
       const { result } = renderHook(() => useSession(), {
         wrapper: createWrapper(),

--- a/frontend/src/contexts/session/reducer.ts
+++ b/frontend/src/contexts/session/reducer.ts
@@ -87,6 +87,7 @@ export type SessionAction =
   | { type: "COMPLETE_TOOL_INVOCATION"; toolUseId: string; output: unknown }
   | { type: "SET_SLASH_COMMANDS"; commands: SlashCommand[] }
   | { type: "SET_LAST_MESSAGE_CONTEXT_USAGE"; contextUsage: number }
+  | { type: "SET_LAST_MESSAGE_DURATION"; durationMs: number }
   | { type: "SET_SEARCH_ACTIVE"; isActive: boolean }
   | { type: "SET_SEARCH_MODE"; mode: SearchMode }
   | { type: "SET_SEARCH_QUERY"; query: string }
@@ -387,6 +388,18 @@ function handleSetLastMessageContextUsage(
   return { ...state, messages };
 }
 
+function handleSetLastMessageDuration(
+  state: SessionState,
+  durationMs: number
+): SessionState {
+  if (state.messages.length === 0) return state;
+  const messages = [...state.messages];
+  const lastMessage = messages[messages.length - 1];
+  if (lastMessage.role !== "assistant") return state;
+  messages[messages.length - 1] = { ...lastMessage, durationMs };
+  return { ...state, messages };
+}
+
 // ----------------------------------------------------------------------------
 // Main reducer
 // ----------------------------------------------------------------------------
@@ -617,6 +630,9 @@ export function sessionReducer(
 
     case "SET_LAST_MESSAGE_CONTEXT_USAGE":
       return handleSetLastMessageContextUsage(state, action.contextUsage);
+
+    case "SET_LAST_MESSAGE_DURATION":
+      return handleSetLastMessageDuration(state, action.durationMs);
 
     // Search actions
     case "SET_SEARCH_ACTIVE":

--- a/frontend/src/contexts/session/types.ts
+++ b/frontend/src/contexts/session/types.ts
@@ -322,6 +322,8 @@ export interface SessionActions {
   setSlashCommands: (commands: SlashCommand[]) => void;
   /** Set context usage percentage on the last assistant message */
   setLastMessageContextUsage: (contextUsage: number) => void;
+  /** Set turn duration on the last assistant message */
+  setLastMessageDuration: (durationMs: number) => void;
   // Search actions
   /** Activate or deactivate search mode */
   setSearchActive: (isActive: boolean) => void;

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -958,6 +958,7 @@ export const ResponseEndMessageSchema = z.object({
   type: z.literal("response_end"),
   messageId: z.string().min(1),
   contextUsage: z.number().min(0).max(100).optional(),
+  durationMs: z.number().int().min(0).optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Adds `durationMs` field to the `response_end` WebSocket message
- Frontend now updates turn duration immediately when response completes
- Fixes race condition where duration only appeared after page refresh

Closes #342

## Test plan

- [x] Unit test added for `response_end` with `durationMs`
- [x] All existing tests pass
- [ ] Manual test: start a chat, verify turn duration appears immediately after AI response completes (no refresh needed)

🤖 Generated with [Claude Code](https://claude.ai/code)