### PR TITLE
fix: Remove sleep from unit tests using fake timers (#237)

### DIFF
--- a/backend/src/__tests__/search-index.test.ts
+++ b/backend/src/__tests__/search-index.test.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { SearchIndexManager, type IndexData } from "../search/search-index";
+import { setFileMtime } from "./test-helpers";
 
 // =============================================================================
 // Test Helpers
@@ -1027,10 +1028,10 @@ describe("index persistence", () => {
 
       // Modify an existing file (need to change mtime)
       const filePath = join(vaultPath, "README.md");
-
-      // Wait a bit to ensure mtime changes
-      await new Promise((resolve) => setTimeout(resolve, 10));
       await writeFile(filePath, "# Modified README\n\nNow contains MODIFIED_CONTENT");
+
+      // Set mtime to future to ensure change detection
+      await setFileMtime(filePath, new Date(Date.now() + 1000));
 
       // Run incremental update
       const result = await manager.updateIndex();
@@ -1076,8 +1077,11 @@ describe("index persistence", () => {
       await writeFile(join(vaultPath, "new-file.md"), "New content");
 
       // Modify an existing file
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      await writeFile(join(vaultPath, "notes/meeting-notes.md"), "# Modified Meeting\n\nModified content");
+      const modifiedFilePath = join(vaultPath, "notes/meeting-notes.md");
+      await writeFile(modifiedFilePath, "# Modified Meeting\n\nModified content");
+
+      // Set mtime to future to ensure change detection
+      await setFileMtime(modifiedFilePath, new Date(Date.now() + 1000));
 
       // Delete a file
       await rm(join(vaultPath, "projects/project-alpha.md"));

--- a/backend/src/__tests__/search-integration.test.ts
+++ b/backend/src/__tests__/search-integration.test.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { SearchIndexManager } from "../search/search-index";
+import { setFileMtime } from "./test-helpers";
 
 // =============================================================================
 // Test Helpers
@@ -415,14 +416,12 @@ describe("Incremental index updates", () => {
   });
 
   test("modified files are re-indexed", async () => {
-    // Wait to ensure mtime changes
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
     // Modify existing file
-    await writeFile(
-      join(tempDir, "notes", "existing.md"),
-      "# Existing\n\nMODIFIED_UNIQUE_CONTENT"
-    );
+    const filePath = join(tempDir, "notes", "existing.md");
+    await writeFile(filePath, "# Existing\n\nMODIFIED_UNIQUE_CONTENT");
+
+    // Set mtime to future to ensure change detection
+    await setFileMtime(filePath, new Date(Date.now() + 1000));
 
     // Run incremental update
     const result = await manager.updateIndex();

--- a/backend/src/__tests__/session-manager.test.ts
+++ b/backend/src/__tests__/session-manager.test.ts
@@ -681,9 +681,7 @@ describe("Session Manager", () => {
       });
       await saveSession(metadata);
 
-      // Wait a tiny bit to ensure different timestamp
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
+      // touchSession sets lastActiveAt to now, which will differ from 2025-01-01
       await touchSession(vaultPath, metadata.id);
 
       const loaded = await loadSession(vaultPath, metadata.id);

--- a/backend/src/__tests__/test-helpers.ts
+++ b/backend/src/__tests__/test-helpers.ts
@@ -4,6 +4,7 @@
  * Common utilities for creating mock objects in tests.
  */
 
+import { open } from "node:fs/promises";
 import type { VaultInfo } from "@memory-loop/shared";
 
 /**
@@ -32,4 +33,20 @@ export function createMockVault(overrides: Partial<VaultInfo> = {}): VaultInfo {
     // Ensure order is always a number (Partial<VaultInfo> allows undefined)
     order: overrides.order ?? 999999,
   };
+}
+
+/**
+ * Sets the modification time (mtime) of a file.
+ * Use instead of sleep() when testing mtime-based change detection.
+ *
+ * @param path - Absolute path to the file
+ * @param time - The time to set as mtime (also sets atime)
+ */
+export async function setFileMtime(path: string, time: Date): Promise<void> {
+  const handle = await open(path, "r");
+  try {
+    await handle.utimes(time, time);
+  } finally {
+    await handle.close();
+  }
 }

--- a/backend/src/__tests__/websocket-handler.test.ts
+++ b/backend/src/__tests__/websocket-handler.test.ts
@@ -572,6 +572,8 @@ describe("WebSocket Handler", () => {
       const slowGenerator = (async function* () {
         yield { type: "system", session_id: "slow-test" };
         // Wait until stopped
+        // Real delay required: async generator coordination.
+        // Fake timers cannot advance generator yield points.
         while (!shouldStop) {
           await new Promise((resolve) => setTimeout(resolve, 5));
         }
@@ -594,7 +596,8 @@ describe("WebSocket Handler", () => {
         JSON.stringify({ type: "discussion_message", text: "Another message" })
       );
 
-      // Give it a moment to start
+      // Real delay required: allows async generator to start before we trigger close.
+      // Fake timers cannot coordinate with generator yield points.
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       // Close connection - this should trigger interrupt
@@ -1173,6 +1176,8 @@ describe("WebSocket Handler", () => {
       mockCreateSession.mockResolvedValueOnce({
         sessionId: "slow-session",
         events: (async function* () {
+          // Real delay required: simulates slow generator processing.
+          // Fake timers cannot advance async generator yield points.
           await new Promise((resolve) => setTimeout(resolve, 1000));
           yield { type: "system", session_id: "slow-session" };
         })(),
@@ -1200,7 +1205,8 @@ describe("WebSocket Handler", () => {
         JSON.stringify({ type: "discussion_message", text: "First" })
       );
 
-      // Give it a moment to start
+      // Real delay required: allows async generator to start before sending second message.
+      // Fake timers cannot coordinate with generator yield points.
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       // Start second discussion (this should abort the first)
@@ -1872,6 +1878,8 @@ describe("WebSocket Handler", () => {
       mockCreateSession.mockResolvedValue({
         sessionId: "active-session",
         events: (async function* () {
+          // Real delay required: simulates slow generator processing.
+          // Fake timers cannot advance async generator yield points.
           await new Promise((resolve) => setTimeout(resolve, 1000));
         })(),
         interrupt: activeInterrupt,
@@ -1891,6 +1899,8 @@ describe("WebSocket Handler", () => {
         JSON.stringify({ type: "discussion_message", text: "Hello" })
       );
 
+      // Real delay required: allows async generator to start before triggering new_session.
+      // Fake timers cannot coordinate with generator yield points.
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       // New session should interrupt
@@ -1962,6 +1972,8 @@ describe("WebSocket Handler", () => {
       mockCreateSession.mockResolvedValue({
         sessionId: "active-session",
         events: (async function* () {
+          // Real delay required: simulates slow generator processing.
+          // Fake timers cannot advance async generator yield points.
           await new Promise((resolve) => setTimeout(resolve, 1000));
         })(),
         interrupt: activeInterrupt,
@@ -1981,6 +1993,8 @@ describe("WebSocket Handler", () => {
         JSON.stringify({ type: "discussion_message", text: "Hello" })
       );
 
+      // Real delay required: allows async generator to start before triggering abort.
+      // Fake timers cannot coordinate with generator yield points.
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       // Abort

--- a/backend/src/extraction/__tests__/extraction-manager.test.ts
+++ b/backend/src/extraction/__tests__/extraction-manager.test.ts
@@ -424,7 +424,8 @@ describe("runExtraction pipeline", () => {
     // Start extraction without awaiting
     const extractionPromise = runExtraction(false);
 
-    // Give it a tick to start
+    // Real delay required: allows async extraction to begin before checking state.
+    // Fake timers cannot coordinate with async Promise execution.
     await new Promise((resolve) => setTimeout(resolve, 1));
 
     // May or may not be running depending on how fast it fails

--- a/frontend/src/components/shared/__tests__/Toast.test.tsx
+++ b/frontend/src/components/shared/__tests__/Toast.test.tsx
@@ -4,7 +4,7 @@
  * Tests rendering, accessibility, auto-dismiss, and user interactions.
  */
 
-import { describe, it, expect, afterEach, mock, beforeEach } from "bun:test";
+import { describe, it, expect, afterEach, mock, beforeEach, jest } from "bun:test";
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { Toast, type ToastProps } from "../Toast";
 
@@ -102,7 +102,11 @@ describe("Toast", () => {
 
   describe("auto-dismiss", () => {
     beforeEach(() => {
-      // Use fake timers for auto-dismiss tests
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
     });
 
     it("verifies default autoDismissMs is 5000", () => {
@@ -121,33 +125,33 @@ describe("Toast", () => {
       // which proves the auto-dismiss mechanism works
     });
 
-    it("calls onDismiss after custom timeout", async () => {
+    it("calls onDismiss after custom timeout", () => {
       const onDismiss = mock(() => {});
       render(<Toast {...defaultProps} onDismiss={onDismiss} autoDismissMs={100} />);
 
       // Wait for custom auto-dismiss
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      jest.advanceTimersByTime(150);
 
       expect(onDismiss).toHaveBeenCalledTimes(1);
     });
 
-    it("does not auto-dismiss when not visible", async () => {
+    it("does not auto-dismiss when not visible", () => {
       const onDismiss = mock(() => {});
       render(<Toast {...defaultProps} isVisible={false} onDismiss={onDismiss} autoDismissMs={100} />);
 
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      jest.advanceTimersByTime(150);
 
       expect(onDismiss).not.toHaveBeenCalled();
     });
 
-    it("clears timer when component unmounts", async () => {
+    it("clears timer when component unmounts", () => {
       const onDismiss = mock(() => {});
       const { unmount } = render(<Toast {...defaultProps} onDismiss={onDismiss} autoDismissMs={200} />);
 
       // Unmount before timeout
       unmount();
 
-      await new Promise((resolve) => setTimeout(resolve, 250));
+      jest.advanceTimersByTime(250);
 
       expect(onDismiss).not.toHaveBeenCalled();
     });

--- a/frontend/src/hooks/__tests__/useTextSelection.test.ts
+++ b/frontend/src/hooks/__tests__/useTextSelection.test.ts
@@ -4,7 +4,7 @@
  * Tests line counting, paragraph extraction, and hook behavior.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, jest } from "bun:test";
 import { renderHook, act } from "@testing-library/react";
 import {
   useTextSelection,
@@ -428,7 +428,9 @@ describe("useTextSelection hook", () => {
     expect(result.current.selection?.totalLines).toBe(4);
   });
 
-  it("updates selection on touchend (iOS touch selection)", async () => {
+  it("updates selection on touchend (iOS touch selection)", () => {
+    jest.useFakeTimers();
+
     const ref = createRef<HTMLTextAreaElement>();
     (ref as { current: HTMLTextAreaElement }).current = mockTextarea;
 
@@ -443,13 +445,15 @@ describe("useTextSelection hook", () => {
       mockTextarea.dispatchEvent(new TouchEvent("touchend"));
     });
 
-    // touchend handler uses setTimeout(10ms), so we need to wait
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 20));
+    // touchend handler uses setTimeout(10ms), advance past it
+    act(() => {
+      jest.advanceTimersByTime(20);
     });
 
     expect(result.current.selection).not.toBeNull();
     expect(result.current.selection?.text).toBe("Hello");
+
+    jest.useRealTimers();
   });
 
   it("updates selection on document selectionchange when textarea is focused", () => {

--- a/frontend/src/hooks/__tests__/useWebSocket.test.ts
+++ b/frontend/src/hooks/__tests__/useWebSocket.test.ts
@@ -12,6 +12,7 @@ import {
   beforeEach,
   afterEach,
   spyOn,
+  jest,
 } from "bun:test";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useWebSocket, buildWebSocketUrl } from "../useWebSocket";
@@ -349,7 +350,9 @@ describe("useWebSocket", () => {
       );
     });
 
-    it("does not reconnect when autoReconnect is false", async () => {
+    it("does not reconnect when autoReconnect is false", () => {
+      jest.useFakeTimers();
+
       renderHook(() =>
         useWebSocket({ initialDelay: 10, autoReconnect: false })
       );
@@ -359,13 +362,19 @@ describe("useWebSocket", () => {
         instances[0].simulateClose();
       });
 
-      // Wait and verify no reconnect
-      await new Promise((r) => setTimeout(r, 50));
+      // Advance time and verify no reconnect
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
 
       expect(instances.length).toBe(1);
+
+      jest.useRealTimers();
     });
 
-    it("does not reconnect after unmount", async () => {
+    it("does not reconnect after unmount", () => {
+      jest.useFakeTimers();
+
       const { unmount } = renderHook(() =>
         useWebSocket({ initialDelay: 10, autoReconnect: true })
       );
@@ -377,10 +386,14 @@ describe("useWebSocket", () => {
       // Unmount before close
       unmount();
 
-      // Wait and verify no new instances
-      await new Promise((r) => setTimeout(r, 50));
+      // Advance time and verify no new instances
+      act(() => {
+        jest.advanceTimersByTime(50);
+      });
 
       expect(instances.length).toBe(1);
+
+      jest.useRealTimers();
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace ~35 real-time delays across 12 test files with Bun's fake timers for faster, deterministic tests
- Add `setFileMtime()` helper for mtime-based change detection tests
- Document 9 tests that require real delays (async generator coordination) with explanatory comments
- Add fake timer guidelines to CLAUDE.md

## Changes by Category

**Fake Timers (timer callbacks):**
- `useLongPress.test.ts` (17 sleeps)
- `Toast.test.tsx` (3 sleeps)
- `useTextSelection.test.ts` (1 sleep)
- `useWebSocket.test.ts` (2 sleeps)

**setSystemTime (Date.now-dependent):**
- `search-cache.test.ts` (11 sleeps for LRU/TTL logic)

**setFileMtime (filesystem mtime):**
- `search-index.test.ts` (2 sleeps)
- `search-integration.test.ts` (1 sleep)
- `session-manager.test.ts` (1 sleep removed, not needed)

**Documented real delays (async generators):**
- `websocket-handler.test.ts` (8 comments added)
- `extraction-manager.test.ts` (1 comment added)

## Test plan

- [x] All tests pass via `./git-hooks/pre-commit.sh`
- [x] Typecheck passes for backend, frontend, shared
- [x] Lint passes for all workspaces
- [x] Code review completed

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)