### PR TITLE
fix: Dim delete button and fix DownloadViewer layout

### DIFF
--- a/frontend/src/components/browse/viewers/CsvViewer.css
+++ b/frontend/src/components/browse/viewers/CsvViewer.css
@@ -317,7 +317,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
@@ -337,6 +337,6 @@
   .csv-viewer__delete-btn:hover {
     background: transparent;
     border-color: transparent;
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
   }
 }

--- a/frontend/src/components/browse/viewers/DownloadViewer.css
+++ b/frontend/src/components/browse/viewers/DownloadViewer.css
@@ -98,7 +98,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
@@ -109,7 +109,7 @@
   color: var(--color-danger);
 }
 
-.download-viewer__icon {
+.download-viewer__trash-icon {
   width: 18px;
   height: 18px;
 }
@@ -118,6 +118,6 @@
   .download-viewer__delete-btn:hover {
     background: transparent;
     border-color: transparent;
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
   }
 }

--- a/frontend/src/components/browse/viewers/DownloadViewer.tsx
+++ b/frontend/src/components/browse/viewers/DownloadViewer.tsx
@@ -115,7 +115,7 @@ function FileIcon(): ReactNode {
 function TrashIcon(): ReactNode {
   return (
     <svg
-      className="download-viewer__icon"
+      className="download-viewer__trash-icon"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/frontend/src/components/browse/viewers/ImageViewer.css
+++ b/frontend/src/components/browse/viewers/ImageViewer.css
@@ -118,7 +118,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
@@ -138,7 +138,7 @@
   .image-viewer__delete-btn:hover {
     background: transparent;
     border-color: transparent;
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
   }
 }
 

--- a/frontend/src/components/browse/viewers/JsonViewer.css
+++ b/frontend/src/components/browse/viewers/JsonViewer.css
@@ -455,7 +455,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
@@ -475,6 +475,6 @@
   .json-viewer__delete-btn:hover {
     background: transparent;
     border-color: transparent;
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
   }
 }

--- a/frontend/src/components/browse/viewers/MarkdownViewer.css
+++ b/frontend/src/components/browse/viewers/MarkdownViewer.css
@@ -644,7 +644,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
@@ -664,6 +664,6 @@
   .markdown-viewer__delete-btn:hover {
     background: transparent;
     border-color: transparent;
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
   }
 }

--- a/frontend/src/components/browse/viewers/PdfViewer.css
+++ b/frontend/src/components/browse/viewers/PdfViewer.css
@@ -136,7 +136,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
@@ -156,7 +156,7 @@
   .pdf-viewer__delete-btn:hover {
     background: transparent;
     border-color: transparent;
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
   }
 }
 

--- a/frontend/src/components/browse/viewers/TxtViewer.css
+++ b/frontend/src/components/browse/viewers/TxtViewer.css
@@ -429,7 +429,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
@@ -449,6 +449,6 @@
   .txt-viewer__delete-btn:hover {
     background: transparent;
     border-color: transparent;
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
   }
 }

--- a/frontend/src/components/browse/viewers/VideoViewer.css
+++ b/frontend/src/components/browse/viewers/VideoViewer.css
@@ -117,7 +117,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
@@ -137,7 +137,7 @@
   .video-viewer__delete-btn:hover {
     background: transparent;
     border-color: transparent;
-    color: var(--color-text-secondary);
+    color: var(--color-text-muted);
   }
 }
 


### PR DESCRIPTION
## Summary
- Delete button now uses `--color-text-muted` instead of `--color-text-secondary` across all 8 viewers, making it visually recede as a last-resort action
- Fixes DownloadViewer where the trash icon class conflicted with the file icon container, causing layout overlap

## Test plan
- [ ] Verify delete button appears dimmer than other controls (Adjust, etc.)
- [ ] Verify DownloadViewer shows file icon and message text without overlap

🤖 Generated with [Claude Code](https://claude.ai/code)