### PR TITLE
fix: Include chat transcripts location in CLAUDE.md setup

### DIFF
--- a/backend/src/__tests__/vault-setup.test.ts
+++ b/backend/src/__tests__/vault-setup.test.ts
@@ -685,6 +685,19 @@ describe("buildClaudeMdPrompt", () => {
     expect(prompt).toContain("Edit tool");
     expect(prompt).toContain("Preserve all existing content");
   });
+
+  test("includes chat transcripts location", () => {
+    const prompt = buildClaudeMdPrompt({}, vaultPath);
+
+    expect(prompt).toContain("Chat transcripts location");
+    expect(prompt).toContain("/chats/");
+  });
+
+  test("chat transcripts location uses custom inbox path", () => {
+    const prompt = buildClaudeMdPrompt({ inboxPath: "Custom_Inbox" }, vaultPath);
+
+    expect(prompt).toContain("Custom_Inbox/chats/");
+  });
 });
 
 // =============================================================================

--- a/backend/src/vault-setup.ts
+++ b/backend/src/vault-setup.ts
@@ -611,6 +611,7 @@ Steps:
 1. Read the current CLAUDE.md file
 2. Add or update a "## Memory Loop" section with:
    - Inbox location for daily note capture (${inboxPath})
+   - Chat transcripts location (${inboxPath}/chats/) - AI conversations from the Think tab are saved here as searchable markdown
    - Goals file location (${goalsPath})
    - Note that daily notes are created via the capture tab
    - PARA directory locations for organization


### PR DESCRIPTION
## Summary
- Adds chat transcripts location (`{inbox}/chats/`) to the CLAUDE.md update prompt during vault setup
- Claude will now know where Think tab conversations are saved as searchable markdown
- Includes tests verifying the prompt contains transcripts info and respects custom inbox paths

## Test plan
- [x] Existing vault-setup tests pass (78 tests)
- [x] New tests verify chat transcripts location is included
- [x] Pre-commit hooks pass (typecheck, lint, unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)