### PR TITLE
feat: Enable Pair Writing mode on iPad

### DIFF
--- a/frontend/src/components/PairWritingMode.css
+++ b/frontend/src/components/PairWritingMode.css
@@ -2,7 +2,7 @@
  * PairWritingMode Component Styles
  *
  * Split-screen layout with editor and conversation panes.
- * Desktop-only component (hidden via CSS media query on touch devices).
+ * Hidden on phones; visible on iPad and desktop (screen width >= 768px).
  *
  * @see .sdd/plans/memory-loop/2026-01-20-pair-writing-mode-plan.md TD-6, TD-9
  * @see .sdd/specs/memory-loop/2026-01-20-pair-writing-mode.md REQ-F-10, REQ-F-11
@@ -293,8 +293,8 @@
    Desktop-Only Visibility (TD-9, REQ-F-10)
    ============================================ */
 
-/* Hide on touch devices */
-@media (hover: none), (pointer: coarse) {
+/* Hide on phones (touch devices with narrow screens), but allow iPads (REQ-F-10) */
+@media (hover: none) and (max-width: 767px), (pointer: coarse) and (max-width: 767px) {
   .pair-writing-mode {
     display: none;
   }

--- a/frontend/src/components/PairWritingMode.tsx
+++ b/frontend/src/components/PairWritingMode.tsx
@@ -5,7 +5,7 @@
  * Left pane: PairWritingEditor for document editing with Quick Actions
  * Right pane: Discussion component (same session as Think tab)
  *
- * Desktop-only: hidden via CSS media query on touch devices (REQ-F-10).
+ * Hidden on phones via CSS media query; visible on iPad and desktop (REQ-F-10).
  *
  * The right pane IS the Discussion tab: same conversation history, same session,
  * same WebSocket connection. Quick Actions and Advisory Actions appear in the
@@ -64,7 +64,7 @@ export interface PairWritingModeProps {
  * - 50/50 split layout with editor and Discussion (REQ-F-11)
  * - Toolbar with Snapshot, Save, Exit buttons (REQ-F-14, REQ-F-23, REQ-F-29)
  * - Exit confirmation when unsaved manual edits exist (REQ-F-30)
- * - Hidden on touch devices via CSS media query (REQ-F-10)
+ * - Hidden on phones via CSS media query; visible on iPad and desktop (REQ-F-10)
  * - Discussion in right pane is the same session as Think tab
  *
  * State management for editor (content, snapshot, unsaved changes) is handled


### PR DESCRIPTION
## Summary
- Change CSS media query to allow Pair Writing mode on iPad while still hiding on iPhone
- iPads (≥768px width) have sufficient screen space for the split-screen editor layout
- iPhones (<768px width) remain blocked due to limited screen real estate

## Test plan
- [ ] Verify Pair Writing mode is hidden on iPhone (Safari/Chrome)
- [ ] Verify Pair Writing mode is visible and functional on iPad
- [ ] Verify desktop behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)