### PR TITLE
fix: Reject card generation when answer is not in source content

### DIFF
--- a/backend/src/spaced-repetition/card-generator.ts
+++ b/backend/src/spaced-repetition/card-generator.ts
@@ -86,7 +86,9 @@ Requirements:
 - Questions must be self-contained and answerable without seeing the source
 - Never use "this", "the above", or assume the reader knows the context
 - Include enough context in the question itself (name the system, concept, or domain)
-- Answers should be concise but complete
+- Answers should be concise but complete (the actual answer must be in the content)
+- Skip Q&A pairs where the answer would be vague, incomplete, or "not provided"
+- If the content mentions something but doesn't explain it, don't make a card about it
 - Each question should test a distinct piece of knowledge - avoid variations that ask the same thing differently
 - Skip subjective opinions, TODOs, or transient information
 - Skip self-referential questions about the note-taker's actions, decisions, or personal context


### PR DESCRIPTION
## Summary
- Adds prompt requirements to prevent generating cards with vague or incomplete answers
- Explicitly rejects "not provided" style answers where source mentions something but doesn't explain it
- Fixes cases like: Q: "What API did X provide?" A: "X provided an API (details not provided)"

## Test plan
- [x] Pre-commit checks pass
- [ ] Generate cards from notes that mention topics without explaining them
- [ ] Verify vague answers are no longer produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)