### PR TITLE
fix: ensure stop button reappears when streaming starts after early abort

### DIFF
--- a/frontend/src/components/Discussion.tsx
+++ b/frontend/src/components/Discussion.tsx
@@ -94,6 +94,13 @@ export function Discussion(): React.ReactNode {
       // Process streaming messages (response_start, response_chunk, response_end)
       handleServerMessage(message);
 
+      // Handle response start - ensure stop button is visible when streaming begins
+      // This handles the race condition where user clicks stop before streaming starts:
+      // the abort may not take effect, and we need the stop button to reappear
+      if (message.type === "response_start") {
+        setIsSubmitting(true);
+      }
+
       // Handle response end - clear submitting state
       if (message.type === "response_end") {
         setIsSubmitting(false);


### PR DESCRIPTION
## Summary

- Fixes race condition where clicking stop before `response_start` arrives causes the stop button to disappear
- When user clicked stop early, `isSubmitting` was set to `false`, but if the backend hadn't started streaming yet, the abort was ignored and the response would stream without a visible stop button
- Now `response_start` sets `isSubmitting=true`, ensuring the stop button is always visible during actual streaming

## Test plan

- [ ] Submit a message and immediately click stop before streaming begins
- [ ] Verify the stop button reappears when the response starts streaming
- [ ] Verify stop button still works normally when clicked during streaming
- [ ] Run `bun run --cwd frontend test src/components/__tests__/Discussion.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)