### PR TITLE
fix: show expand toggle for unloaded directories in MoveDialog

### DIFF
--- a/frontend/src/components/MoveDialog.tsx
+++ b/frontend/src/components/MoveDialog.tsx
@@ -168,7 +168,7 @@ export function MoveDialog({
             onClick={() => selectDirectory(entry.path)}
           >
             <span
-              className={`move-dialog__tree-toggle ${dirs.length > 0 ? "" : "move-dialog__tree-toggle--empty"}`}
+              className={`move-dialog__tree-toggle ${dirs.length > 0 || !directoryCache.get(entry.path) ? "" : "move-dialog__tree-toggle--empty"}`}
               onClick={(e) => {
                 e.stopPropagation();
                 if (dirs.length > 0 || !directoryCache.get(entry.path)) {


### PR DESCRIPTION
## Summary

- Fixed bug where directory expand toggles were hidden for directories not yet loaded from the cache
- The CSS class condition only checked `dirs.length > 0`, but the click handler correctly also checked `!directoryCache.get(entry.path)` for unloaded directories
- Aligned the class condition with the click logic so toggles are visible and clickable for all expandable directories

## Test plan

- [x] Existing MoveDialog tests pass (23 tests)
- [ ] Manual test: Open MoveDialog, verify expand arrows appear for all directories
- [ ] Manual test: Click expand on a directory that hasn't been loaded, verify it loads and shows subdirectories

🤖 Generated with [Claude Code](https://claude.com/claude-code)