### PR TITLE
fix: Simplify discuss action to open-ended conversation

### DIFF
--- a/backend/src/pair-writing-prompts.ts
+++ b/backend/src/pair-writing-prompts.ts
@@ -360,17 +360,12 @@ const ADVISORY_ACTION_CONFIGS: Record<AdvisoryActionType, AdvisoryConfig> = {
   },
   discuss: {
     name: "Discuss",
-    taskDescription: "Engage in a discussion about the selected text",
-    role: "engaging in a discussion about content",
-    selectionLabel: "Selected text to discuss",
-    contextLabel: "Surrounding context (for reference)",
-    closing: "Engage thoughtfully, exploring different angles and encouraging deeper understanding.",
-    rules: [
-      "Consider different perspectives on the content",
-      "Explore implications and underlying assumptions",
-      "Ask questions to deepen understanding",
-      "Encourage critical thinking and reflection",
-    ],
+    taskDescription: "Discuss the selected text",
+    role: "a writing partner ready to discuss",
+    selectionLabel: "Selected text",
+    contextLabel: "Surrounding context",
+    closing: "What would you like to explore?",
+    rules: [],
   },
 };
 
@@ -392,13 +387,14 @@ function buildStandardAdvisoryPrompt(
     calculatePositionHint(context.startLine, context.endLine, context.totalLines)
   );
 
+  const instructionsBlock = config.rules.length > 0
+    ? `\nInstructions:\n${formatRules(config.rules)}\n`
+    : "";
+
   return `You are a writing assistant ${config.role}.
 
 Task: ${config.taskDescription} ${positionPhrase} "${context.filePath}".
-
-Instructions:
-${formatRules(config.rules)}
-
+${instructionsBlock}
 ${config.selectionLabel}:
 ${context.selectedText}
 


### PR DESCRIPTION
## Summary
- Removes prescriptive rules from the discuss advisory action (perspectives, implications, critical thinking)
- Updates prompt builder to omit the Instructions section when rules are empty
- Changes closing from directive to simple invitation: "What would you like to explore?"

The discuss action was duplicating validate and critique's structured analysis. Its purpose is to start an unbounded conversation, not guide a specific analysis pattern.

## Test plan
- [x] Unit tests pass (`bun run --cwd backend test src/__tests__/pair-writing-prompts.test.ts`)
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)