### PR TITLE
fix: Show Pair Writing button on iPad

### DIFF
--- a/frontend/src/components/MarkdownViewer.css
+++ b/frontend/src/components/MarkdownViewer.css
@@ -545,8 +545,8 @@
   outline-offset: 2px;
 }
 
-/* Hide Pair Writing button on touch/mobile devices (REQ-F-10) */
-@media (hover: none), (pointer: coarse) {
+/* Hide Pair Writing button on phones (touch devices with narrow screens), but allow iPads (REQ-F-10) */
+@media (hover: none) and (max-width: 767px), (pointer: coarse) and (max-width: 767px) {
   .markdown-viewer__pair-writing-btn {
     display: none;
   }


### PR DESCRIPTION
## Summary
- Fixes incomplete iPad support from #385
- The previous PR updated `PairWritingMode.css` but missed the entry button in `MarkdownViewer.css`
- Applies the same media query change so the "Pair Writing" button is visible on iPads

## Test plan
- [ ] Open Memory Loop on iPad
- [ ] Navigate to Recall tab and select a markdown file
- [ ] Verify "Pair Writing" button appears in the toolbar
- [ ] Tap button and verify Pair Writing mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)