### PR TITLE
fix: Require unique, unambiguous answers in generated flashcards

### DIFF
--- a/backend/src/spaced-repetition/__tests__/card-generator.test.ts
+++ b/backend/src/spaced-repetition/__tests__/card-generator.test.ts
@@ -386,7 +386,7 @@ describe("QACardGenerator", () => {
       // Prompt should contain truncated content, not full content
       expect(prompt).toContain("[Content truncated...]");
       // The original long content should not appear in full
-      expect(prompt.length).toBeLessThan(longContent.length + 500);
+      expect(prompt).not.toContain(longContent);
     });
 
     test("uses correct model", async () => {

--- a/backend/src/spaced-repetition/card-generator.ts
+++ b/backend/src/spaced-repetition/card-generator.ts
@@ -85,7 +85,9 @@ Requirements:
 - Focus on key facts, concepts, definitions, and relationships
 - Questions must be self-contained and answerable without seeing the source
 - Never use "this", "the above", or assume the reader knows the context
-- Include enough context in the question itself (name the system, concept, or domain)
+- Questions must have a unique, unambiguous answer that doesn't depend on when the note was written
+- Avoid questions like "What did X implement?" or "What was decided?" that could have many valid answers
+- Include enough specifics in the question to uniquely identify what's being asked (project name, feature name, date, version)
 - Answers should be concise but complete (the actual answer must be in the content)
 - Skip Q&A pairs where the answer would be vague, incomplete, or "not provided"
 - If the content mentions something but doesn't explain it, don't make a card about it


### PR DESCRIPTION
## Summary
- Added prompt guidelines requiring generated questions to have unique, unambiguous answers
- Questions must include enough specifics (project name, feature name, date, version) to be uniquely identifiable
- Explicitly discourages vague questions like "What did X implement?" that could have many valid answers

## Test plan
- [x] Existing card-generator tests pass
- [x] Truncation test improved to check content directly rather than using fragile length arithmetic

🤖 Generated with [Claude Code](https://claude.com/claude-code)