### PR TITLE
feat: Add Actions button for iPad text selection in Pair Writing

### DIFF
--- a/frontend/src/components/PairWritingMode.tsx
+++ b/frontend/src/components/PairWritingMode.tsx
@@ -90,6 +90,7 @@ export function PairWritingMode({
   const [showExitConfirm, setShowExitConfirm] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [currentSelection, setCurrentSelection] = useState<SelectionContext | null>(null);
+  const [openMenuTrigger, setOpenMenuTrigger] = useState(0);
 
   // Track previous initialContent to detect external changes (not local edits)
   const prevInitialContent = useRef(initialContent);
@@ -114,6 +115,11 @@ export function PairWritingMode({
   // Handle selection changes from editor
   const handleSelectionChange = useCallback((selection: SelectionContext | null) => {
     setCurrentSelection(selection);
+  }, []);
+
+  // Handle Actions button click (opens context menu in editor)
+  const handleShowActions = useCallback(() => {
+    setOpenMenuTrigger((prev) => prev + 1);
   }, []);
 
   // Handle snapshot button (REQ-F-23)
@@ -236,6 +242,7 @@ export function PairWritingMode({
         onSnapshot={handleSnapshot}
         onSave={handleSave}
         onExit={handleExitClick}
+        onShowActions={handleShowActions}
         filePath={filePath}
         snapshotContent={state.snapshot ?? undefined}
       />
@@ -256,6 +263,7 @@ export function PairWritingMode({
             onSelectionChange={handleSelectionChange}
             hasSnapshot={state.snapshot !== null}
             snapshotContent={state.snapshot ?? undefined}
+            openMenuTrigger={openMenuTrigger}
           />
         </div>
 

--- a/frontend/src/components/PairWritingToolbar.tsx
+++ b/frontend/src/components/PairWritingToolbar.tsx
@@ -25,6 +25,8 @@ export interface PairWritingToolbarProps {
   onSave: () => void;
   /** Called when user clicks Exit button (REQ-F-14) */
   onExit: () => void;
+  /** Called when user clicks Actions button (opens context menu for selected text) */
+  onShowActions?: () => void;
   /** Current file path being edited (displayed in toolbar) */
   filePath?: string;
   /** The actual snapshot text content (for hover preview) */
@@ -72,6 +74,7 @@ export function PairWritingToolbar({
   onSnapshot,
   onSave,
   onExit,
+  onShowActions,
   filePath,
   snapshotContent,
 }: PairWritingToolbarProps): React.ReactNode {
@@ -97,6 +100,33 @@ export function PairWritingToolbar({
 
       {/* Right section: action buttons */}
       <div className="pair-writing-toolbar__actions">
+        {/* Actions button for mobile/iPad (opens context menu without long-press) */}
+        {onShowActions && (
+          <button
+            type="button"
+            className="pair-writing-toolbar__btn pair-writing-toolbar__btn--actions"
+            onClick={onShowActions}
+            disabled={!hasSelection}
+            title={hasSelection ? "Show actions for selected text" : "Select text to enable actions"}
+          >
+            <svg
+              className="pair-writing-toolbar__icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="1" />
+              <circle cx="12" cy="5" r="1" />
+              <circle cx="12" cy="19" r="1" />
+            </svg>
+            <span className="pair-writing-toolbar__label">Actions</span>
+          </button>
+        )}
+
         {/* Snapshot button with hover preview (REQ-F-23) */}
         <div
           className="pair-writing-toolbar__snapshot-wrapper"

--- a/frontend/src/components/__tests__/PairWritingEditor.test.tsx
+++ b/frontend/src/components/__tests__/PairWritingEditor.test.tsx
@@ -4,7 +4,7 @@
  * Tests cover:
  * - Initial rendering with props
  * - Content state management
- * - Context menu interactions (right-click, long-press)
+ * - Context menu interactions (right-click, openMenuTrigger prop)
  * - Quick Action flow (send message, processing state, response handling)
  * - Advisory Action delegation
  * - Error handling
@@ -256,6 +256,40 @@ describe("PairWritingEditor - context menu", () => {
     textarea.dispatchEvent(event);
 
     expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it("opens context menu when openMenuTrigger prop increments (for toolbar Actions button)", () => {
+    const props = createDefaultProps();
+    const { rerender } = render(<PairWritingEditor {...props} openMenuTrigger={0} />);
+
+    const textarea = getTextarea();
+
+    // Select some text first
+    simulateTextSelection(textarea, 0, 15);
+
+    // Menu should not be open yet
+    expect(screen.queryByTestId("context-menu")).toBeNull();
+
+    // Increment the trigger to open menu
+    rerender(<PairWritingEditor {...props} openMenuTrigger={1} />);
+
+    expect(screen.getByTestId("context-menu")).toBeDefined();
+  });
+
+  it("does not open context menu via trigger when no selection exists", () => {
+    const props = createDefaultProps();
+    const { rerender } = render(<PairWritingEditor {...props} openMenuTrigger={0} />);
+
+    const textarea = getTextarea();
+
+    // No selection (cursor only)
+    simulateTextSelection(textarea, 5, 5);
+
+    // Increment the trigger
+    rerender(<PairWritingEditor {...props} openMenuTrigger={1} />);
+
+    // Menu should not open without selection
+    expect(screen.queryByTestId("context-menu")).toBeNull();
   });
 });
 

--- a/frontend/src/components/__tests__/PairWritingToolbar.test.tsx
+++ b/frontend/src/components/__tests__/PairWritingToolbar.test.tsx
@@ -239,6 +239,46 @@ describe("PairWritingToolbar", () => {
     });
   });
 
+  describe("actions button (iPad selection alternative)", () => {
+    it("renders Actions button when onShowActions is provided", () => {
+      const onShowActions = mock(() => {});
+      render(<PairWritingToolbar {...defaultProps} onShowActions={onShowActions} />);
+
+      expect(screen.getByTitle(/show actions/i)).toBeDefined();
+    });
+
+    it("does not render Actions button when onShowActions is not provided", () => {
+      render(<PairWritingToolbar {...defaultProps} />);
+
+      expect(screen.queryByTitle(/show actions/i)).toBeNull();
+    });
+
+    it("calls onShowActions when clicked with selection", () => {
+      const onShowActions = mock(() => {});
+      render(<PairWritingToolbar {...defaultProps} onShowActions={onShowActions} hasSelection={true} />);
+
+      fireEvent.click(screen.getByTitle(/show actions/i));
+
+      expect(onShowActions).toHaveBeenCalledTimes(1);
+    });
+
+    it("is disabled when no selection", () => {
+      const onShowActions = mock(() => {});
+      render(<PairWritingToolbar {...defaultProps} onShowActions={onShowActions} hasSelection={false} />);
+
+      const actionsBtn = screen.getByTitle(/select text to enable/i);
+      expect(actionsBtn.hasAttribute("disabled")).toBe(true);
+    });
+
+    it("is enabled when selection exists", () => {
+      const onShowActions = mock(() => {});
+      render(<PairWritingToolbar {...defaultProps} onShowActions={onShowActions} hasSelection={true} />);
+
+      const actionsBtn = screen.getByTitle(/show actions/i);
+      expect(actionsBtn.hasAttribute("disabled")).toBe(false);
+    });
+  });
+
   describe("accessibility", () => {
     it("has toolbar role", () => {
       render(<PairWritingToolbar {...defaultProps} />);


### PR DESCRIPTION
## Summary
- Remove long-press context menu from PairWritingEditor (conflicts with iOS native text selection)
- Add "Actions" button to toolbar that opens context menu when text is selected
- Provides iPad-friendly alternative to long-press for accessing Quick Actions and Advisory Actions

Closes #387

## Test plan
- [ ] On iPad: Select text in Pair Writing editor using native iOS selection
- [ ] Verify "Actions" button becomes enabled when text is selected
- [ ] Tap "Actions" button and verify context menu appears
- [ ] On desktop: Verify right-click still opens context menu
- [ ] Verify all Quick Actions and Advisory Actions work from the new button

🤖 Generated with [Claude Code](https://claude.com/claude-code)