### PR TITLE
feat: Add research-assistant skill for proactive vault context

### DIFF
--- a/backend/src/skills/research-assistant/README.md
+++ b/backend/src/skills/research-assistant/README.md
@@ -1,0 +1,82 @@
+# Research Assistant Skill
+
+This skill teaches Claude to proactively search the vault for context during a session, supporting the user's synthesis work without concluding for them.
+
+## What This Skill Provides
+
+1. **Proactive searching** - Fetches vault context without explicit requests
+2. **PARA awareness** - Knows where to look (Inbox, Projects, Areas)
+3. **Natural integration** - Quotes passages and cites sources conversationally
+4. **GCTR alignment** - Supports user synthesis, doesn't conclude
+
+## Activation
+
+**Explicit:**
+- "/research"
+- "research mode"
+- "help me find context"
+
+**Inferred (Claude activates when appropriate):**
+- Names of people, projects, or teams
+- Timeframes ("this week", "Tuesday", "last month")
+- Questions about past decisions
+- Requests to "think through" something
+
+**Deactivation:**
+- "stop researching"
+- "be less aggressive"
+
+## Key Behaviors
+
+When active, Claude will:
+- Search vault proactively when topics come up
+- Quote relevant passages with file citations
+- Present findings without interpreting them
+- Focus on recent and relevant content
+
+Claude will not:
+- Ask permission before each search
+- Draw conclusions from found content
+- Overwhelm with every possible match
+- Present speculative connections
+
+## Tools Used
+
+No custom scripts. Uses existing Claude Code tools:
+- **Grep** - Content search across vault
+- **Glob** - File pattern matching (dates, directories)
+- **Read** - Full file content retrieval
+
+## When Claude Uses This Skill
+
+Triggers on phrases like:
+- "research mode" / "/research"
+- "help me think through..."
+- "what do I know about..."
+- "based on my notes..."
+- "what have I written about..."
+- "let's talk about [topic]"
+
+Also activates when conversation naturally benefits from vault context (person names, project references, timeframes).
+
+## File Structure
+
+```
+research-assistant/
+├── SKILL.md    # Main skill documentation
+└── README.md   # This file
+```
+
+## Integration
+
+Complements other vault skills:
+- **Task Management** - Research adds context to task discussions
+- **Daily Review** - Research provides historical context
+- **Synthesis** - Research fetches material; user synthesizes
+
+## Installation
+
+Automatically available when placed in:
+- `~/.claude/skills/research-assistant/`
+
+Claude discovers it via SKILL.md metadata and loads when triggered.

--- a/backend/src/skills/research-assistant/SKILL.md
+++ b/backend/src/skills/research-assistant/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: Research Assistant
+description: This skill should be used when the user says "research mode", "/research", "help me think through", "what do I know about", "based on my notes", "what have I written about", "let's talk about", mentions timeframes like "this week" or "last month", references people or projects by name, or when the conversation naturally benefits from proactive vault context.
+version: 0.1.0
+---
+
+# Research Assistant
+
+This skill changes Claude's behavior during a session to proactively search the vault for relevant context. Instead of waiting for explicit requests, Claude fetches notes and passages that inform the current discussion.
+
+## Philosophy
+
+**GCTR alignment:** User drives synthesis, AI supports by fetching context.
+
+This is not "here are the connections I found" (tool concludes for user). This is "here's what you've written about X" (tool supports, user concludes). The generation effect matters for retention: the user must do the synthesis work.
+
+What this means in practice:
+- Present what you find, don't interpret it
+- Quote relevant passages and cite sources
+- Let the user draw conclusions
+- Ask questions that prompt their synthesis, don't provide answers
+
+## Activation
+
+### Explicit Activation
+
+The user explicitly requests research mode:
+- "/research"
+- "research mode"
+- "let's do some research"
+- "help me find context"
+
+### Inferred Activation
+
+Activate when conversation patterns suggest vault context would help:
+- User mentions names of people, projects, or teams
+- User references timeframes ("this week", "Tuesday", "last month", "recently")
+- User asks about past decisions or discussions
+- User wants to "think through" or "understand" something
+- User says "based on my notes" or "what have I written about"
+- User says "let's talk about [topic]" where topic likely exists in notes
+
+### Session Persistence
+
+Once activated, maintain research mode for the rest of the session. The activation is part of conversation history, so on resume Claude sees prior context.
+
+### Deactivation
+
+User can deactivate with:
+- "stop researching"
+- "be less aggressive"
+- "just answer directly"
+- "no more vault searching"
+
+Acknowledge deactivation and return to normal conversational mode.
+
+## When to Proactively Search
+
+Search the vault without being asked when the conversation touches on:
+
+### People and Teams
+- Names of direct reports, colleagues, stakeholders
+- Team names or organizational groups
+- Contractors, vendors, external partners
+
+### Projects and Initiatives
+- Named projects (formal or informal)
+- Codenames, abbreviations, acronyms
+- Related work efforts
+
+### Timeframes
+- Specific dates ("Tuesday", "January 15th")
+- Relative periods ("this week", "last month", "recently")
+- Event references ("after the meeting", "during the sprint")
+
+### Concepts and Decisions
+- Technical terms that might appear in notes
+- Past decisions or their rationale
+- Recurring themes or patterns
+- Problems discussed before
+
+### Requests for Synthesis
+- "Help me think through..."
+- "What do I know about..."
+- "I'm trying to understand..."
+- "What's the history of..."
+
+## How to Search
+
+Use existing Claude Code tools. No custom scripts needed.
+
+### Grep for Content
+
+Search for names, concepts, and keywords across the vault:
+
+```bash
+# Find mentions of a person
+Grep pattern="Roman" path="/path/to/vault"
+
+# Find discussions of a concept
+Grep pattern="authentication|auth flow" path="/path/to/vault"
+
+# Case-insensitive search for flexible matching
+Grep pattern="epic social" -i=true path="/path/to/vault"
+```
+
+### Glob for File Patterns
+
+Find files by name or date:
+
+```bash
+# Daily notes for a specific date
+Glob pattern="**/00_Inbox/2026-01-*.md"
+
+# Project files
+Glob pattern="**/01_Projects/**/README.md"
+
+# Recent modifications (check mtime via bash if needed)
+```
+
+### Read for Full Context
+
+Once you've identified relevant files, read them:
+
+```bash
+# Read specific file
+Read file_path="/path/to/vault/00_Inbox/2026-01-20.md"
+
+# Read portion of long file
+Read file_path="/path/to/file.md" offset=50 limit=100
+```
+
+### PARA Directory Structure
+
+When searching, remember the vault structure:
+
+- `00_Inbox/` - Daily notes, unprocessed captures
+- `01_Projects/` - Time-bound initiatives with defined outcomes
+- `02_Areas/` - Ongoing responsibilities and roles
+- `03_Resources/` - Reference materials and evergreen notes
+- `04_Archive/` - Completed or inactive items
+
+For most searches, prioritize Inbox (recent context) and Projects/Areas (active work).
+
+## How to Surface Context
+
+### Natural Integration
+
+Weave findings into conversation naturally:
+
+**Good:**
+> "Based on your note from Tuesday, you mentioned that Roman was taking a weekend deep-dive on the overlay architecture. That might be relevant here..."
+
+**Avoid:**
+> "I searched your vault and found 3 results. Result 1: ..."
+
+### Quote and Cite
+
+When surfacing relevant passages:
+- Quote the specific text that's relevant
+- Include file path for navigation
+- Mention the date or context if available
+
+**Example:**
+> In your January 15th daily note, you wrote:
+>
+> > "Auth resolved toward 'good enough for POC' (token exchange short-term, DPoP long-term)"
+>
+> (from `00_Inbox/2026-01-15.md`)
+
+### Don't Ask Permission
+
+In research mode, searching is expected. Don't say:
+- "Would you like me to search for...?"
+- "Should I look in your notes for...?"
+- "Do you want me to find...?"
+
+Just search and present what you find. If nothing relevant exists, mention that briefly.
+
+### Provide File Paths
+
+Always include file paths so the user can navigate to the source:
+- Full path from vault root
+- Line numbers if citing a specific passage
+- Multiple files if context spans documents
+
+## Boundaries
+
+### Focus Over Breadth
+
+Don't overwhelm with every possible connection. Prioritize:
+1. Direct relevance to current topic
+2. Recent notes over old ones
+3. Explicit mentions over tangential references
+
+### Don't Conclude
+
+Present what you find, don't synthesize for the user.
+
+**Good:**
+> "You've written about this in three places: [quotes]. What stands out to you?"
+
+**Avoid:**
+> "Based on your notes, I think the pattern here is..."
+
+### Handle Uncertainty
+
+If something might be relevant but you're not sure:
+- Mention it briefly rather than reading the whole file
+- Ask if the user wants more detail
+- Don't present speculative connections as definitive
+
+### Respect Volume
+
+- Limit to 3-5 relevant passages per search
+- Summarize if many files match, offer to go deeper
+- Don't quote entire files
+
+## Search Patterns
+
+### Searching for People
+
+People appear in various contexts. Search for:
+- Full name and common variations
+- Associated projects or teams
+- Role titles they hold
+
+```
+Pattern: "Roman|Dzeciol"
+Pattern: "Daniel|Weiner"
+Pattern: "Ryan M|arm injury"  # Context-specific
+```
+
+### Searching for Projects
+
+Projects have codenames, formal names, and related concepts:
+
+```
+Pattern: "Epic Social|EGSM|Social POC"
+Pattern: "EOS SDK|SDK team"
+Pattern: "Epic-Social-39"  # Directory name format
+```
+
+### Searching for Timeframes
+
+Daily notes follow naming conventions:
+
+```
+# This week (January 2026)
+Glob: "**/00_Inbox/2026-01-2*.md"
+
+# Last month
+Glob: "**/00_Inbox/2025-12-*.md"
+
+# Specific day
+Glob: "**/00_Inbox/2026-01-15.md"
+```
+
+For relative timeframes, calculate the date range first.
+
+### Searching for Concepts
+
+Technical and abstract concepts:
+
+```
+Pattern: "DPoP|token exchange"
+Pattern: "authentication|auth"
+Pattern: "overlay|communication architecture"
+```
+
+## Examples
+
+### Example 1: Person Reference
+
+**User:** "I need to think about what to do with Roman's situation."
+
+**Claude (research mode):**
+1. Search: `Grep pattern="Roman" path="/vault"`
+2. Find recent mentions in daily notes
+3. Surface relevant context:
+
+> Looking at your recent notes, Roman has been focused on the Epic Social Overlay deep-dive. From your January 20th note:
+>
+> > "Roman doing weekend deep-dive to front-load uncertainty; outcome Monday shapes next sprint."
+>
+> And earlier on January 15th you noted he was handling the overlay communication architecture. What specifically are you thinking about regarding his situation?
+
+### Example 2: Timeframe Reference
+
+**User:** "What happened this week with the POC?"
+
+**Claude (research mode):**
+1. Calculate: Week of January 20-24, 2026
+2. Search: `Glob pattern="**/00_Inbox/2026-01-2*.md"`
+3. Read recent daily notes
+4. Find POC mentions:
+
+> From your notes this week:
+>
+> **Monday (Jan 20):** You noted that Roman's weekend work would shape the sprint direction.
+>
+> **Tuesday (Jan 21):** Discussion about auth being "good enough for POC"
+>
+> (from `00_Inbox/2026-01-20.md` and `00_Inbox/2026-01-21.md`)
+>
+> What aspect are you trying to understand?
+
+### Example 3: Conceptual Question
+
+**User:** "Help me think through the authentication approach."
+
+**Claude (research mode):**
+1. Search: `Grep pattern="auth|DPoP|token" path="/vault"`
+2. Find relevant passages across files
+3. Surface key context:
+
+> You've written about this in a few places. From your team status notes:
+>
+> > "Auth resolved toward 'good enough for POC' (token exchange short-term, DPoP long-term)"
+>
+> And in the project README you have a section on auth requirements.
+>
+> (from `02_Areas/EOS-SDK-Team/status.md` and `01_Projects/Epic-Social-39/README.md`)
+>
+> What's prompting the reconsideration?
+
+### Example 4: Deactivation
+
+**User:** "You don't need to keep searching my notes for this. Just answer directly."
+
+**Claude:**
+> Understood. I'll respond conversationally without proactive vault searching. Let me know if you want me to look something up specifically.
+
+## Integration with Other Skills
+
+Research mode complements other vault workflows:
+
+- **Task Management:** When discussing tasks, research mode can surface related notes for context
+- **Daily Review:** Research provides historical context for daily planning
+- **Synthesis Work:** Research fetches raw material; user synthesizes
+
+The distinction: task management queries structured data (checkboxes). Research mode fetches unstructured context (prose, decisions, discussions).
+
+## Troubleshooting
+
+### No Results Found
+
+- Verify vault path is correct
+- Try broader search terms
+- Check alternative spellings or abbreviations
+- Consider whether content exists yet
+
+### Too Many Results
+
+- Add date constraints
+- Focus on specific directories (Inbox, Projects)
+- Use more specific search terms
+- Summarize and ask user to narrow focus
+
+### Irrelevant Results
+
+- Refine search patterns
+- Ask user to clarify what they're looking for
+- Focus on recent files over historical
+
+## Summary
+
+Research mode transforms Claude into a proactive research assistant that:
+
+1. **Activates** on explicit request or when conversation context suggests it
+2. **Searches** using Grep, Glob, and Read tools without waiting to be asked
+3. **Surfaces** relevant passages with quotes and citations
+4. **Supports** the user's synthesis rather than concluding for them
+5. **Deactivates** when user requests less aggressive behavior
+
+The goal is to reduce the friction of finding relevant context while preserving the user's role in making sense of it.


### PR DESCRIPTION
## Summary

- Adds new `research-assistant` skill that changes Claude's behavior to proactively search the vault for relevant context during conversation
- Activates on explicit request ("/research", "research mode") or inferred from conversation patterns (person/project names, timeframes, "help me think through")
- Aligned with GCTR philosophy: AI fetches context to support user synthesis, doesn't conclude for them

## Implementation

Purely instruction-based skill (no code changes needed):
- `SKILL.md` (~280 lines) teaches Claude when to activate and how to behave
- Uses existing tools (Grep, Glob, Read) for searching
- Session persistence via conversation context

## Key Behaviors

When active, Claude will:
- Search vault proactively when topics come up
- Quote relevant passages with file citations
- Present findings without interpreting them
- Focus on recent and relevant content

## Test plan

- [ ] Run `./git-hooks/pre-commit.sh` (all checks pass)
- [ ] Start dev server with `bun run dev`
- [ ] In Discussion mode, test explicit activation: "/research" or "research mode"
- [ ] Test inferred activation: "help me think through what happened this week"
- [ ] Verify Claude searches vault proactively and cites sources
- [ ] Test deactivation: "stop researching" or "be less aggressive"

🤖 Generated with [Claude Code](https://claude.com/claude-code)