### PR TITLE
fix: Add skeleton loading states and entrance animations to HomeView widgets

### DIFF
--- a/frontend/src/components/home/GoalsCard.css
+++ b/frontend/src/components/home/GoalsCard.css
@@ -153,3 +153,85 @@
     backdrop-filter: blur(4px);
   }
 }
+
+/* Loading skeleton */
+.goals-card--loading {
+  cursor: default;
+  pointer-events: none;
+}
+
+.goals-card__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.goals-card__skeleton-header {
+  width: 40%;
+  height: 0.9em;
+  background: linear-gradient(
+    90deg,
+    var(--color-surface) 25%,
+    var(--glass-border) 50%,
+    var(--color-surface) 75%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--radius-sm);
+  animation: goals-shimmer 1.5s infinite;
+}
+
+.goals-card__skeleton-line {
+  width: 100%;
+  height: 0.9em;
+  background: linear-gradient(
+    90deg,
+    var(--color-surface) 25%,
+    var(--glass-border) 50%,
+    var(--color-surface) 75%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--radius-sm);
+  animation: goals-shimmer 1.5s infinite;
+}
+
+.goals-card__skeleton-line--short {
+  width: 70%;
+}
+
+@keyframes goals-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Entrance animation */
+@keyframes goals-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.goals-card--enter {
+  animation: goals-enter 0.2s ease backwards;
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .goals-card__skeleton-header,
+  .goals-card__skeleton-line {
+    animation: none;
+    background: var(--glass-border);
+  }
+
+  .goals-card--enter {
+    animation: none;
+  }
+}

--- a/frontend/src/components/home/GoalsCard.tsx
+++ b/frontend/src/components/home/GoalsCard.tsx
@@ -12,6 +12,14 @@ import { useSession } from "../../contexts/SessionContext";
 import "./GoalsCard.css";
 
 /**
+ * Props for GoalsCard component.
+ */
+export interface GoalsCardProps {
+  /** Whether goals are still loading */
+  isLoading?: boolean;
+}
+
+/**
  * GoalsCard displays goals.md content as rendered markdown.
  *
  * - Shows full markdown content from the vault's goals.md file
@@ -19,7 +27,7 @@ import "./GoalsCard.css";
  * - Returns null if no goals file exists in the vault
  * - Clicking the card triggers /review-goals command
  */
-export function GoalsCard(): React.ReactNode {
+export function GoalsCard({ isLoading = false }: GoalsCardProps): React.ReactNode {
   const { goals, setDiscussionPrefill, setMode } = useSession();
 
   const handleClick = useCallback(() => {
@@ -27,7 +35,21 @@ export function GoalsCard(): React.ReactNode {
     setMode("discussion");
   }, [setDiscussionPrefill, setMode]);
 
-  // Don't render if no goals content
+  // Show skeleton during load
+  if (isLoading) {
+    return (
+      <div className="goals-card goals-card--loading" aria-label="Goals loading">
+        <div className="goals-card__skeleton">
+          <div className="goals-card__skeleton-header" />
+          <div className="goals-card__skeleton-line" />
+          <div className="goals-card__skeleton-line goals-card__skeleton-line--short" />
+          <div className="goals-card__skeleton-line" />
+        </div>
+      </div>
+    );
+  }
+
+  // Don't render if no goals content (vault might not have goalsPath)
   if (!goals) {
     return null;
   }
@@ -35,7 +57,7 @@ export function GoalsCard(): React.ReactNode {
   return (
     <button
       type="button"
-      className="goals-card"
+      className="goals-card goals-card--enter"
       onClick={handleClick}
       aria-label="Review goals"
     >

--- a/frontend/src/components/home/InspirationCard.css
+++ b/frontend/src/components/home/InspirationCard.css
@@ -156,6 +156,22 @@
   }
 }
 
+/* Entrance animation */
+@keyframes inspiration-enter {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.inspiration-card__item--enter {
+  animation: inspiration-enter 0.2s ease backwards;
+}
+
 /* Fallback for browsers without backdrop-filter */
 @supports not (backdrop-filter: blur(10px)) {
   .inspiration-card__item {
@@ -171,6 +187,10 @@
   .inspiration-card__skeleton-line {
     animation: none;
     background: var(--glass-border);
+  }
+
+  .inspiration-card__item--enter {
+    animation: none;
   }
 }
 

--- a/frontend/src/components/home/InspirationCard.tsx
+++ b/frontend/src/components/home/InspirationCard.tsx
@@ -16,8 +16,8 @@ import "./InspirationCard.css";
 export interface InspirationCardProps {
   /** Contextual prompt (null if not available or on weekends) */
   contextual: InspirationItem | null;
-  /** Inspirational quote (always present) */
-  quote: InspirationItem;
+  /** Inspirational quote (null during loading or if unavailable) */
+  quote: InspirationItem | null;
   /** Whether data is still loading */
   isLoading?: boolean;
 }
@@ -44,7 +44,8 @@ export function InspirationCard({
     [setDiscussionPrefill, setMode]
   );
 
-  if (isLoading) {
+  // Show skeleton if loading or no quote available
+  if (isLoading || !quote) {
     return (
       <section className="inspiration-card inspiration-card--loading" aria-label="Inspiration">
         <div className="inspiration-card__skeleton">
@@ -59,7 +60,7 @@ export function InspirationCard({
     <section className="inspiration-card" aria-label="Inspiration">
       <button
         type="button"
-        className="inspiration-card__item inspiration-card__quote"
+        className="inspiration-card__item inspiration-card__quote inspiration-card__item--enter"
         onClick={() => handleClick(quote.text)}
         aria-label="Use this quote for discussion"
       >
@@ -74,7 +75,7 @@ export function InspirationCard({
       {contextual && (
         <button
           type="button"
-          className="inspiration-card__item inspiration-card__prompt"
+          className="inspiration-card__item inspiration-card__prompt inspiration-card__item--enter"
           onClick={() => handleClick(contextual.text)}
           aria-label="Use this prompt for discussion"
         >

--- a/frontend/src/components/home/RecentActivity.css
+++ b/frontend/src/components/home/RecentActivity.css
@@ -266,3 +266,106 @@
     padding: var(--spacing-sm) var(--spacing-md);
   }
 }
+
+/* ==============================================
+   Skeleton Loading State
+   ============================================== */
+
+.recent-activity__card--skeleton {
+  pointer-events: none;
+}
+
+.recent-activity__skeleton-text {
+  width: 100%;
+  height: 2.4em;
+  background: linear-gradient(
+    90deg,
+    var(--color-surface) 25%,
+    var(--glass-border) 50%,
+    var(--color-surface) 75%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--radius-sm);
+  animation: activity-shimmer 1.5s infinite;
+  margin-bottom: var(--spacing-sm);
+}
+
+.recent-activity__skeleton-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.recent-activity__skeleton-meta {
+  width: 80px;
+  height: 1em;
+  background: linear-gradient(
+    90deg,
+    var(--color-surface) 25%,
+    var(--glass-border) 50%,
+    var(--color-surface) 75%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--radius-sm);
+  animation: activity-shimmer 1.5s infinite;
+}
+
+.recent-activity__skeleton-action {
+  width: 50px;
+  height: 1.5em;
+  background: linear-gradient(
+    90deg,
+    var(--color-surface) 25%,
+    var(--glass-border) 50%,
+    var(--color-surface) 75%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--radius-md);
+  animation: activity-shimmer 1.5s infinite;
+}
+
+@keyframes activity-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* ==============================================
+   Entrance Animation
+   ============================================== */
+
+@keyframes recent-activity-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.recent-activity__card--enter {
+  animation: recent-activity-enter 0.25s ease backwards;
+  /* animationDelay set via inline style for staggering */
+}
+
+/* ==============================================
+   Reduced Motion Preference
+   ============================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  .recent-activity__skeleton-text,
+  .recent-activity__skeleton-meta,
+  .recent-activity__skeleton-action {
+    animation: none;
+    background: var(--glass-border);
+  }
+
+  .recent-activity__card--enter {
+    animation: none;
+  }
+}

--- a/frontend/src/components/home/SpacedRepetitionWidget.css
+++ b/frontend/src/components/home/SpacedRepetitionWidget.css
@@ -104,6 +104,45 @@
 }
 
 /* ==============================================
+   Idle State (No Cards Due)
+   ============================================== */
+
+.spaced-repetition-widget__idle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-md);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.spaced-repetition-widget__idle-message {
+  opacity: 0.8;
+}
+
+/* ==============================================
+   Entrance Animation
+   ============================================== */
+
+@keyframes widget-content-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.spaced-repetition-widget__question,
+.spaced-repetition-widget__answer,
+.spaced-repetition-widget__complete,
+.spaced-repetition-widget__idle {
+  animation: widget-content-enter 0.2s ease backwards;
+}
+
+/* ==============================================
    Error State
    ============================================== */
 
@@ -556,5 +595,15 @@
 @supports not (backdrop-filter: blur(10px)) {
   .spaced-repetition-widget {
     background-color: var(--color-surface);
+  }
+}
+
+/* Reduced motion preference for entrance animations */
+@media (prefers-reduced-motion: reduce) {
+  .spaced-repetition-widget__question,
+  .spaced-repetition-widget__answer,
+  .spaced-repetition-widget__complete,
+  .spaced-repetition-widget__idle {
+    animation: none;
   }
 }

--- a/frontend/src/components/home/__tests__/HomeView.test.tsx
+++ b/frontend/src/components/home/__tests__/HomeView.test.tsx
@@ -52,10 +52,11 @@ describe("HomeView", () => {
   });
 
   describe("inspiration", () => {
-    it("does not render InspirationCard when no inspiration data", () => {
+    it("renders InspirationCard with skeleton when no inspiration data", () => {
       render(<HomeView />, { wrapper: Wrapper });
 
-      expect(screen.queryByLabelText("Inspiration")).toBeNull();
+      // InspirationCard always renders, showing skeleton when loading or no data
+      expect(screen.getByLabelText("Inspiration")).toBeTruthy();
     });
   });
 });

--- a/frontend/src/components/home/__tests__/SpacedRepetitionWidget.test.tsx
+++ b/frontend/src/components/home/__tests__/SpacedRepetitionWidget.test.tsx
@@ -168,15 +168,15 @@ describe("SpacedRepetitionWidget", () => {
       expect(container.firstChild).toBeNull();
     });
 
-    it("renders nothing when no cards are due", async () => {
+    it("shows idle state when no cards are due", async () => {
       const mockFetch = createMockFetch({ dueCards: { cards: [], count: 0 } });
-      const { container } = renderWithSession(
+      renderWithSession(
         <SpacedRepetitionWidget vaultId="test-vault" fetchFn={mockFetch} />
       );
 
-      // Wait for the fetch to complete
+      // Wait for the fetch to complete and show idle state
       await waitFor(() => {
-        expect(container.firstChild).toBeNull();
+        expect(screen.getByText("No cards due today")).toBeDefined();
       });
     });
 


### PR DESCRIPTION
## Summary

- Widgets now show skeleton placeholders during load instead of popping into existence
- Added entrance animations with staggered timing for RecentActivity cards
- SpacedRepetitionWidget shows loading spinner immediately and "No cards due" idle state
- All animations respect `prefers-reduced-motion`

## Test plan

- [ ] Load HomeView with slow network (Chrome DevTools throttling) - skeletons should appear immediately
- [ ] Content should animate in smoothly when data arrives
- [ ] RecentActivity cards should stagger in with 50ms delay between items
- [ ] Switch vaults rapidly - no jarring pops, clean transitions
- [ ] Test with `prefers-reduced-motion` enabled - animations should be disabled
- [ ] Verify SpacedRepetitionWidget shows loading then idle/questions appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)