### PR TITLE
fix: Exclude CLAUDE.md from card discovery

### DIFF
--- a/backend/src/spaced-repetition/card-discovery-scheduler.ts
+++ b/backend/src/spaced-repetition/card-discovery-scheduler.ts
@@ -165,6 +165,10 @@ async function discoverMarkdownFiles(
       const subFiles = await discoverMarkdownFiles(basePath, vault, entryRelPath);
       files.push(...subFiles);
     } else if (stats.isFile() && extname(entry).toLowerCase() === ".md") {
+      // Skip CLAUDE.md files (project instructions, not knowledge content)
+      if (entry === "CLAUDE.md") {
+        continue;
+      }
       files.push({
         absolutePath: entryAbsPath,
         relativePath: entryRelPath,


### PR DESCRIPTION
## Summary
- Exclude `CLAUDE.md` files from card discovery processing
- These files contain project instructions, not knowledge content suitable for spaced repetition

## Test plan
- [x] New test verifies CLAUDE.md exclusion in root and subdirectories
- [x] Updated existing test to expect correct file count
- [x] All 63 card-discovery-scheduler tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)