### PR TITLE
fix: Disable extraction scheduler in development mode

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun run --watch src/index.ts",
+    "dev": "NODE_ENV=development bun run --watch src/index.ts",
     "build": "tsc --noEmit",
     "start": "bun run src/index.ts",
     "test": "LOG_LEVEL=silent bun test",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -41,16 +41,20 @@ if (server.hostname === "0.0.0.0") {
 // Extraction Scheduler (REQ-F-4)
 // =============================================================================
 
-// Start the extraction scheduler
+// Start the extraction scheduler (disabled in development mode)
 // - Performs recovery check if sandbox file exists from interrupted run
 // - Triggers catch-up extraction if last run was >24h ago
 // - Schedules daily extraction at configured time (default: 3am)
-void startScheduler().then((started) => {
-  if (started) {
-    log.info(`Extraction scheduler started with schedule: ${getCronSchedule()}`);
-  } else {
-    log.warn("Extraction scheduler failed to start");
-  }
-}).catch((error: unknown) => {
-  log.error("Failed to start extraction scheduler:", error);
-});
+if (process.env.NODE_ENV === "development") {
+  log.info("Extraction scheduler disabled in development mode");
+} else {
+  void startScheduler().then((started) => {
+    if (started) {
+      log.info(`Extraction scheduler started with schedule: ${getCronSchedule()}`);
+    } else {
+      log.warn("Extraction scheduler failed to start");
+    }
+  }).catch((error: unknown) => {
+    log.error("Failed to start extraction scheduler:", error);
+  });
+}


### PR DESCRIPTION
## Summary
- Set `NODE_ENV=development` in the dev script
- Skip scheduler startup when `NODE_ENV=development`
- Manual extraction via the "Run Extraction" button still works

This prevents the scheduler from running catch-up extractions and scheduling daily jobs while developing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)