### PR TITLE
fix: Make CLAUDE.md update fire-and-forget to prevent HTTP timeouts

### DIFF
--- a/backend/src/__tests__/vault-setup.test.ts
+++ b/backend/src/__tests__/vault-setup.test.ts
@@ -1006,18 +1006,9 @@ describe("runVaultSetup", () => {
     expect(marker.paraCreated).toContain("Archives");
   });
 
-  test("marker has claudeMdUpdated as true when SDK succeeds", async () => {
-    await runVaultSetup("test-vault");
-
-    const content = await readFile(join(vaultPath, SETUP_MARKER_PATH), "utf-8");
-    const marker = JSON.parse(content) as SetupCompleteMarker;
-
-    expect(marker.claudeMdUpdated).toBe(true);
-  });
-
-  test("marker has claudeMdUpdated as false when SDK fails", async () => {
-    configureSdkForTesting(createErrorMockQueryFn("SDK error"));
-
+  test("marker has claudeMdUpdated as false (fire-and-forget, result unknown)", async () => {
+    // CLAUDE.md update runs in background to avoid HTTP timeouts,
+    // so the marker always shows false since we don't wait for the result
     await runVaultSetup("test-vault");
 
     const content = await readFile(join(vaultPath, SETUP_MARKER_PATH), "utf-8");


### PR DESCRIPTION
## Summary

- CLAUDE.md update via SDK now runs in background without blocking setup completion
- Prevents "Failed fetch" errors caused by 30-60+ second SDK calls exceeding browser timeouts
- Success/failure is logged asynchronously; marker shows `claudeMdUpdated: false` since result is unknown at write time

## Test plan

- [x] Unit tests updated to reflect new fire-and-forget behavior
- [x] Pre-commit checks pass
- [ ] Manual test: trigger vault setup via UI, verify no timeout error

🤖 Generated with [Claude Code](https://claude.com/claude-code)