### PR TITLE
fix: Tighten extraction prompts to prevent memory file bloat

### DIFF
--- a/backend/src/extraction/fact-extractor.ts
+++ b/backend/src/extraction/fact-extractor.ts
@@ -191,26 +191,39 @@ export function buildExtractionPrompt(
   // Combine user-customizable categories with operational instructions
   return `# Memory Extraction
 
-Extract durable facts about the user from conversation transcripts. Focus on information that remains true across sessions, not transient conversation details.
+## Purpose
+
+This memory file provides context so AI assistants can give more relevant, personalized responses. It is **operational context**, not a biography or life story. Every entry should earn its space by changing how an AI would respond to the user.
+
+## Principles
+
+**Brevity over completeness.** State facts concisely. "Prefers TypeScript for larger projects" not "The user has expressed that they find TypeScript's type system valuable when working on projects of significant scale."
+
+**Actionable over interesting.** Include what changes AI behavior. Skip trivia that doesn't affect how to assist the user.
+
+**Current over historical.** Preferences and context that apply now. Past projects or outdated preferences can be dropped unless they inform current work.
+
+---
 
 ${basePrompt}
 
+---
+
 ## What to Extract vs. Ignore
 
-**Extract** (durable facts):
-- "I've been programming for 15 years"
-- "Our team uses trunk-based development"
-- "I prefer TypeScript over JavaScript for larger projects"
-- "Memory Loop is my side project for AI-augmented note-taking"
+**Extract** (changes how AI responds):
+- "Senior engineer, 20 years experience" → calibrates technical depth
+- "Prefers direct feedback over diplomatic hedging" → shapes communication style
+- "Building Memory Loop as a side project" → provides context for questions
+- "Team uses trunk-based development" → informs suggestions
 
-**Ignore** (transient details):
-- "Can you fix this bug?"
-- "I'm working on the login page today"
-- "Thanks, that worked!"
-- Session-specific troubleshooting steps
-- Temporary workarounds
+**Ignore** (doesn't change AI behavior):
+- "Can you fix this bug?" → session-specific request
+- "I'm working on the login page today" → transient task
+- "Thanks, that worked!" → conversational noise
+- Detailed troubleshooting steps → not reusable context
 
-The test: would this fact be useful context in a conversation six months from now?
+**The test:** Would knowing this fact change how an AI responds to the user? If not, skip it.
 
 ---
 
@@ -236,34 +249,33 @@ ${transcriptList}
 
 ### Output Format
 
-Use a hybrid narrative and list format. Write prose for interconnected information; use bullet lists only for truly independent items.
+Concise statements, not explanations. Each fact should be one or two sentences maximum.
 
-Good example:
+Good:
 \`\`\`markdown
 ## Preferences
-Values concise communication over verbose explanations. Prefers seeing tradeoffs explicitly stated rather than having decisions made silently. When implementing:
-- Start simple, add complexity when needed
-- Avoid over-engineering
-- Show your reasoning
+Values direct communication. Wants tradeoffs stated explicitly. Implementation approach: start simple, add complexity only when needed.
 \`\`\`
 
-Bad example (over-bulleted):
+Bad (too verbose):
 \`\`\`markdown
 ## Preferences
-- Prefers concise communication
-- Wants to see tradeoffs
-- Likes simple solutions
-- Dislikes over-engineering
+The user has consistently demonstrated a preference for concise communication styles. They have mentioned on several occasions that they appreciate when tradeoffs are explicitly stated rather than having decisions made silently. Their implementation philosophy tends toward starting with simple solutions and only adding complexity when the situation demands it.
 \`\`\`
+
+Use bullet lists only when items are truly independent and a list is shorter than prose.
 
 ### Merge Behavior
 
-You are updating an existing memory file, not creating a new one.
+You are updating an existing memory file, not creating a new one. The file has a size budget; entries must justify their space.
 
-- **Add** new facts that don't exist yet
-- **Update** existing facts when new information contradicts or refines them (prefer newer information but preserve relevant context)
-- **Preserve** existing facts that aren't contradicted (don't remove information just because current transcripts don't mention it)
-- **Consolidate** redundant facts (if adding something already captured, update the existing entry instead)
+- **Add** new facts that pass the "changes AI behavior" test
+- **Update** facts when new information refines them (prefer recent over stale)
+- **Compress** verbose entries into concise statements
+- **Consolidate** related facts rather than listing separately
+- **Remove** facts that no longer provide actionable context (outdated projects, superseded preferences, trivia that doesn't affect assistance)
+
+The goal is a lean, high-signal file. When in doubt, shorter is better. A 200-line file of dense, useful context beats a 2000-line file of comprehensive biography.
 
 ### Security
 

--- a/backend/src/prompts/durable-facts.md
+++ b/backend/src/prompts/durable-facts.md
@@ -2,19 +2,19 @@
 
 ## Categories
 
-Extract facts into these categories:
+Each category exists because it changes how an AI should respond. If information doesn't fit one of these purposes, it probably doesn't belong.
 
 ### Identity
-Who the user is: background, expertise, roles, experience. Information that establishes context for who you're working with.
+Background that calibrates technical depth and domain assumptions. "Senior engineer, 20 years" means skip beginner explanations. "Manager of 8 engineers" means leadership context matters. Keep to a few sentences that establish the baseline.
 
 ### Goals
-What the user is trying to achieve: projects they're building, outcomes they want, problems they're solving. Both immediate objectives and longer-term aspirations.
+Active projects and objectives that provide context for questions. When the user asks about "the plugin system," knowing they're building Memory Loop makes the question concrete. Include only current work; drop completed or abandoned projects.
 
 ### Preferences
-How the user likes to work: communication style, decision-making approach, tool preferences, constraints they operate under. Patterns in how they want things done.
+Communication and working style that shapes how to respond. "Prefers direct feedback" means don't hedge. "Thinks out loud" means expect iterative refinement. "Avoids em-dashes" means follow that in writing. These directly change output style.
 
 ### Project Context
-Technical and organizational context: architectural decisions, why things exist the way they do, team structure, codebase patterns. Information that helps you make better suggestions.
+Technical decisions and constraints that inform suggestions. "Uses bun, not npm" prevents wrong tool recommendations. "Monorepo with shared/ workspace" shapes where to put code. Include what affects recommendations; skip historical rationale unless it's still relevant.
 
-### Recurring Insights
-Patterns that emerged across conversations: repeated themes, evolving understanding, realizations the user has had. Things worth remembering because they keep coming up.
+### Patterns
+Recurring themes that prevent repeated mistakes. If the user consistently rejects over-engineered solutions, note it. If they've explained a concept three times, capture the settled understanding. These are patterns in *this user's* thinking, not general insights.


### PR DESCRIPTION
## Summary

- Add purpose framing to extraction prompt: "operational context, not a biography"
- Add brevity principles and size budget awareness to prevent unbounded growth
- Reframe durable-facts.md categories to explain why each matters for AI behavior

## Problem

The memory extraction system was producing verbose, biographical content that would eventually hit the 50k character limit. The prompt had no constraints on length or purpose.

## Solution

**Wrapper prompt changes:**
- Purpose statement at top establishing this is operational context
- Three principles: brevity over completeness, actionable over interesting, current over historical
- Changed the test from "useful in six months" to "would this change how an AI responds"
- Added compress/remove to merge behavior (was add-only)
- Size awareness: "200 lines of dense context beats 2000 lines of biography"

**durable-facts.md changes:**
- Each category now explains *why* it matters (how it changes AI behavior)
- Added scope hints (e.g., "few sentences", "only current work")
- Renamed "Recurring Insights" → "Patterns" to avoid philosophical bloat

## Test plan

- [ ] Run extraction against test transcripts and verify output is concise
- [ ] Confirm memory file stays under reasonable size over multiple extraction runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)