### PR TITLE
feat: Add Open button to spaced repetition question phase

### DIFF
--- a/backend/src/routes/cards.ts
+++ b/backend/src/routes/cards.ts
@@ -39,6 +39,7 @@ interface DueCardPreview {
   id: string;
   question: string;
   next_review: string;
+  card_file: string;
 }
 
 /**
@@ -113,6 +114,7 @@ cardRoutes.get("/due", async (c) => {
       id: card.metadata.id,
       question: card.content.question,
       next_review: card.metadata.next_review,
+      card_file: `${vault.metadataPath}/cards/${card.metadata.id}.md`,
     }));
 
     const response: DueCardsResponse = {

--- a/frontend/src/components/home/SpacedRepetitionWidget.tsx
+++ b/frontend/src/components/home/SpacedRepetitionWidget.tsx
@@ -268,13 +268,24 @@ export function SpacedRepetitionWidget({
   );
 
   /**
-   * Handle Open action: navigate to source file in Recall tab.
+   * Handle Open Source action: navigate to source file in Recall tab.
+   * Used in revealed phase to view the original note.
    */
-  const handleOpenCard = useCallback(() => {
+  const handleOpenSource = useCallback(() => {
     if (!state.cardDetail?.source_file) return;
     setCurrentPath(state.cardDetail.source_file);
     setMode("browse");
   }, [state.cardDetail?.source_file, setCurrentPath, setMode]);
+
+  /**
+   * Handle Open Card action: navigate to card file in Recall tab.
+   * Used in question phase to edit the card (e.g., fix the question).
+   */
+  const handleOpenCard = useCallback(() => {
+    if (!state.currentCard?.card_file) return;
+    setCurrentPath(state.currentCard.card_file);
+    setMode("browse");
+  }, [state.currentCard?.card_file, setCurrentPath, setMode]);
 
   /**
    * Handle keyboard shortcuts for assessment (1/2/3/4 keys).
@@ -417,6 +428,17 @@ export function SpacedRepetitionWidget({
               >
                 Forget
               </button>
+              {state.currentCard?.card_file && (
+                <button
+                  type="button"
+                  className="spaced-repetition-widget__btn spaced-repetition-widget__btn--open"
+                  onClick={handleOpenCard}
+                  disabled={isLoading}
+                  aria-label="Open card file in Recall tab"
+                >
+                  Open
+                </button>
+              )}
               <button
                 type="button"
                 className="spaced-repetition-widget__btn spaced-repetition-widget__btn--reveal"
@@ -469,7 +491,7 @@ export function SpacedRepetitionWidget({
                 <button
                   type="button"
                   className="spaced-repetition-widget__btn spaced-repetition-widget__btn--open"
-                  onClick={handleOpenCard}
+                  onClick={handleOpenSource}
                   aria-label="Open source file in Recall tab"
                 >
                   Open

--- a/frontend/src/components/home/__tests__/SpacedRepetitionWidget.test.tsx
+++ b/frontend/src/components/home/__tests__/SpacedRepetitionWidget.test.tsx
@@ -32,9 +32,9 @@ function renderWithSession(ui: React.ReactElement) {
 
 const mockDueCardsResponse: DueCardsResponse = {
   cards: [
-    { id: "card-1", question: "What is TypeScript?", next_review: "2026-01-23" },
-    { id: "card-2", question: "What is React?", next_review: "2026-01-23" },
-    { id: "card-3", question: "What is Bun?", next_review: "2026-01-23" },
+    { id: "card-1", question: "What is TypeScript?", next_review: "2026-01-23", card_file: "06_Metadata/memory-loop/cards/card-1.md" },
+    { id: "card-2", question: "What is React?", next_review: "2026-01-23", card_file: "06_Metadata/memory-loop/cards/card-2.md" },
+    { id: "card-3", question: "What is Bun?", next_review: "2026-01-23", card_file: "06_Metadata/memory-loop/cards/card-3.md" },
   ],
   count: 3,
 };
@@ -523,7 +523,7 @@ describe("SpacedRepetitionWidget", () => {
     it("shows completion message when all cards reviewed", async () => {
       // Start with a single card
       const singleCardResponse: DueCardsResponse = {
-        cards: [{ id: "card-1", question: "What is TypeScript?", next_review: "2026-01-23" }],
+        cards: [{ id: "card-1", question: "What is TypeScript?", next_review: "2026-01-23", card_file: "06_Metadata/memory-loop/cards/card-1.md" }],
         count: 1,
       };
 
@@ -550,7 +550,7 @@ describe("SpacedRepetitionWidget", () => {
 
     it("shows checkmark icon in completion state", async () => {
       const singleCardResponse: DueCardsResponse = {
-        cards: [{ id: "card-1", question: "What is TypeScript?", next_review: "2026-01-23" }],
+        cards: [{ id: "card-1", question: "What is TypeScript?", next_review: "2026-01-23", card_file: "06_Metadata/memory-loop/cards/card-1.md" }],
         count: 1,
       };
 

--- a/frontend/src/hooks/__tests__/useCards.test.ts
+++ b/frontend/src/hooks/__tests__/useCards.test.ts
@@ -53,6 +53,7 @@ const mockDueCard: DueCard = {
   id: "550e8400-e29b-41d4-a716-446655440001",
   question: "What is the capital of France?",
   next_review: "2026-01-23",
+  card_file: "06_Metadata/memory-loop/cards/550e8400-e29b-41d4-a716-446655440001.md",
 };
 
 const mockCardDetail: CardDetail = {

--- a/shared/src/protocol.ts
+++ b/shared/src/protocol.ts
@@ -328,6 +328,8 @@ export const DueCardSchema = z.object({
   question: z.string().min(1, "Question is required"),
   /** ISO 8601 date when card is due for review */
   next_review: z.string(),
+  /** Path to the card file (relative to vault, e.g., 06_Metadata/memory-loop/cards/{id}.md) */
+  card_file: z.string(),
 });
 
 /**


### PR DESCRIPTION
## Summary

- Adds Open button to question phase that opens the card file for editing
- Enables fixing time-sensitive questions (e.g., adding "As of Jan 20..." context) without leaving review
- Revealed phase Open button still navigates to source file for context

## Test plan

- [ ] Start spaced repetition review with due cards
- [ ] Verify Open button appears in question phase
- [ ] Click Open and confirm it navigates to the card markdown file in Recall tab
- [ ] Return to Ground tab and continue review
- [ ] Reveal answer and verify Open button still opens source file (not card file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)