### PR TITLE
fix: Pass cardsEnabled to VaultSelect config dialog and preserve subtitle

### DIFF
--- a/frontend/src/components/vault/VaultSelect.tsx
+++ b/frontend/src/components/vault/VaultSelect.tsx
@@ -354,10 +354,15 @@ export function VaultSelect({ onReady }: VaultSelectProps): React.ReactNode {
                 // Map EditableVaultConfig fields to VaultInfo fields
                 name: config.title ?? v.name,
                 subtitle: config.subtitle ?? v.subtitle,
+                discussionModel: config.discussionModel ?? v.discussionModel,
                 promptsPerGeneration: config.promptsPerGeneration ?? v.promptsPerGeneration,
                 maxPoolSize: config.maxPoolSize ?? v.maxPoolSize,
                 quotesPerWeek: config.quotesPerWeek ?? v.quotesPerWeek,
+                recentCaptures: config.recentCaptures ?? v.recentCaptures,
+                recentDiscussions: config.recentDiscussions ?? v.recentDiscussions,
                 badges: config.badges ?? v.badges,
+                order: config.order ?? v.order,
+                cardsEnabled: config.cardsEnabled ?? v.cardsEnabled,
               }
             : v
         )
@@ -703,6 +708,7 @@ export function VaultSelect({ onReady }: VaultSelectProps): React.ReactNode {
             recentDiscussions: configEditorVault.recentDiscussions,
             badges: configEditorVault.badges,
             order: configEditorVault.order === Infinity ? undefined : configEditorVault.order,
+            cardsEnabled: configEditorVault.cardsEnabled,
           }}
           onSave={handleConfigSave}
           onCancel={handleConfigCancel}

--- a/frontend/src/contexts/session/__tests__/reducer-update-config.test.ts
+++ b/frontend/src/contexts/session/__tests__/reducer-update-config.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for UPDATE_VAULT_CONFIG reducer action
+ */
+import { describe, expect, test } from "bun:test";
+import { sessionReducer } from "../reducer";
+import { createInitialSessionState } from "../initial-state";
+import type { SessionState } from "../types";
+import type { VaultInfo } from "@memory-loop/shared";
+
+const initialSessionState = createInitialSessionState();
+
+const mockVault: VaultInfo = {
+  id: "test-vault",
+  name: "Original Name",
+  subtitle: "Original Subtitle",
+  path: "/test/path",
+  hasClaudeMd: true,
+  contentRoot: "/test/path",
+  inboxPath: "00_Inbox",
+  metadataPath: "06_Metadata",
+  attachmentPath: "05_Attachments",
+  setupComplete: true,
+  discussionModel: "opus",
+  promptsPerGeneration: 5,
+  maxPoolSize: 50,
+  quotesPerWeek: 1,
+  recentCaptures: 5,
+  recentDiscussions: 5,
+  badges: [],
+  order: 1,
+  cardsEnabled: false, // Start with false
+};
+
+describe("UPDATE_VAULT_CONFIG action", () => {
+  test("updates vault name from title", () => {
+    const state: SessionState = { ...initialSessionState, vault: mockVault };
+    const result = sessionReducer(state, {
+      type: "UPDATE_VAULT_CONFIG",
+      config: { title: "New Name" },
+    });
+    expect(result.vault?.name).toBe("New Name");
+  });
+
+  test("preserves cardsEnabled false when not in config", () => {
+    const state: SessionState = { ...initialSessionState, vault: mockVault };
+    const result = sessionReducer(state, {
+      type: "UPDATE_VAULT_CONFIG",
+      config: { title: "New Name" },
+    });
+    expect(result.vault?.cardsEnabled).toBe(false);
+  });
+
+  test("updates cardsEnabled to true", () => {
+    const state: SessionState = { ...initialSessionState, vault: mockVault };
+    const result = sessionReducer(state, {
+      type: "UPDATE_VAULT_CONFIG",
+      config: { cardsEnabled: true },
+    });
+    expect(result.vault?.cardsEnabled).toBe(true);
+  });
+
+  test("updates cardsEnabled to false", () => {
+    const vaultWithTrue: VaultInfo = { ...mockVault, cardsEnabled: true };
+    const state: SessionState = { ...initialSessionState, vault: vaultWithTrue };
+    const result = sessionReducer(state, {
+      type: "UPDATE_VAULT_CONFIG",
+      config: { cardsEnabled: false },
+    });
+    expect(result.vault?.cardsEnabled).toBe(false);
+  });
+
+  test("preserves subtitle when undefined in config", () => {
+    const state: SessionState = { ...initialSessionState, vault: mockVault };
+    const result = sessionReducer(state, {
+      type: "UPDATE_VAULT_CONFIG",
+      config: { title: "New Name" }, // subtitle not provided
+    });
+    expect(result.vault?.subtitle).toBe("Original Subtitle");
+  });
+});

--- a/frontend/src/contexts/session/reducer.ts
+++ b/frontend/src/contexts/session/reducer.ts
@@ -718,7 +718,7 @@ export function sessionReducer(
           ...state.vault,
           // Apply editable fields from config
           name: action.config.title ?? state.vault.name,
-          subtitle: action.config.subtitle,
+          subtitle: action.config.subtitle ?? state.vault.subtitle,
           discussionModel: action.config.discussionModel ?? state.vault.discussionModel,
           promptsPerGeneration: action.config.promptsPerGeneration ?? state.vault.promptsPerGeneration,
           maxPoolSize: action.config.maxPoolSize ?? state.vault.maxPoolSize,


### PR DESCRIPTION
## Summary
- Fix VaultSelect's ConfigEditorDialog missing `cardsEnabled` in initialConfig, causing checkbox to always show checked
- Fix local vault state update after save to include all editable fields (`cardsEnabled`, `discussionModel`, `recentCaptures`, `recentDiscussions`, `order`)
- Fix session reducer's UPDATE_VAULT_CONFIG overwriting `subtitle` with undefined instead of preserving existing value

## Test plan
- [x] All existing tests pass
- [x] New reducer tests for UPDATE_VAULT_CONFIG action
- [x] New backend tests for cardsEnabled save/retrieve via REST API
- [ ] Manual: Set cardsEnabled to false, verify checkbox shows unchecked on dialog reopen
- [ ] Manual: Save config changes, verify values update without page refresh

🤖 Generated with [Claude Code](https://claude.ai/code)