### PR TITLE
feat: Install vault-task-management skill during vault setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,9 @@ afterEach(() => {
 
 ### Running Tests (IMPORTANT)
 
-**For full test suites**: Always use `./git-hooks/pre-commit.sh`. This runs all tests correctly.
+**Tests cannot run in parallel.** Running multiple test suites simultaneously causes flaky failures due to filesystem contention, temp directory conflicts, and shared resource access. If you see random test failures that pass when re-run, this is likely the cause. Do not waste tokens debugging phantom failures from parallel execution.
+
+**For full test suites**: Always use `./git-hooks/pre-commit.sh`. This runs all tests correctly (sequentially, one workspace at a time).
 
 **For targeted tests**: Use the specific test file path:
 ```bash
@@ -184,6 +186,7 @@ bun run --cwd frontend test src/components/__tests__/Home.test.tsx
 - Run `bun run test` (combined command causes resource conflicts)
 - Run `bun run --cwd <module> test` without a specific file (runs all tests in module)
 - Pipe test output through `head` or `tail` (truncates output, hides results)
+- Launch multiple test commands in parallel (causes flaky failures)
 
 ## Documentation
 

--- a/backend/src/skills/vault-task-management/README.md
+++ b/backend/src/skills/vault-task-management/README.md
@@ -1,0 +1,92 @@
+# Vault Task Management Skill
+
+This skill teaches Claude about task management in Obsidian vaults using checkbox syntax with status markers.
+
+## What This Skill Provides
+
+1. **Task syntax understanding** - Recognition of status markers (x, f, /, b, ?)
+2. **PARA category awareness** - Inbox, Projects, and Areas distinctions
+3. **Query tools** - Scripts to efficiently find tasks across the vault
+4. **Formatting guidance** - How to present task information to users
+
+## Task Status Markers
+
+- `[ ]` - Incomplete task
+- `[x]` - Complete
+- `[f]` - Fire (urgent/important)
+- `[/]` - Partial/in-progress
+- `[b]` - Bookmarked/deferred
+- `[?]` - Has open questions
+
+## Scripts
+
+### `scripts/find-tasks.sh`
+
+Raw query tool that outputs pipe-delimited data:
+```bash
+./scripts/find-tasks.sh [all|incomplete|x|f|/|b|?] [vault_path]
+```
+
+Output format: `category|status|file|line|task_text`
+
+### `scripts/show-tasks.sh`
+
+Human-readable formatted output:
+```bash
+./scripts/show-tasks.sh [all|incomplete|x|f|/|b|?] [vault_path]
+```
+
+Groups tasks by category with file locations and line numbers.
+
+## Usage Examples
+
+```bash
+# Show all fire tasks
+./scripts/show-tasks.sh f ~/Projects/Vaults/second-brain
+
+# Find incomplete tasks for parsing
+./scripts/find-tasks.sh incomplete ~/Projects/Vaults/second-brain
+
+# Show tasks with open questions
+./scripts/show-tasks.sh ? ~/Projects/Vaults/second-brain
+
+# List all tasks in current directory
+./scripts/show-tasks.sh all .
+```
+
+## When Claude Uses This Skill
+
+This skill triggers when users ask to:
+- "find tasks"
+- "show tasks"
+- "list tasks"
+- "fire tasks"
+- "incomplete tasks"
+- "tasks in inbox"
+- "tasks with status X"
+
+## File Structure
+
+```
+vault-task-management/
+├── SKILL.md              # Main skill documentation
+├── README.md             # This file
+└── scripts/
+    ├── find-tasks.sh     # Raw query tool
+    └── show-tasks.sh     # Formatted output tool
+```
+
+## Integration
+
+This skill integrates with:
+- Daily review workflows (`/daily-review`)
+- Inbox processing (`/inbox-processor`)
+- Project tracking
+- Weekly synthesis
+
+## Installation
+
+This skill is automatically available in Claude Code when placed in:
+- `~/.claude/skills/vault-task-management/`
+
+Claude will discover it via the SKILL.md metadata and load it when triggered by relevant user queries.

--- a/backend/src/skills/vault-task-management/SKILL.md
+++ b/backend/src/skills/vault-task-management/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: Vault Task Management
+description: This skill should be used when the user asks to "find tasks", "show tasks", "list tasks", "query tasks", "tasks with status", "fire tasks", "incomplete tasks", "tasks in inbox", "tasks in projects", or mentions task checkboxes with status markers (x, f, /, b, ?). Provides task querying across PARA directories in Obsidian vaults.
+version: 0.1.0
+---
+
+# Vault Task Management
+
+This skill provides Claude with knowledge about task management in Obsidian vaults using checkbox syntax with status markers, and tools to efficiently find and query tasks across PARA directories.
+
+## Task Definition
+
+A **task** is any line in a markdown file that starts with `- [ ]` where the character within the brackets denotes the current status.
+
+### Task Status Markers
+
+- `x` - Complete
+- `f` - Fire (important/urgent)
+- `/` - Partial (in progress)
+- `b` - Bookmarked (deferred)
+- `?` - Has open questions
+
+### Task Syntax Examples
+
+```markdown
+- [ ] This is an incomplete task
+- [x] This is a completed task
+- [f] This is a fire/urgent task
+- [/] This is a partial/in-progress task
+- [b] This is a bookmarked/deferred task
+- [?] This task has open questions
+```
+
+## Task Categories
+
+Tasks are organized into three primary categories based on their location in the PARA structure:
+
+1. **Inbox** - Tasks in `00_Inbox/` files (unprocessed, need categorization)
+2. **Projects** - Tasks in `01_Projects/` files (time-bound initiatives)
+3. **Areas** - Tasks in `02_Areas/` files (ongoing responsibilities)
+
+**Note:** Tasks may exist in `03_Resources/` and `04_Archive/` directories, but these are considered secondary for active task management purposes.
+
+## Finding Tasks
+
+Two scripts are available for querying tasks:
+
+1. **`scripts/find-tasks.sh`** - Raw pipe-delimited output for parsing
+2. **`scripts/show-tasks.sh`** - Human-readable formatted output
+
+### Find Tasks (Raw Output)
+
+Use for programmatic parsing or piping to other commands:
+
+```bash
+./scripts/find-tasks.sh [status_filter] [vault_path]
+```
+
+### Show Tasks (Formatted Output)
+
+Use for presenting results to users:
+
+```bash
+./scripts/show-tasks.sh [status_filter] [vault_path]
+```
+
+**Parameters:**
+- `status_filter` - Filter tasks by status (default: `all`)
+  - `all` - Show all tasks regardless of status
+  - `incomplete` - Show all tasks that are NOT complete (excludes `x`)
+  - `x`, `f`, `/`, `b`, `?` - Show only tasks with specific status
+- `vault_path` - Path to Obsidian vault (default: current directory)
+
+### Script Output Format
+
+The script outputs pipe-delimited results:
+
+```
+category|status|file_path|line_number|task_text
+```
+
+**Example output:**
+```
+inbox|f|00_Inbox/2026-01-14.md|15|Follow up with team on SDK adoption
+projects|/|01_Projects/Epic-Social-39.00/README.md|42|Complete authentication integration
+areas|?|02_Areas/EOS-SDK-Team/Team-Project-Status.md|8|Clarify deployment timeline with ops
+```
+
+### Common Query Patterns
+
+**Find all fire tasks (formatted):**
+```bash
+./scripts/show-tasks.sh f /path/to/vault
+```
+
+**Find all incomplete tasks (formatted):**
+```bash
+./scripts/show-tasks.sh incomplete /path/to/vault
+```
+
+**Find tasks with open questions (raw for parsing):**
+```bash
+./scripts/find-tasks.sh ? /path/to/vault
+```
+
+**Find all tasks in current vault:**
+```bash
+./scripts/show-tasks.sh all .
+```
+
+## Using the Scripts in Claude Sessions
+
+When a user asks about tasks, prefer `show-tasks.sh` for direct presentation to users, or `find-tasks.sh` when you need to parse and analyze the data programmatically.
+
+### Example Workflow (Formatted Output)
+
+1. User asks: "Show me all my fire tasks"
+2. Execute: `./scripts/show-tasks.sh f /home/rjroy/Projects/Vaults/second-brain`
+3. Present the formatted output directly
+
+**Example output from show-tasks.sh:**
+```
+Inbox:
+  [f] Unreal Fest Chicago 2026 proposal (due Jan 22)
+    File: 00_Inbox/2026-01-05.md (line 158)
+
+Areas:
+  [f] SDK Performance: Get it formally tied to Epic Social Overlay
+    File: 02_Areas/Leadership-Development/2026-Manager-Operating-System.md (line 38)
+
+Total tasks: 2
+```
+
+### Example Workflow (Parsed Analysis)
+
+1. User asks: "How many incomplete tasks do I have in each category?"
+2. Execute: `./scripts/find-tasks.sh incomplete /home/rjroy/Projects/Vaults/second-brain`
+3. Parse pipe-delimited output and count by category
+4. Present analysis:
+
+```
+Incomplete Task Summary:
+- Inbox: 12 tasks
+- Projects: 5 tasks
+- Areas: 8 tasks
+Total: 25 incomplete tasks
+```
+
+### Formatting Guidelines
+
+When presenting task results:
+
+1. **Group by category** - Separate inbox, projects, and areas
+2. **Include context** - Show file path and line number for easy navigation
+3. **Count tasks** - Provide total count in header
+4. **Clean presentation** - Remove technical pipe-delimited format from user view
+5. **Highlight status** - Make status markers clear when showing multiple statuses
+
+### Reasoning About Tasks
+
+Beyond querying, use task information to:
+
+- **Identify bottlenecks** - Many `?` tasks may indicate unclear requirements
+- **Spot urgency** - High `f` task count suggests overcommitment
+- **Track progress** - Ratio of `/` to incomplete tasks shows momentum
+- **Process inbox** - Large number of inbox tasks suggests need for organization
+- **Surface blockers** - `b` tasks that remain bookmarked too long may need attention
+
+## Task Context and Metadata
+
+When examining tasks, consider:
+
+1. **File context** - Tasks in project READMEs vs daily notes have different implications
+2. **Heading context** - Read the surrounding markdown to understand task context
+3. **Related tasks** - Tasks in the same file or section may be dependent
+4. **Temporal context** - Tasks in daily notes vs persistent project files have different urgency
+
+To get full context for a task:
+1. Use the script to locate the task (file + line number)
+2. Read the file around that line number to understand context
+3. Check the file's YAML frontmatter if present
+4. Consider the file's location in PARA structure
+
+## Advanced Queries
+
+Combine script execution with other tools for complex queries:
+
+**Find tasks in a specific project:**
+```bash
+./scripts/find-tasks.sh all /path/to/vault | grep "01_Projects/ProjectName"
+```
+
+**Count tasks by status:**
+```bash
+./scripts/find-tasks.sh all /path/to/vault | cut -d'|' -f2 | sort | uniq -c
+```
+
+**Find oldest inbox tasks (by filename date):**
+```bash
+./scripts/find-tasks.sh all /path/to/vault | grep "^inbox" | sort -t'|' -k3
+```
+
+## Best Practices
+
+When working with tasks in the vault:
+
+1. **Always use the script** - Don't try to grep manually; the script handles edge cases
+2. **Provide full context** - Include file path and line number when discussing specific tasks
+3. **Respect PARA boundaries** - Understand implications of tasks in different categories
+4. **Don't modify tasks without asking** - Task status changes should be intentional
+5. **Consider task age** - Old incomplete tasks in inbox may need attention
+6. **Batch similar queries** - Run script once and filter results rather than multiple executions
+
+## Script Implementation Details
+
+The `find-tasks.sh` script:
+
+- Searches only PARA directories (`00_Inbox`, `01_Projects`, `02_Areas`)
+- Uses `grep` with recursive search through `.md` files only
+- Captures line numbers for precise task location
+- Categorizes tasks based on file path
+- Sorts output by category, status, then file path
+- Handles edge cases (missing directories, special characters in tasks)
+- Outputs pipe-delimited format for easy parsing
+
+## Examples
+
+### Example 1: Daily review workflow
+
+User: "What tasks do I have in my inbox?"
+
+Claude executes:
+```bash
+./scripts/find-tasks.sh all /home/rjroy/Projects/Vaults/second-brain | grep "^inbox"
+```
+
+Then presents grouped, formatted results.
+
+### Example 2: Project focus
+
+User: "Show me incomplete tasks for Epic 39"
+
+Claude executes:
+```bash
+./scripts/find-tasks.sh incomplete /home/rjroy/Projects/Vaults/second-brain | grep "Epic-Social-39"
+```
+
+Then presents tasks with file context.
+
+### Example 3: Priority triage
+
+User: "What needs my attention right now?"
+
+Claude executes:
+```bash
+./scripts/find-tasks.sh f /home/rjroy/Projects/Vaults/second-brain
+```
+
+Then analyzes fire tasks and suggests priority order.
+
+### Example 4: Blocked work
+
+User: "Which tasks have been deferred?"
+
+Claude executes:
+```bash
+./scripts/find-tasks.sh b /home/rjroy/Projects/Vaults/second-brain
+```
+
+Then reviews bookmarked tasks and asks if any should be unblocked.
+
+## Integration with Other Workflows
+
+This task management skill integrates with:
+
+- **Daily review** - `/daily-review` can surface tasks created during the day
+- **Inbox processing** - `/inbox-processor` can identify tasks that need categorization
+- **Project tracking** - Task queries inform project status updates
+- **Weekly synthesis** - Task completion rates contribute to productivity insights
+
+When tasks appear in these workflows, use the script to retrieve full task context and current status.
+
+## Troubleshooting
+
+**Script returns no results:**
+- Verify vault path is correct
+- Check that search directories exist
+- Ensure markdown files contain task syntax
+- Confirm status filter is valid
+
+**Tasks appear in wrong category:**
+- Verify file is in correct PARA directory
+- Check for symbolic links or unusual directory structures
+
+**Script fails to execute:**
+- Ensure script has execute permissions (`chmod +x`)
+- Verify bash is available
+- Check for syntax errors if modified
+
+## Summary
+
+Use this skill to:
+1. **Understand task syntax** - Recognize status markers and their meanings
+2. **Query efficiently** - Use the script rather than manual searching
+3. **Present clearly** - Format results for user comprehension
+4. **Reason contextually** - Consider file location, status patterns, and temporal context
+5. **Integrate holistically** - Connect task information with other vault workflows
+
+The task management system provides structured tracking while maintaining flexibility through status markers and PARA organization.

--- a/backend/src/skills/vault-task-management/scripts/find-tasks.sh
+++ b/backend/src/skills/vault-task-management/scripts/find-tasks.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# find-tasks.sh - Find tasks in Obsidian vault with status filtering
+# Usage: find-tasks.sh [status_filter] [vault_path]
+#   status_filter: all | incomplete | x | f | / | b | ?
+#   vault_path: defaults to current directory
+
+set -euo pipefail
+
+# Parse arguments
+STATUS_FILTER="${1:-all}"
+VAULT_PATH="${2:-.}"
+
+# Validate vault path exists
+if [[ ! -d "$VAULT_PATH" ]]; then
+    echo "Error: Vault path '$VAULT_PATH' does not exist" >&2
+    exit 1
+fi
+
+# Define search directories (PARA structure)
+SEARCH_DIRS=(
+    "$VAULT_PATH/00_Inbox"
+    "$VAULT_PATH/01_Projects"
+    "$VAULT_PATH/02_Areas"
+)
+
+# Build grep pattern based on status filter
+case "$STATUS_FILTER" in
+    all)
+        PATTERN='\- \[.\]'
+        ;;
+    incomplete)
+        PATTERN='\- \[[^x]\]'
+        ;;
+    x|f|/|b|\?)
+        PATTERN="\- \[${STATUS_FILTER}\]"
+        ;;
+    *)
+        echo "Error: Invalid status filter '$STATUS_FILTER'" >&2
+        echo "Valid options: all, incomplete, x, f, /, b, ?" >&2
+        exit 1
+        ;;
+esac
+
+# Function to categorize file path
+categorize_path() {
+    local path="$1"
+    if [[ "$path" == *"/00_Inbox/"* ]]; then
+        echo "inbox"
+    elif [[ "$path" == *"/01_Projects/"* ]]; then
+        echo "projects"
+    elif [[ "$path" == *"/02_Areas/"* ]]; then
+        echo "areas"
+    else
+        echo "other"
+    fi
+}
+
+# Find and format tasks
+for dir in "${SEARCH_DIRS[@]}"; do
+    if [[ ! -d "$dir" ]]; then
+        continue
+    fi
+
+    # Use grep to find tasks with line numbers
+    # -n: show line numbers
+    # -r: recursive
+    # -H: show filename
+    # --include: only .md files
+    grep -nrH --include="*.md" "$PATTERN" "$dir" 2>/dev/null | while IFS=: read -r filepath linenum content; do
+        # Make path relative to vault
+        rel_path="${filepath#$VAULT_PATH/}"
+        category=$(categorize_path "$filepath")
+
+        # Extract status character
+        status=$(echo "$content" | sed -n 's/.*\[\(.\)\].*/\1/p')
+
+        # Clean up task content (remove checkbox)
+        task_text=$(echo "$content" | sed 's/\- \[.\] //')
+
+        # Output format: category|status|file|line|task
+        echo "${category}|${status}|${rel_path}|${linenum}|${task_text}"
+    done
+done | sort -t'|' -k1,1 -k2,2 -k3,3

--- a/backend/src/skills/vault-task-management/scripts/show-tasks.sh
+++ b/backend/src/skills/vault-task-management/scripts/show-tasks.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# show-tasks.sh - Friendly wrapper for find-tasks.sh with formatted output
+# Usage: show-tasks.sh [status_filter] [vault_path]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIND_TASKS="$SCRIPT_DIR/find-tasks.sh"
+
+# Run find-tasks and format output
+"$FIND_TASKS" "$@" | awk -F'|' '
+BEGIN {
+    current_category = ""
+    count = 0
+}
+{
+    category = $1
+    status = $2
+    file = $3
+    line = $4
+    task = $5
+
+    # Print category header when it changes
+    if (category != current_category) {
+        if (current_category != "") print ""
+        print toupper(substr(category, 1, 1)) substr(category, 2) ":"
+        current_category = category
+    }
+
+    # Print task with status marker if present
+    status_display = (status == " " || status == "") ? "[ ]" : "[" status "]"
+    printf "  %s %s\n", status_display, task
+    printf "    File: %s (line %s)\n", file, line
+    count++
+}
+END {
+    if (count > 0) {
+        print ""
+        print "Total tasks: " count
+    } else {
+        print "No tasks found."
+    }
+}
+'


### PR DESCRIPTION
## Summary

- Add skill installation step to vault setup process (installs to `.claude/skills/`)
- Bundle `vault-task-management` skill for Obsidian task queries with checkbox syntax
- Preserve executable permissions on shell scripts during installation
- Add parallel test execution warning to CLAUDE.md

Closes #374

## Test plan

- [x] All 76 vault-setup tests pass
- [x] Full pre-commit checks pass
- [x] Skills are copied with correct directory structure
- [x] Shell scripts retain executable permissions
- [x] Existing skills are not overwritten

🤖 Generated with [Claude Code](https://claude.ai/code)