### PR TITLE
fix: Add 30-minute overlap to daily card discovery cutoff

### DIFF
--- a/backend/src/spaced-repetition/card-discovery-scheduler.ts
+++ b/backend/src/spaced-repetition/card-discovery-scheduler.ts
@@ -44,6 +44,9 @@ export const WEEKLY_CATCH_UP_LIMIT = 500 * 1024;
 /** Milliseconds in a day (24 hours) */
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+/** Overlap buffer for daily pass (30 minutes) to handle schedule drift */
+const DAILY_OVERLAP_MS = 30 * 60 * 1000;
+
 /** Milliseconds in a week (7 days) */
 const MS_PER_WEEK = 7 * MS_PER_DAY;
 
@@ -337,7 +340,7 @@ export async function runDailyPass(getNow: () => Date = () => new Date()): Promi
   };
 
   const now = getNow();
-  const cutoffTime = new Date(now.getTime() - MS_PER_DAY);
+  const cutoffTime = new Date(now.getTime() - MS_PER_DAY - DAILY_OVERLAP_MS);
 
   log.info(`Starting daily discovery pass (files modified since ${cutoffTime.toISOString()})`);
 


### PR DESCRIPTION
## Summary
- Adds a 30-minute overlap buffer to the daily discovery pass cutoff time
- Prevents files modified near the 24-hour boundary from being missed due to schedule drift

## Test plan
- [x] Existing tests pass (pre-commit hook ran during commit)
- [ ] Verify daily pass considers files from 24.5 hours ago

🤖 Generated with [Claude Code](https://claude.com/claude-code)