### PR TITLE
fix: Pass cardsEnabled to config dialog and update session after save

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,7 +34,7 @@ type DialogType = "changeVault" | null;
  * Main app content when a vault is selected.
  */
 function MainContent(): React.ReactNode {
-  const { mode, vault, clearVault, setMeetingState } = useSession();
+  const { mode, vault, clearVault, setMeetingState, updateVaultConfig } = useSession();
   const handleServerMessage = useServerMessageHandler();
   const [activeDialog, setActiveDialog] = useState<DialogType>(null);
   const [configEditorOpen, setConfigEditorOpen] = useState(false);
@@ -138,6 +138,9 @@ function MainContent(): React.ReactNode {
     const success = await updateConfig(config);
 
     if (success) {
+      // Update session vault with new config values
+      updateVaultConfig(config);
+
       // Show success toast
       setToastVariant("success");
       setToastMessage("Settings saved");
@@ -257,6 +260,7 @@ function MainContent(): React.ReactNode {
             recentDiscussions: vault.recentDiscussions,
             badges: vault.badges,
             order: vault.order === Infinity ? undefined : vault.order,
+            cardsEnabled: vault.cardsEnabled,
           }}
           onSave={handleConfigSave}
           onCancel={handleConfigCancel}

--- a/frontend/src/contexts/SessionContext.tsx
+++ b/frontend/src/contexts/SessionContext.tsx
@@ -28,6 +28,7 @@ import type {
   ContextSnippet,
   HealthIssue,
   MeetingState,
+  EditableVaultConfig,
 } from "@memory-loop/shared";
 
 import {
@@ -427,6 +428,11 @@ export function SessionProvider({
     dispatch({ type: "CLEAR_MEETING" });
   }, []);
 
+  // Vault config actions
+  const updateVaultConfig = useCallback((config: EditableVaultConfig) => {
+    dispatch({ type: "UPDATE_VAULT_CONFIG", config });
+  }, []);
+
   const value: SessionContextValue = {
     ...state,
     selectVault,
@@ -487,6 +493,7 @@ export function SessionProvider({
     dismissHealthIssue,
     setMeetingState,
     clearMeeting,
+    updateVaultConfig,
   };
 
   return (

--- a/frontend/src/contexts/session/reducer.ts
+++ b/frontend/src/contexts/session/reducer.ts
@@ -18,6 +18,7 @@ import type {
   ToolInvocation,
   HealthIssue,
   MeetingState,
+  EditableVaultConfig,
 } from "@memory-loop/shared";
 
 import type {
@@ -99,7 +100,9 @@ export type SessionAction =
   | { type: "DISMISS_HEALTH_ISSUE"; issueId: string }
   // Meeting actions
   | { type: "SET_MEETING_STATE"; state: MeetingState }
-  | { type: "CLEAR_MEETING" };
+  | { type: "CLEAR_MEETING" }
+  // Vault config update
+  | { type: "UPDATE_VAULT_CONFIG"; config: EditableVaultConfig };
 
 // ----------------------------------------------------------------------------
 // Helper functions for reducer
@@ -704,6 +707,28 @@ export function sessionReducer(
       return {
         ...state,
         meeting: { isActive: false },
+      };
+
+    // Vault config update - merges editable config fields into current vault
+    case "UPDATE_VAULT_CONFIG":
+      if (!state.vault) return state;
+      return {
+        ...state,
+        vault: {
+          ...state.vault,
+          // Apply editable fields from config
+          name: action.config.title ?? state.vault.name,
+          subtitle: action.config.subtitle,
+          discussionModel: action.config.discussionModel ?? state.vault.discussionModel,
+          promptsPerGeneration: action.config.promptsPerGeneration ?? state.vault.promptsPerGeneration,
+          maxPoolSize: action.config.maxPoolSize ?? state.vault.maxPoolSize,
+          quotesPerWeek: action.config.quotesPerWeek ?? state.vault.quotesPerWeek,
+          recentCaptures: action.config.recentCaptures ?? state.vault.recentCaptures,
+          recentDiscussions: action.config.recentDiscussions ?? state.vault.recentDiscussions,
+          badges: action.config.badges ?? state.vault.badges,
+          order: action.config.order ?? state.vault.order,
+          cardsEnabled: action.config.cardsEnabled ?? state.vault.cardsEnabled,
+        },
       };
 
     default:

--- a/frontend/src/contexts/session/types.ts
+++ b/frontend/src/contexts/session/types.ts
@@ -18,6 +18,7 @@ import type {
   ConversationMessageProtocol,
   HealthIssue,
   MeetingState,
+  EditableVaultConfig,
 } from "@memory-loop/shared";
 
 /**
@@ -303,6 +304,9 @@ export interface SessionActions {
   setMeetingState: (state: MeetingState) => void;
   /** Clear meeting state (meeting stopped or vault changed) */
   clearMeeting: () => void;
+  // Vault config actions
+  /** Update vault config fields after successful save */
+  updateVaultConfig: (config: EditableVaultConfig) => void;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed `cardsEnabled` not being passed to ConfigEditorDialog, causing it to always show the default value instead of the vault's actual setting
- Added session vault update after config save so reopening the dialog shows correct values without page reload

## Test plan
- [ ] Open vault settings dialog, verify cardsEnabled shows correct current value
- [ ] Toggle cardsEnabled, save, reopen dialog - should show the new value
- [ ] Reload page, open settings - should still show correct value

🤖 Generated with [Claude Code](https://claude.com/claude-code)