### PR TITLE
fix: Allow dots in vault IDs for GitHub-style directory names

### DIFF
--- a/backend/src/__tests__/vault-resolution.test.ts
+++ b/backend/src/__tests__/vault-resolution.test.ts
@@ -47,6 +47,12 @@ describe("isValidVaultId", () => {
     expect(isValidVaultId("vault_1-test")).toBe(true);
   });
 
+  it("accepts vault IDs with dots", () => {
+    expect(isValidVaultId("rjroy.github.io")).toBe(true);
+    expect(isValidVaultId("my.vault.name")).toBe(true);
+    expect(isValidVaultId("vault.v2")).toBe(true);
+  });
+
   it("rejects empty vault IDs", () => {
     expect(isValidVaultId("")).toBe(false);
   });
@@ -57,6 +63,11 @@ describe("isValidVaultId", () => {
 
   it("rejects vault IDs starting with underscore", () => {
     expect(isValidVaultId("_vault")).toBe(false);
+  });
+
+  it("rejects vault IDs starting with dot", () => {
+    expect(isValidVaultId(".vault")).toBe(false);
+    expect(isValidVaultId(".hidden")).toBe(false);
   });
 
   it("rejects path traversal attempts", () => {

--- a/backend/src/middleware/vault-resolution.ts
+++ b/backend/src/middleware/vault-resolution.ts
@@ -16,10 +16,10 @@ import { getVaultById } from "../vault-manager";
 
 /**
  * Regular expression for valid vault IDs.
- * Allows alphanumeric characters, hyphens, and underscores.
+ * Allows alphanumeric characters, hyphens, underscores, and dots.
  * Must start with alphanumeric and be 1-100 characters.
  */
-const VAULT_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,99}$/;
+const VAULT_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$/;
 
 /**
  * Error response format for REST endpoints.
@@ -101,7 +101,7 @@ export function vaultResolution(): MiddlewareHandler {
         c,
         400,
         "VALIDATION_ERROR",
-        "Invalid vault ID format. Must be alphanumeric with hyphens or underscores."
+        "Invalid vault ID format. Must be alphanumeric with hyphens, underscores, or dots."
       );
     }
 


### PR DESCRIPTION
## Summary
- Vault ID validation regex now allows dots (e.g., `rjroy.github.io`)
- Dots are only allowed after the first character to prevent hidden directories
- Added tests for vault IDs with dots and vault IDs starting with dots

## Test plan
- [x] Backend tests pass with new test cases
- [x] Manual test: Verify vault with dots in name is accessible via REST API

🤖 Generated with [Claude Code](https://claude.com/claude-code)