### PR TITLE
fix: include file name in delete confirmation dialog

### DIFF
--- a/frontend/src/components/FileTree.tsx
+++ b/frontend/src/components/FileTree.tsx
@@ -1023,7 +1023,7 @@ export function FileTree({ onFileSelect, onLoadDirectory, onDeleteFile, onDelete
       <ConfirmDialog
         isOpen={pendingDeletePath !== null}
         title="Delete File?"
-        message="This cannot be undone! The file will be permanently deleted from your vault."
+        message={`This cannot be undone! The file "${pendingDeletePath?.split("/").pop() ?? ""}" will be permanently deleted from your vault.`}
         confirmLabel="Delete"
         onConfirm={handleConfirmDelete}
         onCancel={handleCancelDelete}

--- a/frontend/src/components/__tests__/FileTree.test.tsx
+++ b/frontend/src/components/__tests__/FileTree.test.tsx
@@ -584,7 +584,7 @@ describe("FileTree", () => {
 
       // Should show confirmation dialog
       expect(screen.getByText("Delete File?")).toBeDefined();
-      expect(screen.getByText("This cannot be undone! The file will be permanently deleted from your vault.")).toBeDefined();
+      expect(screen.getByText('This cannot be undone! The file "README.md" will be permanently deleted from your vault.')).toBeDefined();
     });
 
     it("calls onDeleteFile when deletion is confirmed", () => {


### PR DESCRIPTION
## Summary
- Show the specific file name in the delete confirmation message (e.g., `The file "notes.md" will be permanently deleted`)
- Matches the existing pattern used for directory deletion confirmations
- Updated corresponding test assertion

## Test plan
- [ ] Right-click a file in the file tree and select "Delete file"
- [ ] Verify the confirmation dialog shows the file name in the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)