### PR TITLE
fix: Require self-contained questions in card generation

### DIFF
--- a/backend/src/spaced-repetition/__tests__/card-generator.test.ts
+++ b/backend/src/spaced-repetition/__tests__/card-generator.test.ts
@@ -287,6 +287,13 @@ describe("buildQAExtractionPrompt", () => {
 
     expect(prompt).toContain("[]");
   });
+
+  test("requires questions to be self-contained", () => {
+    const prompt = buildQAExtractionPrompt("content", "file.md");
+
+    expect(prompt).toContain("self-contained");
+    expect(prompt).toContain("without seeing the source");
+  });
 });
 
 // =============================================================================

--- a/backend/src/spaced-repetition/card-generator.ts
+++ b/backend/src/spaced-repetition/card-generator.ts
@@ -83,9 +83,13 @@ export function buildQAExtractionPrompt(content: string, filePath: string): stri
 
 Requirements:
 - Focus on key facts, concepts, definitions, and relationships
-- Questions should be specific and have a clear, testable answer
+- Questions must be self-contained and answerable without seeing the source
+- Never use "this", "the above", or assume the reader knows the context
+- Include enough context in the question itself (name the system, concept, or domain)
 - Answers should be concise but complete
 - Skip subjective opinions, TODOs, or transient information
+- Skip session-specific details (debugging values, conversation artifacts, temporary states)
+- Only extract facts that would be useful to recall weeks or months later
 - If the content has no extractable facts, return an empty array
 
 Source file: ${filePath}


### PR DESCRIPTION
## Summary

- Generated Q&A cards were assuming reader knew the source context, producing questions like "What is X in this chat session?" that are meaningless during recall
- Updated prompt to require self-contained questions answerable without seeing the source
- Added filtering for session-specific details and transient information

## Test plan

- [x] Existing card generator tests pass
- [x] Added regression test for self-contained requirement
- [ ] Verify manually that new cards from chat transcripts don't reference "this session"

🤖 Generated with [Claude Code](https://claude.com/claude-code)