### PR TITLE
refactor: Centralize SDK dependency injection with fail-safe pattern

### DIFF
--- a/backend/src/__tests__/inspiration-manager.test.ts
+++ b/backend/src/__tests__/inspiration-manager.test.ts
@@ -39,8 +39,6 @@ import {
   generateContextualPrompts,
   generateInspirationQuote,
   generateWeekendPrompts,
-  setQueryFunction,
-  resetQueryFunction,
   selectRandom,
   selectWeightedRandom,
   getInspiration,
@@ -55,8 +53,8 @@ import {
   DAY_CONTEXT_CONFIG,
   GENERATION_MODEL,
   MAX_GENERATION_CONTEXT,
-  type QueryFunction,
 } from "../inspiration-manager";
+import { configureSdkForTesting, _resetForTesting, type QueryFunction } from "../sdk-provider";
 
 // =============================================================================
 // parseGenerationMarker Tests
@@ -2422,7 +2420,7 @@ function createErrorMockQueryFn(message: string): QueryFunction {
 
 describe("generateContextualPrompts", () => {
   afterEach(() => {
-    resetQueryFunction();
+    _resetForTesting();
   });
 
   test("returns empty array for empty context", async () => {
@@ -2438,7 +2436,7 @@ describe("generateContextualPrompts", () => {
   test("calls query function with correct parameters", async () => {
     let capturedArgs: { prompt: string; options: { model: string } } | null = null;
 
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn('- "A prompt based on context"', (args) => {
         capturedArgs = args;
       })
@@ -2452,7 +2450,7 @@ describe("generateContextualPrompts", () => {
   });
 
   test("parses response from mock SDK", async () => {
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn(`- "What goals energize you most?"
 - "How can you build on yesterday's momentum?"`)
     );
@@ -2467,7 +2465,7 @@ describe("generateContextualPrompts", () => {
   test("truncates long context", async () => {
     let capturedPrompt = "";
 
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn("", (args) => {
         capturedPrompt = args.prompt;
       })
@@ -2486,7 +2484,7 @@ describe("generateContextualPrompts", () => {
   });
 
   test("returns empty array on SDK error", async () => {
-    setQueryFunction(createErrorMockQueryFn("SDK connection failed"));
+    configureSdkForTesting(createErrorMockQueryFn("SDK connection failed"));
 
     const items = await generateContextualPrompts("Some context");
 
@@ -2494,7 +2492,7 @@ describe("generateContextualPrompts", () => {
   });
 
   test("handles SDK returning empty response", async () => {
-    setQueryFunction(createMockQueryFn(""));
+    configureSdkForTesting(createMockQueryFn(""));
 
     const items = await generateContextualPrompts("Some context");
 
@@ -2508,13 +2506,13 @@ describe("generateContextualPrompts", () => {
 
 describe("generateInspirationQuote", () => {
   afterEach(() => {
-    resetQueryFunction();
+    _resetForTesting();
   });
 
   test("calls query function with correct parameters", async () => {
     let capturedArgs: { prompt: string; options: { model: string } } | null = null;
 
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn('- "A wise quote" -- Someone', (args) => {
         capturedArgs = args;
       })
@@ -2528,7 +2526,7 @@ describe("generateInspirationQuote", () => {
   });
 
   test("parses quote with attribution", async () => {
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn('- "The only way to do great work is to love what you do." -- Steve Jobs')
     );
 
@@ -2542,7 +2540,7 @@ describe("generateInspirationQuote", () => {
   });
 
   test("handles quote without attribution", async () => {
-    setQueryFunction(createMockQueryFn('- "An anonymous wise saying"'));
+    configureSdkForTesting(createMockQueryFn('- "An anonymous wise saying"'));
 
     const items = await generateInspirationQuote();
 
@@ -2551,7 +2549,7 @@ describe("generateInspirationQuote", () => {
   });
 
   test("returns empty array on SDK error", async () => {
-    setQueryFunction(createErrorMockQueryFn("API rate limit exceeded"));
+    configureSdkForTesting(createErrorMockQueryFn("API rate limit exceeded"));
 
     const items = await generateInspirationQuote();
 
@@ -2559,7 +2557,7 @@ describe("generateInspirationQuote", () => {
   });
 
   test("handles multiple assistant events", async () => {
-    setQueryFunction(
+    configureSdkForTesting(
       createMultiResponseMockQueryFn(['- "First part', ' continued" -- Author'])
     );
 
@@ -2580,13 +2578,13 @@ describe("generateInspirationQuote", () => {
 
 describe("generateWeekendPrompts", () => {
   afterEach(() => {
-    resetQueryFunction();
+    _resetForTesting();
   });
 
   test("calls query function with correct parameters", async () => {
     let capturedArgs: { prompt: string; options: { model: string } } | null = null;
 
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn('- "A creative prompt"', (args) => {
         capturedArgs = args;
       })
@@ -2601,7 +2599,7 @@ describe("generateWeekendPrompts", () => {
   });
 
   test("parses multiple creative prompts", async () => {
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn(`- "What would you create if you had no constraints?"
 - "If you could learn any skill instantly, what would it be?"
 - "Describe your perfect lazy day"`)
@@ -2617,7 +2615,7 @@ describe("generateWeekendPrompts", () => {
   test("works without context (general creative prompts)", async () => {
     let capturedPrompt = "";
 
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn('- "A creative prompt"', (args) => {
         capturedPrompt = args.prompt;
       })
@@ -2632,7 +2630,7 @@ describe("generateWeekendPrompts", () => {
   test("works with context (uses light nudge)", async () => {
     let capturedPrompt = "";
 
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn('- "A creative prompt"', (args) => {
         capturedPrompt = args.prompt;
       })
@@ -2646,7 +2644,7 @@ describe("generateWeekendPrompts", () => {
   });
 
   test("returns empty array on SDK error", async () => {
-    setQueryFunction(createErrorMockQueryFn("SDK error"));
+    configureSdkForTesting(createErrorMockQueryFn("SDK error"));
 
     const items = await generateWeekendPrompts();
 
@@ -2654,7 +2652,7 @@ describe("generateWeekendPrompts", () => {
   });
 
   test("handles empty SDK response", async () => {
-    setQueryFunction(createMockQueryFn(""));
+    configureSdkForTesting(createMockQueryFn(""));
 
     const items = await generateWeekendPrompts();
 
@@ -2663,18 +2661,18 @@ describe("generateWeekendPrompts", () => {
 });
 
 // =============================================================================
-// setQueryFunction / resetQueryFunction Tests
+// SDK Provider Injection Tests
 // =============================================================================
 
-describe("Query Function Injection", () => {
+describe("SDK Provider Injection", () => {
   afterEach(() => {
-    resetQueryFunction();
+    _resetForTesting();
   });
 
-  test("setQueryFunction allows mocking SDK calls", async () => {
+  test("configureSdkForTesting allows mocking SDK calls", async () => {
     let wasCalled = false;
 
-    setQueryFunction(
+    configureSdkForTesting(
       createMockQueryFn('- "Test"', () => {
         wasCalled = true;
       })
@@ -2684,13 +2682,13 @@ describe("Query Function Injection", () => {
     expect(wasCalled).toBe(true);
   });
 
-  test("resetQueryFunction restores default behavior", async () => {
-    setQueryFunction(createMockQueryFn('- "Mock"'));
-    resetQueryFunction();
+  test("_resetForTesting clears SDK configuration", async () => {
+    configureSdkForTesting(createMockQueryFn('- "Mock"'));
+    _resetForTesting();
 
-    // After reset, calling with empty context should return empty array
-    // (testing that it doesn't use mock anymore, which would return a result)
-    const items = await generateContextualPrompts("");
+    // After reset, SDK is uninitialized so calls should fail gracefully
+    // (the function catches errors and returns empty array)
+    const items = await generateContextualPrompts("context");
     expect(items).toEqual([]);
   });
 });
@@ -2898,7 +2896,7 @@ describe("getInspiration", () => {
   });
 
   afterEach(async () => {
-    resetQueryFunction();
+    _resetForTesting();
     await rm(testVaultPath, { recursive: true, force: true });
   });
 
@@ -2910,7 +2908,7 @@ describe("getInspiration", () => {
   describe("basic functionality", () => {
     test("returns object with contextual and quote properties", async () => {
       // Mock to prevent real SDK calls
-      setQueryFunction(createMockQueryFn(""));
+      configureSdkForTesting(createMockQueryFn(""));
 
       const vault = createTestVault();
       const result = await getInspiration(vault);
@@ -2920,7 +2918,7 @@ describe("getInspiration", () => {
     });
 
     test("returns fallback quote when quote file missing", async () => {
-      setQueryFunction(createMockQueryFn(""));
+      configureSdkForTesting(createMockQueryFn(""));
 
       const vault = createTestVault();
       const result = await getInspiration(vault);
@@ -2929,7 +2927,7 @@ describe("getInspiration", () => {
     });
 
     test("returns null for contextual when file missing", async () => {
-      setQueryFunction(createMockQueryFn(""));
+      configureSdkForTesting(createMockQueryFn(""));
 
       // Use a weekday date
       const vault = createTestVault();
@@ -2955,7 +2953,7 @@ describe("getInspiration", () => {
         quoteContent
       );
 
-      setQueryFunction(createMockQueryFn(""));
+      configureSdkForTesting(createMockQueryFn(""));
 
       const vault = createTestVault();
       const result = await getInspiration(vault);
@@ -2985,7 +2983,7 @@ describe("getInspiration", () => {
         quoteContent
       );
 
-      setQueryFunction(createMockQueryFn(""));
+      configureSdkForTesting(createMockQueryFn(""));
 
       // Only test on weekdays - the function checks isWeekday internally
       const vault = createTestVault();
@@ -3005,7 +3003,7 @@ describe("getInspiration", () => {
     test("triggers quote generation when quote file missing", async () => {
       let queryWasCalled = false;
 
-      setQueryFunction(
+      configureSdkForTesting(
         createMockQueryFn('- "Generated quote" -- AI', () => {
           queryWasCalled = true;
         })
@@ -3041,7 +3039,7 @@ describe("getInspiration", () => {
       );
 
       let queryWasCalled = false;
-      setQueryFunction(
+      configureSdkForTesting(
         createMockQueryFn("", () => {
           queryWasCalled = true;
         })
@@ -3057,7 +3055,7 @@ describe("getInspiration", () => {
 
   describe("error handling", () => {
     test("returns fallback quote when generation fails", async () => {
-      setQueryFunction(createErrorMockQueryFn("SDK error"));
+      configureSdkForTesting(createErrorMockQueryFn("SDK error"));
 
       const vault = createTestVault();
       const result = await getInspiration(vault);
@@ -3067,7 +3065,7 @@ describe("getInspiration", () => {
     });
 
     test("handles permission errors gracefully", async () => {
-      setQueryFunction(createMockQueryFn(""));
+      configureSdkForTesting(createMockQueryFn(""));
 
       // Point to a path that definitely doesn't exist
       const nonExistentVault = createMockVault({
@@ -3101,7 +3099,7 @@ describe("getInspiration", () => {
         quoteContent
       );
 
-      setQueryFunction(createMockQueryFn(""));
+      configureSdkForTesting(createMockQueryFn(""));
 
       // On weekends, contextual should be null
       // Note: We can't easily mock the date in this test, so we verify the
@@ -3124,7 +3122,7 @@ describe("getInspiration", () => {
 
   describe("integration with file writing", () => {
     test("creates quote file after generation", async () => {
-      setQueryFunction(
+      configureSdkForTesting(
         createMockQueryFn('- "Newly generated" -- AI Author')
       );
 
@@ -3150,7 +3148,7 @@ describe("getInspiration", () => {
         oldContent
       );
 
-      setQueryFunction(
+      configureSdkForTesting(
         createMockQueryFn('- "New quote" -- New Author')
       );
 

--- a/backend/src/__tests__/sdk-provider.test.ts
+++ b/backend/src/__tests__/sdk-provider.test.ts
@@ -1,0 +1,128 @@
+/**
+ * SDK Provider Tests
+ *
+ * Tests for the centralized SDK provider module.
+ * Verifies fail-safe behavior where uninitialized SDK throws rather than
+ * making real API calls.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  initializeSdkProvider,
+  configureSdkForTesting,
+  getSdkQuery,
+  _resetForTesting,
+  SdkNotInitializedError,
+} from "../sdk-provider";
+
+// Always clean up after each test
+afterEach(() => {
+  _resetForTesting();
+});
+
+describe("SdkNotInitializedError", () => {
+  test("has correct name", () => {
+    const error = new SdkNotInitializedError();
+    expect(error.name).toBe("SdkNotInitializedError");
+  });
+
+  test("has informative message", () => {
+    const error = new SdkNotInitializedError();
+    expect(error.message).toContain("initializeSdkProvider");
+    expect(error.message).toContain("configureSdkForTesting");
+  });
+
+  test("is instance of Error", () => {
+    const error = new SdkNotInitializedError();
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe("getSdkQuery", () => {
+  test("throws SdkNotInitializedError when not initialized", () => {
+    expect(() => getSdkQuery()).toThrow(SdkNotInitializedError);
+  });
+
+  test("returns query function after initializeSdkProvider", () => {
+    initializeSdkProvider();
+    const query = getSdkQuery();
+    expect(typeof query).toBe("function");
+  });
+
+  test("returns mock function after configureSdkForTesting", () => {
+    const mockFn = (() => {}) as never;
+    configureSdkForTesting(mockFn);
+    expect(getSdkQuery()).toBe(mockFn);
+  });
+});
+
+describe("initializeSdkProvider", () => {
+  test("throws if called twice", () => {
+    initializeSdkProvider();
+    expect(() => initializeSdkProvider()).toThrow("already initialized");
+  });
+
+  test("allows getSdkQuery after initialization", () => {
+    initializeSdkProvider();
+    expect(() => getSdkQuery()).not.toThrow();
+  });
+});
+
+describe("configureSdkForTesting", () => {
+  test("returns cleanup function", () => {
+    const cleanup = configureSdkForTesting((() => {}) as never);
+    expect(typeof cleanup).toBe("function");
+  });
+
+  test("cleanup function resets state", () => {
+    const cleanup = configureSdkForTesting((() => {}) as never);
+    cleanup();
+    expect(() => getSdkQuery()).toThrow(SdkNotInitializedError);
+  });
+
+  test("allows multiple configurations (for test isolation)", () => {
+    const mock1 = (() => "mock1") as never;
+    const mock2 = (() => "mock2") as never;
+
+    configureSdkForTesting(mock1);
+    expect(getSdkQuery()).toBe(mock1);
+
+    // Can reconfigure without calling cleanup
+    configureSdkForTesting(mock2);
+    expect(getSdkQuery()).toBe(mock2);
+  });
+});
+
+describe("_resetForTesting", () => {
+  test("does not throw when not initialized", () => {
+    expect(() => _resetForTesting()).not.toThrow();
+  });
+
+  test("resets after initializeSdkProvider", () => {
+    initializeSdkProvider();
+    _resetForTesting();
+    expect(() => getSdkQuery()).toThrow(SdkNotInitializedError);
+  });
+
+  test("allows re-initialization after reset", () => {
+    initializeSdkProvider();
+    _resetForTesting();
+    expect(() => initializeSdkProvider()).not.toThrow();
+  });
+});
+
+describe("Fail-safe behavior", () => {
+  test("uninitialized SDK throws, not makes API calls", () => {
+    // This is the key safety guarantee: without initialization,
+    // getSdkQuery() throws rather than returning the real SDK.
+    // If the real SDK was returned, calling it would hit the API.
+    try {
+      getSdkQuery();
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(SdkNotInitializedError);
+      // NOT an SDK error from a real API call
+      expect(error).not.toHaveProperty("status");
+    }
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,10 @@
  * - Memory extraction scheduler (REQ-F-4)
  */
 
+// Initialize SDK provider FIRST, before any other imports that might use it
+import { initializeSdkProvider } from "./sdk-provider";
+initializeSdkProvider();
+
 import { serverConfig, isTlsEnabled, createHttpRedirectServer, getPort } from "./server";
 import { serverLog as log } from "./logger";
 import { startScheduler, getCronSchedule } from "./extraction/extraction-manager";

--- a/backend/src/sdk-provider.ts
+++ b/backend/src/sdk-provider.ts
@@ -1,0 +1,81 @@
+/**
+ * SDK Provider
+ *
+ * Centralized management for Claude Agent SDK query function.
+ * Provides a fail-safe pattern where:
+ * - Production: Must call initializeSdkProvider() at startup
+ * - Tests: Must call configureSdkForTesting() with a mock
+ * - Without initialization: Throws SdkNotInitializedError (not real API calls)
+ *
+ * This prevents accidental API calls in tests by requiring explicit configuration.
+ */
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+export type QueryFunction = typeof query;
+
+let _queryFn: QueryFunction | null = null;
+let _initialized = false;
+
+/**
+ * Error thrown when SDK is used without initialization.
+ * This is a safety net to prevent accidental real API calls in tests.
+ */
+export class SdkNotInitializedError extends Error {
+  constructor() {
+    super(
+      "SDK not initialized. Call initializeSdkProvider() at startup, " +
+        "or configureSdkForTesting() in tests."
+    );
+    this.name = "SdkNotInitializedError";
+  }
+}
+
+/**
+ * Initialize with real SDK (call once at server startup).
+ * Throws if already initialized to prevent accidental re-initialization.
+ */
+export function initializeSdkProvider(): void {
+  if (_initialized) {
+    throw new Error("SDK provider already initialized");
+  }
+  _queryFn = query;
+  _initialized = true;
+}
+
+/**
+ * Configure with mock for testing. Returns cleanup function.
+ * Call the returned function in afterEach to reset state.
+ *
+ * @param mockFn - Mock query function for testing
+ * @returns Cleanup function to call in afterEach
+ */
+export function configureSdkForTesting(mockFn: QueryFunction): () => void {
+  _queryFn = mockFn;
+  _initialized = true;
+
+  return () => {
+    _queryFn = null;
+    _initialized = false;
+  };
+}
+
+/**
+ * Get the SDK query function.
+ * Throws SdkNotInitializedError if not initialized, preventing accidental API calls.
+ */
+export function getSdkQuery(): QueryFunction {
+  if (!_initialized || _queryFn === null) {
+    throw new SdkNotInitializedError();
+  }
+  return _queryFn;
+}
+
+/**
+ * Reset for testing isolation. Only use in test cleanup.
+ * Does not throw if not initialized (safe for afterEach cleanup).
+ */
+export function _resetForTesting(): void {
+  _queryFn = null;
+  _initialized = false;
+}

--- a/backend/src/vault-setup.ts
+++ b/backend/src/vault-setup.ts
@@ -11,7 +11,6 @@
 import { copyFile, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { query } from "@anthropic-ai/claude-agent-sdk";
 import { createLogger } from "./logger";
 import { getVaultById, fileExists, directoryExists } from "./vault-manager";
 import { validatePath } from "./file-browser";
@@ -24,38 +23,9 @@ import {
   resolveAttachmentPath,
   type VaultConfig,
 } from "./vault-config";
+import { getSdkQuery } from "./sdk-provider";
 
 const log = createLogger("VaultSetup");
-
-// =============================================================================
-// SDK Query Injection (for testing)
-// =============================================================================
-
-/**
- * Type for the SDK query function.
- */
-export type QueryFunction = typeof query;
-
-/**
- * Module-level query function reference.
- * Can be overridden in tests using setQueryFunction.
- */
-let queryFn: QueryFunction = query;
-
-/**
- * Sets the query function for testing purposes.
- * Allows mocking SDK calls.
- */
-export function setQueryFunction(fn: QueryFunction): void {
-  queryFn = fn;
-}
-
-/**
- * Resets the query function to the default SDK implementation.
- */
-export function resetQueryFunction(): void {
-  queryFn = query;
-}
 
 // =============================================================================
 // Types
@@ -513,7 +483,7 @@ export async function updateClaudeMd(
   try {
     log.info("Calling SDK to update CLAUDE.md...");
 
-    const queryResult = queryFn({
+    const queryResult = getSdkQuery()({
       prompt,
       options: {
         cwd: vaultPath,


### PR DESCRIPTION
Replaces inconsistent SDK injection patterns across modules with a centralized sdk-provider that throws SdkNotInitializedError when uninitialized, preventing accidental API calls in tests.

Production: initializeSdkProvider() at server startup
Tests: configureSdkForTesting(mock) returns cleanup function