### PR TITLE
feat: Exclude chat transcripts from card discovery

### DIFF
--- a/backend/src/spaced-repetition/__tests__/card-discovery-scheduler.test.ts
+++ b/backend/src/spaced-repetition/__tests__/card-discovery-scheduler.test.ts
@@ -194,6 +194,21 @@ describe("discoverAllFiles", () => {
     expect(files.some((f) => f.relativePath === "regular.md")).toBe(true);
   });
 
+  it("skips chat transcripts directory", async () => {
+    const vaultPath = await createTestVault(join(testDir, "vaults"), "test-vault");
+    // Create inbox directory (00_Inbox is auto-detected as inboxPath)
+    await createMarkdownFile(vaultPath, "00_Inbox/chats/2026-01-24-session.md", "# Chat Transcript");
+    await createMarkdownFile(vaultPath, "00_Inbox/daily/2026-01-24.md", "# Daily Note");
+    await createMarkdownFile(vaultPath, "regular.md", "# Regular");
+
+    const files = await discoverAllFiles();
+    // Chats should be excluded (ephemeral, not curated knowledge)
+    expect(files.some((f) => f.relativePath.includes("00_Inbox/chats"))).toBe(false);
+    // Other inbox files should be included
+    expect(files.some((f) => f.relativePath === "00_Inbox/daily/2026-01-24.md")).toBe(true);
+    expect(files.some((f) => f.relativePath === "regular.md")).toBe(true);
+  });
+
   it("only includes .md files", async () => {
     const vaultPath = await createTestVault(join(testDir, "vaults"), "test-vault");
     await createMarkdownFile(vaultPath, "note.md", "# Note");

--- a/backend/src/spaced-repetition/card-discovery-scheduler.ts
+++ b/backend/src/spaced-repetition/card-discovery-scheduler.ts
@@ -157,6 +157,10 @@ async function discoverMarkdownFiles(
       if (entry === "06_Metadata" || entryRelPath === vault.metadataPath) {
         continue;
       }
+      // Skip chat transcripts directory (ephemeral, not curated knowledge)
+      if (entryRelPath === `${vault.inboxPath}/chats`) {
+        continue;
+      }
       // Recurse into subdirectory
       const subFiles = await discoverMarkdownFiles(basePath, vault, entryRelPath);
       files.push(...subFiles);


### PR DESCRIPTION
## Summary

- Excludes `{inboxPath}/chats/` directory from spaced repetition card discovery
- Chat transcripts are ephemeral process artifacts, not curated knowledge
- If something from a conversation is worth remembering, the user extracts it into a proper note

## Test plan

- [x] Added test verifying chat transcripts are excluded while other inbox files are discovered
- [x] All existing card discovery tests pass
- [x] Type check and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)