### PR TITLE
feat: Add Card Generator settings tab

### DIFF
--- a/backend/src/handlers/__tests__/card-generator-handlers.test.ts
+++ b/backend/src/handlers/__tests__/card-generator-handlers.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Card Generator Handlers Tests
+ *
+ * Tests for WebSocket handlers that manage card generator configuration.
+ * Uses dependency injection to test handlers without file I/O.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { ServerMessage, ErrorCode } from "@memory-loop/shared";
+import type { HandlerContext, RequiredHandlerDependencies } from "../types.js";
+import { createConnectionState } from "../types.js";
+import {
+  handleGetCardGeneratorConfig,
+  handleSaveCardGeneratorRequirements,
+  handleSaveCardGeneratorConfig,
+  handleResetCardGeneratorRequirements,
+  handleGetCardGenerationStatus,
+  handleTriggerCardGeneration,
+} from "../card-generator-handlers.js";
+import {
+  saveRequirementsOverride,
+  saveCardGeneratorConfig,
+  DEFAULT_WEEKLY_BYTE_LIMIT,
+  DEFAULT_REQUIREMENTS,
+} from "../../spaced-repetition/card-generator-config.js";
+
+describe("card-generator-handlers", () => {
+  let testDir: string;
+  let originalHome: string;
+
+  beforeEach(async () => {
+    testDir = join(
+      tmpdir(),
+      `card-handler-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    await mkdir(testDir, { recursive: true });
+    originalHome = process.env.HOME ?? "";
+    process.env.HOME = testDir;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = originalHome;
+    try {
+      await rm(testDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  /**
+   * Create a mock handler context that captures sent messages.
+   */
+  function createMockContext(): { ctx: HandlerContext; messages: ServerMessage[] } {
+    const messages: ServerMessage[] = [];
+
+    const ctx: HandlerContext = {
+      state: createConnectionState(),
+      send: (message: ServerMessage) => {
+        messages.push(message);
+      },
+      sendError: (code: ErrorCode, message: string) => {
+        messages.push({ type: "error", code, message });
+      },
+      deps: {} as RequiredHandlerDependencies, // Not used by card generator handlers
+    };
+
+    return { ctx, messages };
+  }
+
+  // =============================================================================
+  // handleGetCardGeneratorConfig Tests
+  // =============================================================================
+
+  describe("handleGetCardGeneratorConfig", () => {
+    test("returns default config when no overrides exist", async () => {
+      const { ctx, messages } = createMockContext();
+
+      await handleGetCardGeneratorConfig(ctx);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].type).toBe("card_generator_config_content");
+
+      const msg = messages[0] as {
+        type: "card_generator_config_content";
+        requirements: string;
+        isOverride: boolean;
+        weeklyByteLimit: number;
+        weeklyBytesUsed: number;
+      };
+      expect(msg.requirements).toBe(DEFAULT_REQUIREMENTS);
+      expect(msg.isOverride).toBe(false);
+      expect(msg.weeklyByteLimit).toBe(DEFAULT_WEEKLY_BYTE_LIMIT);
+      expect(msg.weeklyBytesUsed).toBe(0);
+    });
+
+    test("returns custom requirements when override exists", async () => {
+      await saveRequirementsOverride("Custom requirements content");
+
+      const { ctx, messages } = createMockContext();
+      await handleGetCardGeneratorConfig(ctx);
+
+      expect(messages).toHaveLength(1);
+      const msg = messages[0] as {
+        type: "card_generator_config_content";
+        requirements: string;
+        isOverride: boolean;
+      };
+      expect(msg.requirements).toBe("Custom requirements content");
+      expect(msg.isOverride).toBe(true);
+    });
+
+    test("returns custom byte limit when configured", async () => {
+      await saveCardGeneratorConfig({ weeklyByteLimit: 1000000 });
+
+      const { ctx, messages } = createMockContext();
+      await handleGetCardGeneratorConfig(ctx);
+
+      expect(messages).toHaveLength(1);
+      const msg = messages[0] as {
+        type: "card_generator_config_content";
+        weeklyByteLimit: number;
+      };
+      expect(msg.weeklyByteLimit).toBe(1000000);
+    });
+  });
+
+  // =============================================================================
+  // handleSaveCardGeneratorRequirements Tests
+  // =============================================================================
+
+  describe("handleSaveCardGeneratorRequirements", () => {
+    test("saves requirements and returns success", async () => {
+      const { ctx, messages } = createMockContext();
+
+      await handleSaveCardGeneratorRequirements(ctx, "New requirements");
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].type).toBe("card_generator_requirements_saved");
+
+      const msg = messages[0] as {
+        type: "card_generator_requirements_saved";
+        success: boolean;
+        isOverride: boolean;
+      };
+      expect(msg.success).toBe(true);
+      expect(msg.isOverride).toBe(true);
+    });
+
+    test("persists requirements to disk", async () => {
+      const { ctx } = createMockContext();
+
+      await handleSaveCardGeneratorRequirements(ctx, "Persisted requirements");
+
+      // Verify by loading config
+      const { ctx: ctx2, messages } = createMockContext();
+      await handleGetCardGeneratorConfig(ctx2);
+
+      const msg = messages[0] as {
+        type: "card_generator_config_content";
+        requirements: string;
+        isOverride: boolean;
+      };
+      expect(msg.requirements).toBe("Persisted requirements");
+      expect(msg.isOverride).toBe(true);
+    });
+  });
+
+  // =============================================================================
+  // handleSaveCardGeneratorConfig Tests
+  // =============================================================================
+
+  describe("handleSaveCardGeneratorConfig", () => {
+    test("saves byte limit and returns success", async () => {
+      const { ctx, messages } = createMockContext();
+
+      await handleSaveCardGeneratorConfig(ctx, 2000000);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].type).toBe("card_generator_config_saved");
+
+      const msg = messages[0] as {
+        type: "card_generator_config_saved";
+        success: boolean;
+      };
+      expect(msg.success).toBe(true);
+    });
+
+    test("persists byte limit to disk", async () => {
+      const { ctx } = createMockContext();
+
+      await handleSaveCardGeneratorConfig(ctx, 3000000);
+
+      // Verify by loading config
+      const { ctx: ctx2, messages } = createMockContext();
+      await handleGetCardGeneratorConfig(ctx2);
+
+      const msg = messages[0] as {
+        type: "card_generator_config_content";
+        weeklyByteLimit: number;
+      };
+      expect(msg.weeklyByteLimit).toBe(3000000);
+    });
+  });
+
+  // =============================================================================
+  // handleResetCardGeneratorRequirements Tests
+  // =============================================================================
+
+  describe("handleResetCardGeneratorRequirements", () => {
+    test("removes override and returns default", async () => {
+      // First create an override
+      await saveRequirementsOverride("Custom content to be reset");
+
+      const { ctx, messages } = createMockContext();
+      await handleResetCardGeneratorRequirements(ctx);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].type).toBe("card_generator_requirements_reset");
+
+      const msg = messages[0] as {
+        type: "card_generator_requirements_reset";
+        success: boolean;
+        content: string;
+      };
+      expect(msg.success).toBe(true);
+      expect(msg.content).toBe(DEFAULT_REQUIREMENTS);
+    });
+
+    test("is idempotent when no override exists", async () => {
+      const { ctx, messages } = createMockContext();
+
+      await handleResetCardGeneratorRequirements(ctx);
+
+      expect(messages).toHaveLength(1);
+      const msg = messages[0] as {
+        type: "card_generator_requirements_reset";
+        success: boolean;
+        content: string;
+      };
+      expect(msg.success).toBe(true);
+      expect(msg.content).toBe(DEFAULT_REQUIREMENTS);
+    });
+
+    test("subsequent load returns default after reset", async () => {
+      await saveRequirementsOverride("To be reset");
+
+      const { ctx } = createMockContext();
+      await handleResetCardGeneratorRequirements(ctx);
+
+      // Verify by loading config
+      const { ctx: ctx2, messages } = createMockContext();
+      await handleGetCardGeneratorConfig(ctx2);
+
+      const msg = messages[0] as {
+        type: "card_generator_config_content";
+        isOverride: boolean;
+      };
+      expect(msg.isOverride).toBe(false);
+    });
+  });
+
+  // =============================================================================
+  // handleGetCardGenerationStatus Tests
+  // =============================================================================
+
+  describe("handleGetCardGenerationStatus", () => {
+    test("returns idle status when no generation running", () => {
+      const { ctx, messages } = createMockContext();
+
+      handleGetCardGenerationStatus(ctx);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].type).toBe("card_generation_status");
+
+      const msg = messages[0] as {
+        type: "card_generation_status";
+        status: string;
+        message: string;
+      };
+      expect(msg.status).toBe("idle");
+      expect(msg.message).toContain("No generation running");
+    });
+  });
+
+  // =============================================================================
+  // handleTriggerCardGeneration Tests
+  // =============================================================================
+
+  describe("handleTriggerCardGeneration", () => {
+    test("sends initial running status", async () => {
+      const { ctx, messages } = createMockContext();
+
+      // Start the generation (will complete quickly since no vaults configured)
+      await handleTriggerCardGeneration(ctx);
+
+      // Should have at least 2 messages: initial "running" and final status
+      expect(messages.length).toBeGreaterThanOrEqual(2);
+
+      // First message should be the initial "running" status
+      expect(messages[0].type).toBe("card_generation_status");
+      const initialMsg = messages[0] as {
+        type: "card_generation_status";
+        status: string;
+        message: string;
+      };
+      expect(initialMsg.status).toBe("running");
+      expect(initialMsg.message).toContain("Starting");
+    });
+
+    test("sends final status after completion", async () => {
+      const { ctx, messages } = createMockContext();
+
+      await handleTriggerCardGeneration(ctx);
+
+      // Last message should be the final status (complete or error)
+      const lastMsg = messages[messages.length - 1] as {
+        type: "card_generation_status";
+        status: string;
+      };
+      expect(lastMsg.type).toBe("card_generation_status");
+      // Status should be either "complete" or "error" (no vaults = error case)
+      expect(["complete", "error"]).toContain(lastMsg.status);
+    });
+
+    test("handles generation with no configured vaults gracefully", async () => {
+      const { ctx, messages } = createMockContext();
+
+      // With HOME pointing to temp dir, there are no vaults
+      await handleTriggerCardGeneration(ctx);
+
+      // Should not throw and should send status messages
+      expect(messages.length).toBeGreaterThanOrEqual(1);
+      expect(messages.every((m) => m.type === "card_generation_status")).toBe(true);
+    });
+  });
+
+  // =============================================================================
+  // Integration Tests
+  // =============================================================================
+
+  describe("integration: full config workflow", () => {
+    test("customize, verify, reset workflow", async () => {
+      // Start fresh - get defaults
+      const { ctx: ctx1, messages: msgs1 } = createMockContext();
+      await handleGetCardGeneratorConfig(ctx1);
+
+      let configMsg = msgs1[0] as {
+        type: "card_generator_config_content";
+        requirements: string;
+        isOverride: boolean;
+        weeklyByteLimit: number;
+      };
+      expect(configMsg.isOverride).toBe(false);
+      expect(configMsg.weeklyByteLimit).toBe(DEFAULT_WEEKLY_BYTE_LIMIT);
+
+      // Save custom requirements
+      const { ctx: ctx2 } = createMockContext();
+      await handleSaveCardGeneratorRequirements(ctx2, "Custom rules");
+
+      // Save custom byte limit
+      const { ctx: ctx3 } = createMockContext();
+      await handleSaveCardGeneratorConfig(ctx3, 5000000);
+
+      // Verify custom config
+      const { ctx: ctx4, messages: msgs4 } = createMockContext();
+      await handleGetCardGeneratorConfig(ctx4);
+
+      configMsg = msgs4[0] as typeof configMsg;
+      expect(configMsg.requirements).toBe("Custom rules");
+      expect(configMsg.isOverride).toBe(true);
+      expect(configMsg.weeklyByteLimit).toBe(5000000);
+
+      // Reset requirements
+      const { ctx: ctx5 } = createMockContext();
+      await handleResetCardGeneratorRequirements(ctx5);
+
+      // Verify reset (requirements default, byte limit still custom)
+      const { ctx: ctx6, messages: msgs6 } = createMockContext();
+      await handleGetCardGeneratorConfig(ctx6);
+
+      configMsg = msgs6[0] as typeof configMsg;
+      expect(configMsg.requirements).toBe(DEFAULT_REQUIREMENTS);
+      expect(configMsg.isOverride).toBe(false);
+      expect(configMsg.weeklyByteLimit).toBe(5000000); // Byte limit preserved
+    });
+  });
+});

--- a/backend/src/handlers/card-generator-handlers.ts
+++ b/backend/src/handlers/card-generator-handlers.ts
@@ -1,0 +1,239 @@
+/**
+ * Card Generator Handlers
+ *
+ * Handles card generator operations over WebSocket:
+ * - get_card_generator_config: Read config with requirements, override status, byte limits
+ * - save_card_generator_requirements: Write requirements override
+ * - save_card_generator_config: Update byte limit config
+ * - reset_card_generator_requirements: Remove requirements override
+ * - trigger_card_generation: Manually trigger card generation
+ * - get_card_generation_status: Query current generation status
+ */
+
+import type { HandlerContext } from "./types.js";
+import { wsLog as log } from "../logger.js";
+import {
+  saveCardGeneratorConfig,
+  loadRequirements,
+  saveRequirementsOverride,
+  deleteRequirementsOverride,
+  getDefaultRequirements,
+} from "../spaced-repetition/card-generator-config.js";
+import {
+  triggerManualGeneration,
+  isGenerationRunning,
+  getWeeklyUsage,
+} from "../spaced-repetition/card-discovery-scheduler.js";
+
+// =============================================================================
+// Config Handlers
+// =============================================================================
+
+/**
+ * Handles get_card_generator_config message.
+ * Returns config with requirements, override status, and byte limit info.
+ */
+export async function handleGetCardGeneratorConfig(ctx: HandlerContext): Promise<void> {
+  log.info("Getting card generator config");
+
+  try {
+    const [requirementsInfo, usage] = await Promise.all([
+      loadRequirements(),
+      getWeeklyUsage(),
+    ]);
+
+    log.info(`Card generator config loaded: isOverride=${requirementsInfo.isOverride}, byteLimit=${usage.byteLimit}, bytesUsed=${usage.bytesUsed}`);
+    ctx.send({
+      type: "card_generator_config_content",
+      requirements: requirementsInfo.content,
+      isOverride: requirementsInfo.isOverride,
+      weeklyByteLimit: usage.byteLimit,
+      weeklyBytesUsed: usage.bytesUsed,
+    });
+  } catch (error) {
+    log.error("Failed to get card generator config", error);
+    const message = error instanceof Error ? error.message : "Failed to get config";
+    ctx.sendError("INTERNAL_ERROR", message);
+  }
+}
+
+/**
+ * Handles save_card_generator_requirements message.
+ * Saves requirements to user override location.
+ */
+export async function handleSaveCardGeneratorRequirements(
+  ctx: HandlerContext,
+  content: string
+): Promise<void> {
+  log.info(`Saving card generator requirements (${content.length} chars)`);
+
+  try {
+    await saveRequirementsOverride(content);
+
+    log.info("Card generator requirements saved");
+    ctx.send({
+      type: "card_generator_requirements_saved",
+      success: true,
+      isOverride: true,
+    });
+  } catch (error) {
+    log.error("Failed to save card generator requirements", error);
+    const message = error instanceof Error ? error.message : "Failed to save requirements";
+    ctx.send({
+      type: "card_generator_requirements_saved",
+      success: false,
+      isOverride: false,
+      error: message,
+    });
+  }
+}
+
+/**
+ * Handles save_card_generator_config message.
+ * Updates the byte limit configuration.
+ */
+export async function handleSaveCardGeneratorConfig(
+  ctx: HandlerContext,
+  weeklyByteLimit: number
+): Promise<void> {
+  log.info(`Saving card generator config (weeklyByteLimit=${weeklyByteLimit})`);
+
+  try {
+    await saveCardGeneratorConfig({ weeklyByteLimit });
+
+    log.info("Card generator config saved");
+    ctx.send({
+      type: "card_generator_config_saved",
+      success: true,
+    });
+  } catch (error) {
+    log.error("Failed to save card generator config", error);
+    const message = error instanceof Error ? error.message : "Failed to save config";
+    ctx.send({
+      type: "card_generator_config_saved",
+      success: false,
+      error: message,
+    });
+  }
+}
+
+/**
+ * Handles reset_card_generator_requirements message.
+ * Removes user override and returns the default requirements.
+ */
+export async function handleResetCardGeneratorRequirements(ctx: HandlerContext): Promise<void> {
+  log.info("Resetting card generator requirements to default");
+
+  try {
+    await deleteRequirementsOverride();
+    const defaultContent = getDefaultRequirements();
+
+    log.info("Card generator requirements reset to default");
+    ctx.send({
+      type: "card_generator_requirements_reset",
+      success: true,
+      content: defaultContent,
+    });
+  } catch (error) {
+    log.error("Failed to reset card generator requirements", error);
+    const message = error instanceof Error ? error.message : "Failed to reset requirements";
+    ctx.send({
+      type: "card_generator_requirements_reset",
+      success: false,
+      content: "",
+      error: message,
+    });
+  }
+}
+
+// =============================================================================
+// Generation Trigger Handler
+// =============================================================================
+
+/**
+ * Handles trigger_card_generation message.
+ * Manually triggers card generation using remaining weekly budget.
+ */
+export async function handleTriggerCardGeneration(ctx: HandlerContext): Promise<void> {
+  log.info("Triggering manual card generation");
+
+  // Send initial status
+  ctx.send({
+    type: "card_generation_status",
+    status: "running",
+    message: "Starting card generation...",
+  });
+
+  try {
+    const result = await triggerManualGeneration();
+
+    if (!result.started) {
+      log.warn(`Card generation not started: ${result.reason}`);
+      ctx.send({
+        type: "card_generation_status",
+        status: "error",
+        error: result.reason,
+        message: result.reason ?? "Generation could not start",
+      });
+      return;
+    }
+
+    if (result.stats) {
+      log.info(`Manual card generation complete: ${result.stats.filesProcessed} files, ${result.stats.cardsCreated} cards`);
+      ctx.send({
+        type: "card_generation_status",
+        status: "complete",
+        message: `Processed ${result.stats.filesProcessed} files, created ${result.stats.cardsCreated} cards`,
+        filesProcessed: result.stats.filesProcessed,
+        cardsCreated: result.stats.cardsCreated,
+        bytesProcessed: result.stats.bytesProcessed,
+      });
+    } else if (result.reason) {
+      log.error(`Manual card generation failed: ${result.reason}`);
+      ctx.send({
+        type: "card_generation_status",
+        status: "error",
+        error: result.reason,
+        message: "Generation failed",
+      });
+    } else {
+      log.info("Manual card generation completed");
+      ctx.send({
+        type: "card_generation_status",
+        status: "complete",
+        message: "Generation completed",
+      });
+    }
+  } catch (error) {
+    log.error("Manual card generation threw", error);
+    const message = error instanceof Error ? error.message : "Generation failed";
+    ctx.send({
+      type: "card_generation_status",
+      status: "error",
+      error: message,
+      message: "Generation failed unexpectedly",
+    });
+  }
+}
+
+/**
+ * Handles get_card_generation_status message.
+ * Returns current generation status.
+ */
+export function handleGetCardGenerationStatus(ctx: HandlerContext): void {
+  log.debug("Getting card generation status");
+
+  try {
+    const running = isGenerationRunning();
+
+    ctx.send({
+      type: "card_generation_status",
+      status: running ? "running" : "idle",
+      message: running ? "Generation in progress" : "No generation running",
+    });
+  } catch (error) {
+    log.error("Failed to get card generation status", error);
+    const message = error instanceof Error ? error.message : "Failed to get status";
+    ctx.sendError("INTERNAL_ERROR", message);
+  }
+}

--- a/backend/src/spaced-repetition/__tests__/card-generator-config.test.ts
+++ b/backend/src/spaced-repetition/__tests__/card-generator-config.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Card Generator Config Tests
+ *
+ * Tests for card generator configuration persistence.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, rm, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+import {
+  loadCardGeneratorConfig,
+  saveCardGeneratorConfig,
+  loadRequirements,
+  saveRequirementsOverride,
+  deleteRequirementsOverride,
+  hasRequirementsOverride,
+  getDefaultRequirements,
+  getConfigFilePath,
+  getRequirementsFilePath,
+  DEFAULT_WEEKLY_BYTE_LIMIT,
+  DEFAULT_REQUIREMENTS,
+} from "../card-generator-config.js";
+
+describe("card-generator-config", () => {
+  // =============================================================================
+  // Constants Tests
+  // =============================================================================
+
+  describe("constants", () => {
+    test("DEFAULT_WEEKLY_BYTE_LIMIT is 500KB", () => {
+      expect(DEFAULT_WEEKLY_BYTE_LIMIT).toBe(500 * 1024);
+    });
+
+    test("DEFAULT_REQUIREMENTS is a non-empty string", () => {
+      expect(typeof DEFAULT_REQUIREMENTS).toBe("string");
+      expect(DEFAULT_REQUIREMENTS.length).toBeGreaterThan(0);
+    });
+
+    test("DEFAULT_REQUIREMENTS contains key instruction points", () => {
+      expect(DEFAULT_REQUIREMENTS).toContain("self-contained");
+      expect(DEFAULT_REQUIREMENTS).toContain("unique, unambiguous answer");
+    });
+  });
+
+  // =============================================================================
+  // Path Resolution Tests
+  // =============================================================================
+
+  describe("path resolution", () => {
+    test("getConfigFilePath returns path under home directory", () => {
+      const path = getConfigFilePath();
+      expect(path.startsWith(homedir())).toBe(true);
+    });
+
+    test("getConfigFilePath returns path with correct structure", () => {
+      const path = getConfigFilePath();
+      expect(path).toContain(".config/memory-loop");
+      expect(path.endsWith("card-generator-config.json")).toBe(true);
+    });
+
+    test("getRequirementsFilePath returns path under home directory", () => {
+      const path = getRequirementsFilePath();
+      expect(path.startsWith(homedir())).toBe(true);
+    });
+
+    test("getRequirementsFilePath returns path with correct structure", () => {
+      const path = getRequirementsFilePath();
+      expect(path).toContain(".config/memory-loop");
+      expect(path.endsWith("card-generator-requirements.md")).toBe(true);
+    });
+  });
+
+  // =============================================================================
+  // getDefaultRequirements Tests
+  // =============================================================================
+
+  describe("getDefaultRequirements", () => {
+    test("returns DEFAULT_REQUIREMENTS constant", () => {
+      expect(getDefaultRequirements()).toBe(DEFAULT_REQUIREMENTS);
+    });
+  });
+
+  // =============================================================================
+  // Config File I/O Tests
+  // =============================================================================
+
+  describe("loadCardGeneratorConfig and saveCardGeneratorConfig", () => {
+    let testDir: string;
+    let originalHome: string;
+
+    beforeEach(async () => {
+      testDir = join(
+        tmpdir(),
+        `card-generator-config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      await mkdir(testDir, { recursive: true });
+      originalHome = process.env.HOME ?? "";
+      process.env.HOME = testDir;
+    });
+
+    afterEach(async () => {
+      process.env.HOME = originalHome;
+      try {
+        await rm(testDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    test("returns default config when file does not exist", async () => {
+      const config = await loadCardGeneratorConfig();
+      expect(config.weeklyByteLimit).toBe(DEFAULT_WEEKLY_BYTE_LIMIT);
+    });
+
+    test("writes and reads config correctly", async () => {
+      const config = { weeklyByteLimit: 1000000 };
+
+      await saveCardGeneratorConfig(config);
+      const loaded = await loadCardGeneratorConfig();
+
+      expect(loaded.weeklyByteLimit).toBe(1000000);
+    });
+
+    test("creates config directory if not exists", async () => {
+      const config = { weeklyByteLimit: DEFAULT_WEEKLY_BYTE_LIMIT };
+      await saveCardGeneratorConfig(config);
+
+      const configPath = getConfigFilePath();
+      const content = await readFile(configPath, "utf-8");
+      expect(content).toBeDefined();
+    });
+
+    test("overwrites existing config file", async () => {
+      await saveCardGeneratorConfig({ weeklyByteLimit: 500000 });
+      await saveCardGeneratorConfig({ weeklyByteLimit: 1000000 });
+
+      const loaded = await loadCardGeneratorConfig();
+      expect(loaded.weeklyByteLimit).toBe(1000000);
+    });
+
+    test("returns default for invalid JSON", async () => {
+      const configPath = getConfigFilePath();
+      await mkdir(join(testDir, ".config/memory-loop"), { recursive: true });
+      await writeFile(configPath, "not valid json {{{", "utf-8");
+
+      const config = await loadCardGeneratorConfig();
+      expect(config.weeklyByteLimit).toBe(DEFAULT_WEEKLY_BYTE_LIMIT);
+    });
+
+    test("returns default for invalid schema", async () => {
+      const configPath = getConfigFilePath();
+      await mkdir(join(testDir, ".config/memory-loop"), { recursive: true });
+      await writeFile(
+        configPath,
+        JSON.stringify({ invalid: "schema" }),
+        "utf-8"
+      );
+
+      const config = await loadCardGeneratorConfig();
+      expect(config.weeklyByteLimit).toBe(DEFAULT_WEEKLY_BYTE_LIMIT);
+    });
+
+    test("returns default for out-of-range byte limit", async () => {
+      const configPath = getConfigFilePath();
+      await mkdir(join(testDir, ".config/memory-loop"), { recursive: true });
+      // Limit is below minimum (100KB)
+      await writeFile(
+        configPath,
+        JSON.stringify({ weeklyByteLimit: 50000 }),
+        "utf-8"
+      );
+
+      const config = await loadCardGeneratorConfig();
+      expect(config.weeklyByteLimit).toBe(DEFAULT_WEEKLY_BYTE_LIMIT);
+    });
+
+    test("writes pretty-formatted JSON", async () => {
+      await saveCardGeneratorConfig({ weeklyByteLimit: DEFAULT_WEEKLY_BYTE_LIMIT });
+
+      const configPath = getConfigFilePath();
+      const content = await readFile(configPath, "utf-8");
+
+      expect(content).toContain("\n");
+      expect(content).toContain("  ");
+    });
+  });
+
+  // =============================================================================
+  // Requirements Override I/O Tests
+  // =============================================================================
+
+  describe("requirements override operations", () => {
+    let testDir: string;
+    let originalHome: string;
+
+    beforeEach(async () => {
+      testDir = join(
+        tmpdir(),
+        `requirements-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      await mkdir(testDir, { recursive: true });
+      originalHome = process.env.HOME ?? "";
+      process.env.HOME = testDir;
+    });
+
+    afterEach(async () => {
+      process.env.HOME = originalHome;
+      try {
+        await rm(testDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    describe("hasRequirementsOverride", () => {
+      test("returns false when no override exists", async () => {
+        const result = await hasRequirementsOverride();
+        expect(result).toBe(false);
+      });
+
+      test("returns true when override exists", async () => {
+        await saveRequirementsOverride("custom requirements");
+        const result = await hasRequirementsOverride();
+        expect(result).toBe(true);
+      });
+    });
+
+    describe("loadRequirements", () => {
+      test("returns default when no override exists", async () => {
+        const info = await loadRequirements();
+
+        expect(info.content).toBe(DEFAULT_REQUIREMENTS);
+        expect(info.isOverride).toBe(false);
+      });
+
+      test("returns override when it exists", async () => {
+        const customContent = "Custom requirements\n- Rule 1\n- Rule 2";
+        await saveRequirementsOverride(customContent);
+
+        const info = await loadRequirements();
+
+        expect(info.content).toBe(customContent);
+        expect(info.isOverride).toBe(true);
+      });
+    });
+
+    describe("saveRequirementsOverride", () => {
+      test("creates requirements file", async () => {
+        const content = "My custom requirements";
+        await saveRequirementsOverride(content);
+
+        const path = getRequirementsFilePath();
+        const saved = await readFile(path, "utf-8");
+
+        expect(saved).toBe(content);
+      });
+
+      test("creates config directory if needed", async () => {
+        await saveRequirementsOverride("test content");
+
+        const info = await loadRequirements();
+        expect(info.isOverride).toBe(true);
+      });
+
+      test("overwrites existing override", async () => {
+        await saveRequirementsOverride("first version");
+        await saveRequirementsOverride("second version");
+
+        const info = await loadRequirements();
+        expect(info.content).toBe("second version");
+      });
+    });
+
+    describe("deleteRequirementsOverride", () => {
+      test("removes override file", async () => {
+        await saveRequirementsOverride("to be deleted");
+        expect(await hasRequirementsOverride()).toBe(true);
+
+        await deleteRequirementsOverride();
+        expect(await hasRequirementsOverride()).toBe(false);
+      });
+
+      test("is idempotent when no file exists", async () => {
+        // Should not throw
+        await deleteRequirementsOverride();
+        await deleteRequirementsOverride();
+
+        expect(await hasRequirementsOverride()).toBe(false);
+      });
+
+      test("loadRequirements returns default after deletion", async () => {
+        await saveRequirementsOverride("custom content");
+        await deleteRequirementsOverride();
+
+        const info = await loadRequirements();
+        expect(info.content).toBe(DEFAULT_REQUIREMENTS);
+        expect(info.isOverride).toBe(false);
+      });
+    });
+  });
+
+  // =============================================================================
+  // Integration Tests
+  // =============================================================================
+
+  describe("integration: config and requirements workflow", () => {
+    let testDir: string;
+    let originalHome: string;
+
+    beforeEach(async () => {
+      testDir = join(
+        tmpdir(),
+        `config-integration-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      await mkdir(testDir, { recursive: true });
+      originalHome = process.env.HOME ?? "";
+      process.env.HOME = testDir;
+    });
+
+    afterEach(async () => {
+      process.env.HOME = originalHome;
+      try {
+        await rm(testDir, { recursive: true, force: true });
+      } catch {
+        // Ignore
+      }
+    });
+
+    test("config and requirements files are independent", async () => {
+      // Save config
+      await saveCardGeneratorConfig({ weeklyByteLimit: 1000000 });
+
+      // Save requirements
+      await saveRequirementsOverride("custom requirements");
+
+      // Both should be retrievable independently
+      const config = await loadCardGeneratorConfig();
+      const requirements = await loadRequirements();
+
+      expect(config.weeklyByteLimit).toBe(1000000);
+      expect(requirements.content).toBe("custom requirements");
+      expect(requirements.isOverride).toBe(true);
+    });
+
+    test("deleting requirements does not affect config", async () => {
+      await saveCardGeneratorConfig({ weeklyByteLimit: 2000000 });
+      await saveRequirementsOverride("to delete");
+
+      await deleteRequirementsOverride();
+
+      const config = await loadCardGeneratorConfig();
+      expect(config.weeklyByteLimit).toBe(2000000);
+    });
+
+    test("full workflow: customize, verify, reset", async () => {
+      // Start with defaults
+      let config = await loadCardGeneratorConfig();
+      let requirements = await loadRequirements();
+
+      expect(config.weeklyByteLimit).toBe(DEFAULT_WEEKLY_BYTE_LIMIT);
+      expect(requirements.isOverride).toBe(false);
+
+      // Customize both
+      await saveCardGeneratorConfig({ weeklyByteLimit: 5000000 });
+      await saveRequirementsOverride("My custom rules");
+
+      config = await loadCardGeneratorConfig();
+      requirements = await loadRequirements();
+
+      expect(config.weeklyByteLimit).toBe(5000000);
+      expect(requirements.content).toBe("My custom rules");
+      expect(requirements.isOverride).toBe(true);
+
+      // Reset requirements to default
+      await deleteRequirementsOverride();
+      requirements = await loadRequirements();
+
+      expect(requirements.content).toBe(DEFAULT_REQUIREMENTS);
+      expect(requirements.isOverride).toBe(false);
+
+      // Config should still be customized
+      config = await loadCardGeneratorConfig();
+      expect(config.weeklyByteLimit).toBe(5000000);
+    });
+  });
+});

--- a/backend/src/spaced-repetition/card-generator-config.ts
+++ b/backend/src/spaced-repetition/card-generator-config.ts
@@ -1,0 +1,271 @@
+/**
+ * Card Generator Config
+ *
+ * Manages configuration for the card generator:
+ * - Weekly byte limit for card generation
+ * - Requirements prompt override
+ *
+ * Files:
+ * - ~/.config/memory-loop/card-generator-config.json - Config settings
+ * - ~/.config/memory-loop/card-generator-requirements.md - Requirements override
+ */
+
+import { readFile, writeFile, mkdir, unlink } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+import { z } from "zod";
+import { createLogger } from "../logger.js";
+import { fileExists } from "../vault-manager.js";
+
+const log = createLogger("card-generator-config");
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Config directory name within user home.
+ */
+const CONFIG_DIR = ".config/memory-loop";
+
+/**
+ * Config file name for card generator settings.
+ */
+const CONFIG_FILE = "card-generator-config.json";
+
+/**
+ * Requirements override file name.
+ */
+const REQUIREMENTS_FILE = "card-generator-requirements.md";
+
+/**
+ * Default weekly byte limit (500KB).
+ */
+export const DEFAULT_WEEKLY_BYTE_LIMIT = 500 * 1024;
+
+/**
+ * Default requirements for Q&A extraction.
+ * This is the content that can be customized by users.
+ */
+export const DEFAULT_REQUIREMENTS = `- Focus on key facts, concepts, definitions, and relationships
+- Questions must be self-contained and answerable without seeing the source
+- Never use "this", "the above", or assume the reader knows the context
+- Questions must have a unique, unambiguous answer that doesn't depend on when the note was written
+- Avoid questions like "What did X implement?" or "What was decided?" that could have many valid answers
+- Include enough specifics in the question to uniquely identify what's being asked (project name, feature name, date, version)
+- Answers should be concise but complete (the actual answer must be in the content)
+- Skip Q&A pairs where the answer would be vague, incomplete, or "not provided"
+- If the content mentions something but doesn't explain it, don't make a card about it
+- Each question should test a distinct piece of knowledge - avoid variations that ask the same thing differently
+- Skip subjective opinions, TODOs, or transient information
+- Skip self-referential questions about the note-taker's actions, decisions, or personal context
+- Questions must be answerable by anyone, not just the person who wrote the note
+- Avoid first-person or second-person framing ("you", "we", "I", "my", "our")
+- Only extract facts that would be useful to recall weeks or months later
+- If the content has no extractable facts, return an empty array`;
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+/**
+ * Schema for card generator config.
+ */
+const CardGeneratorConfigSchema = z.object({
+  /** Weekly byte limit for card generation (100KB - 10MB) */
+  weeklyByteLimit: z.number().int().min(102400).max(10485760).default(DEFAULT_WEEKLY_BYTE_LIMIT),
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type CardGeneratorConfig = z.infer<typeof CardGeneratorConfigSchema>;
+
+/**
+ * Info about the loaded requirements.
+ */
+export interface RequirementsInfo {
+  /** The requirements content */
+  content: string;
+  /** Whether this is a user override */
+  isOverride: boolean;
+}
+
+// =============================================================================
+// Path Resolution
+// =============================================================================
+
+/**
+ * Get the config directory path.
+ */
+function getConfigDir(): string {
+  const home = process.env.HOME ?? homedir();
+  return join(home, CONFIG_DIR);
+}
+
+/**
+ * Get the absolute path to the config file.
+ */
+export function getConfigFilePath(): string {
+  return join(getConfigDir(), CONFIG_FILE);
+}
+
+/**
+ * Get the absolute path to the requirements override file.
+ */
+export function getRequirementsFilePath(): string {
+  return join(getConfigDir(), REQUIREMENTS_FILE);
+}
+
+// =============================================================================
+// Config File Operations
+// =============================================================================
+
+/**
+ * Load the card generator config from disk.
+ * Returns default config if file doesn't exist.
+ *
+ * @returns Current config
+ */
+export async function loadCardGeneratorConfig(): Promise<CardGeneratorConfig> {
+  const configPath = getConfigFilePath();
+
+  let content: string;
+  try {
+    content = await readFile(configPath, "utf-8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+      log.debug("Config file not found, returning defaults");
+      return { weeklyByteLimit: DEFAULT_WEEKLY_BYTE_LIMIT };
+    }
+    log.error(`Failed to read config file: ${(e as Error).message}`);
+    throw e;
+  }
+
+  // Parse JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    log.warn(`Invalid JSON in config file at ${configPath}, returning defaults`);
+    return { weeklyByteLimit: DEFAULT_WEEKLY_BYTE_LIMIT };
+  }
+
+  // Validate against schema
+  const result = CardGeneratorConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    log.warn(
+      `Invalid config schema at ${configPath}, returning defaults`,
+      result.error.issues
+    );
+    return { weeklyByteLimit: DEFAULT_WEEKLY_BYTE_LIMIT };
+  }
+
+  return result.data;
+}
+
+/**
+ * Save the card generator config to disk.
+ *
+ * @param config - Config to save
+ */
+export async function saveCardGeneratorConfig(config: CardGeneratorConfig): Promise<void> {
+  const configPath = getConfigFilePath();
+  const dir = dirname(configPath);
+
+  // Ensure config directory exists
+  await mkdir(dir, { recursive: true });
+
+  // Serialize config to JSON with pretty formatting
+  const content = JSON.stringify(config, null, 2);
+
+  // Write config file
+  await writeFile(configPath, content, "utf-8");
+
+  log.debug(`Wrote card generator config to ${configPath}`);
+}
+
+// =============================================================================
+// Requirements File Operations
+// =============================================================================
+
+/**
+ * Get the default requirements content.
+ */
+export function getDefaultRequirements(): string {
+  return DEFAULT_REQUIREMENTS;
+}
+
+/**
+ * Check if a user requirements override exists.
+ */
+export async function hasRequirementsOverride(): Promise<boolean> {
+  return fileExists(getRequirementsFilePath());
+}
+
+/**
+ * Load the requirements, preferring user override if it exists.
+ *
+ * @returns RequirementsInfo with content and metadata
+ */
+export async function loadRequirements(): Promise<RequirementsInfo> {
+  const overridePath = getRequirementsFilePath();
+
+  // Check for user override first
+  if (await hasRequirementsOverride()) {
+    try {
+      const content = await readFile(overridePath, "utf-8");
+      log.debug(`Loaded user requirements override from ${overridePath}`);
+      return {
+        content,
+        isOverride: true,
+      };
+    } catch (error) {
+      log.warn(`Failed to read user requirements override: ${(error as Error).message}`);
+      // Fall through to default
+    }
+  }
+
+  // Return default requirements
+  log.debug("No user override, using default requirements");
+  return {
+    content: DEFAULT_REQUIREMENTS,
+    isOverride: false,
+  };
+}
+
+/**
+ * Save requirements override to user config.
+ *
+ * @param content - Requirements content to save
+ */
+export async function saveRequirementsOverride(content: string): Promise<void> {
+  const overridePath = getRequirementsFilePath();
+  const dir = dirname(overridePath);
+
+  // Ensure config directory exists
+  await mkdir(dir, { recursive: true });
+
+  // Write requirements file
+  await writeFile(overridePath, content, "utf-8");
+
+  log.info(`Saved requirements override to ${overridePath}`);
+}
+
+/**
+ * Delete the requirements override, restoring defaults.
+ */
+export async function deleteRequirementsOverride(): Promise<void> {
+  const overridePath = getRequirementsFilePath();
+
+  try {
+    await unlink(overridePath);
+    log.info(`Deleted requirements override at ${overridePath}`);
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw e;
+    }
+    log.debug("No requirements override to delete");
+  }
+}

--- a/backend/src/websocket-handler.ts
+++ b/backend/src/websocket-handler.ts
@@ -121,6 +121,16 @@ import {
   handleAdvisoryAction,
 } from "./handlers/pair-writing-handlers.js";
 
+// Card generator handlers
+import {
+  handleGetCardGeneratorConfig,
+  handleSaveCardGeneratorRequirements,
+  handleSaveCardGeneratorConfig,
+  handleResetCardGeneratorRequirements,
+  handleTriggerCardGeneration,
+  handleGetCardGenerationStatus,
+} from "./handlers/card-generator-handlers.js";
+
 // Re-export types for external consumers
 export type { WebSocketLike, ConnectionState };
 export { createConnectionState, generateMessageId };
@@ -597,6 +607,31 @@ export class WebSocketHandler {
 
       case "advisory_action_request":
         await handleAdvisoryAction(ctx, message);
+        break;
+
+      // Card Generator handlers
+      case "get_card_generator_config":
+        await handleGetCardGeneratorConfig(ctx);
+        break;
+
+      case "save_card_generator_requirements":
+        await handleSaveCardGeneratorRequirements(ctx, message.content);
+        break;
+
+      case "save_card_generator_config":
+        await handleSaveCardGeneratorConfig(ctx, message.weeklyByteLimit);
+        break;
+
+      case "reset_card_generator_requirements":
+        await handleResetCardGeneratorRequirements(ctx);
+        break;
+
+      case "trigger_card_generation":
+        await handleTriggerCardGeneration(ctx);
+        break;
+
+      case "get_card_generation_status":
+        handleGetCardGenerationStatus(ctx);
         break;
     }
   }

--- a/frontend/src/components/vault/CardGeneratorEditor.css
+++ b/frontend/src/components/vault/CardGeneratorEditor.css
@@ -1,0 +1,400 @@
+/**
+ * CardGeneratorEditor Component Styles
+ *
+ * Editor for the card generator configuration.
+ * Follows the same patterns as ExtractionPromptEditor.
+ */
+
+.card-generator-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 400px;
+}
+
+/* Header */
+.card-generator-editor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-sm);
+}
+
+.card-generator-editor__info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.card-generator-editor__label {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text);
+}
+
+.card-generator-editor__badge {
+  padding: 2px 6px;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  border-radius: var(--radius-sm);
+}
+
+.card-generator-editor__badge--override {
+  background-color: var(--color-accent-primary-a15);
+  color: var(--color-accent-primary);
+}
+
+.card-generator-editor__badge--default {
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+}
+
+.card-generator-editor__path {
+  font-size: var(--font-size-xs);
+  font-family: var(--font-family-mono);
+  color: var(--color-text-tertiary);
+}
+
+/* Description */
+.card-generator-editor__description {
+  margin: 0 0 var(--spacing-md) 0;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+/* Editor content */
+.card-generator-editor__content {
+  flex: 1;
+  min-height: 0;
+  margin-bottom: var(--spacing-md);
+}
+
+.card-generator-editor__textarea {
+  width: 100%;
+  height: 100%;
+  min-height: 150px;
+  padding: var(--spacing-md);
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family-mono);
+  line-height: 1.6;
+  resize: none;
+  transition: border-color 0.2s ease;
+}
+
+.card-generator-editor__textarea:focus {
+  outline: none;
+  border-color: var(--color-accent-primary);
+}
+
+.card-generator-editor__textarea::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+/* Loading state */
+.card-generator-editor__loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 150px;
+  gap: var(--spacing-md);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.card-generator-editor__spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent-primary);
+  border-radius: 50%;
+  animation: card-generator-editor-spin 0.8s linear infinite;
+}
+
+@keyframes card-generator-editor-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Config section (byte limit) */
+.card-generator-editor__config {
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.card-generator-editor__config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-sm);
+}
+
+.card-generator-editor__config-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.card-generator-editor__config-value {
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family-mono);
+  color: var(--color-text-secondary);
+}
+
+.card-generator-editor__slider {
+  width: 100%;
+  height: 6px;
+  margin: var(--spacing-sm) 0;
+  background: var(--color-border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  cursor: pointer;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.card-generator-editor__slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  background: var(--color-accent-primary);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.card-generator-editor__slider::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+}
+
+.card-generator-editor__slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  background: var(--color-accent-primary);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform 0.15s ease;
+}
+
+.card-generator-editor__slider::-moz-range-thumb:hover {
+  transform: scale(1.1);
+}
+
+/* Usage display */
+.card-generator-editor__usage {
+  margin-top: var(--spacing-sm);
+}
+
+.card-generator-editor__usage-bar {
+  height: 8px;
+  background-color: var(--color-bg-primary);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.card-generator-editor__usage-fill {
+  height: 100%;
+  background-color: var(--color-accent-primary);
+  border-radius: var(--radius-sm);
+  transition: width 0.3s ease;
+}
+
+.card-generator-editor__usage-text {
+  display: block;
+  margin-top: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+}
+
+/* Generation section */
+.card-generator-editor__generation {
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.card-generator-editor__generation-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.card-generator-editor__generation-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.card-generator-editor__generation-warning {
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background-color: var(--color-warning-bg, rgba(245, 158, 11, 0.1));
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  color: var(--color-warning, #f59e0b);
+}
+
+.card-generator-editor__generation-status {
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+}
+
+.card-generator-editor__generation-status--running {
+  background-color: var(--color-accent-primary-a15, rgba(59, 130, 246, 0.15));
+  color: var(--color-accent-primary);
+}
+
+.card-generator-editor__generation-status--complete {
+  background-color: var(--color-success-bg, rgba(34, 197, 94, 0.1));
+  color: var(--color-success, #22c55e);
+}
+
+.card-generator-editor__generation-status--error {
+  background-color: var(--color-error-bg, rgba(239, 68, 68, 0.1));
+  color: var(--color-error, #ef4444);
+}
+
+/* Error display */
+.card-generator-editor__error {
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+  background-color: var(--color-error-bg, rgba(239, 68, 68, 0.1));
+  border: 1px solid var(--color-error, #ef4444);
+  border-radius: var(--radius-md);
+  color: var(--color-error, #ef4444);
+  font-size: var(--font-size-sm);
+}
+
+/* Actions */
+.card-generator-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+}
+
+.card-generator-editor__btn {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.card-generator-editor__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.card-generator-editor__btn--run {
+  background-color: var(--color-accent-secondary, #8b5cf6);
+  border: 1px solid transparent;
+  color: var(--color-white);
+}
+
+.card-generator-editor__btn--run:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.card-generator-editor__btn--run:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.card-generator-editor__btn--reset {
+  background-color: transparent;
+  border: 1px solid var(--color-warning, #f59e0b);
+  color: var(--color-warning, #f59e0b);
+}
+
+.card-generator-editor__btn--reset:hover:not(:disabled) {
+  background-color: var(--color-warning-bg, rgba(245, 158, 11, 0.1));
+}
+
+.card-generator-editor__btn--discard {
+  background-color: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.card-generator-editor__btn--discard:hover:not(:disabled) {
+  background-color: var(--color-bg-secondary);
+  border-color: var(--color-border-hover);
+  color: var(--color-text);
+}
+
+.card-generator-editor__btn--save {
+  background-color: var(--color-accent-primary);
+  border: 1px solid transparent;
+  color: var(--color-white);
+}
+
+.card-generator-editor__btn--save:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.card-generator-editor__btn--save:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.card-generator-editor__btn--loading {
+  cursor: wait;
+}
+
+/* Mobile optimizations */
+@media (max-width: 480px) {
+  .card-generator-editor {
+    min-height: 300px;
+  }
+
+  .card-generator-editor__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .card-generator-editor__textarea {
+    min-height: 120px;
+  }
+
+  .card-generator-editor__description {
+    font-size: var(--font-size-xs);
+  }
+
+  .card-generator-editor__actions {
+    flex-direction: column;
+  }
+
+  .card-generator-editor__btn {
+    width: 100%;
+    text-align: center;
+  }
+
+  .card-generator-editor__generation-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--spacing-sm);
+  }
+
+  .card-generator-editor__generation-header .card-generator-editor__btn {
+    width: 100%;
+  }
+}

--- a/frontend/src/components/vault/CardGeneratorEditor.tsx
+++ b/frontend/src/components/vault/CardGeneratorEditor.tsx
@@ -1,0 +1,374 @@
+/**
+ * CardGeneratorEditor Component
+ *
+ * Editor for the card generator configuration.
+ * Features:
+ * - Textarea for viewing/editing the requirements prompt
+ * - Slider for weekly byte limit (100KB - 10MB)
+ * - Usage display showing current week's bytes used
+ * - Run Generator button to manually trigger generation
+ * - Indicator showing if user override is active
+ */
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import type { ClientMessage, ServerMessage } from "@memory-loop/shared";
+import "./CardGeneratorEditor.css";
+
+/**
+ * Props for the CardGeneratorEditor component.
+ */
+export interface CardGeneratorEditorProps {
+  /** Function to send WebSocket messages */
+  sendMessage: (message: ClientMessage) => void;
+  /** Last received server message (for handling responses) */
+  lastMessage: ServerMessage | null;
+}
+
+/**
+ * Format bytes as human-readable string.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * CardGeneratorEditor Component
+ *
+ * Provides an interface for configuring the card generator.
+ */
+export function CardGeneratorEditor({
+  sendMessage,
+  lastMessage,
+}: CardGeneratorEditorProps): React.ReactNode {
+  // Requirements state
+  const [requirements, setRequirements] = useState("");
+  const [originalRequirements, setOriginalRequirements] = useState("");
+  const [isOverride, setIsOverride] = useState(false);
+
+  // Config state
+  const [weeklyByteLimit, setWeeklyByteLimit] = useState(512000); // 500KB default
+  const [originalByteLimit, setOriginalByteLimit] = useState(512000);
+  const [weeklyBytesUsed, setWeeklyBytesUsed] = useState(0);
+
+  // UI state
+  const [isLoading, setIsLoading] = useState(true);
+  const [pendingSaves, setPendingSaves] = useState(0);
+  const [isResetting, setIsResetting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Derived saving state
+  const isSaving = pendingSaves > 0;
+
+  // Generation status state
+  const [generationStatus, setGenerationStatus] = useState<
+    "idle" | "running" | "complete" | "error"
+  >("idle");
+  const [generationMessage, setGenerationMessage] = useState<string | null>(null);
+
+  // Track if we've requested the content
+  const hasRequestedRef = useRef(false);
+
+  // Calculate if there are unsaved changes
+  const hasRequirementsChanges = requirements !== originalRequirements;
+  const hasConfigChanges = weeklyByteLimit !== originalByteLimit;
+  const hasChanges = hasRequirementsChanges || hasConfigChanges;
+
+  // Request config on mount
+  useEffect(() => {
+    if (!hasRequestedRef.current) {
+      hasRequestedRef.current = true;
+      sendMessage({ type: "get_card_generator_config" });
+    }
+  }, [sendMessage]);
+
+  // Ref to track current state for save callbacks
+  const requirementsRef = useRef(requirements);
+  requirementsRef.current = requirements;
+  const byteLimitRef = useRef(weeklyByteLimit);
+  byteLimitRef.current = weeklyByteLimit;
+
+  // Handle server messages
+  useEffect(() => {
+    if (!lastMessage) return;
+
+    if (lastMessage.type === "card_generator_config_content") {
+      setRequirements(lastMessage.requirements);
+      setOriginalRequirements(lastMessage.requirements);
+      setIsOverride(lastMessage.isOverride);
+      setWeeklyByteLimit(lastMessage.weeklyByteLimit);
+      setOriginalByteLimit(lastMessage.weeklyByteLimit);
+      setWeeklyBytesUsed(lastMessage.weeklyBytesUsed);
+      setIsLoading(false);
+      setError(null);
+    } else if (lastMessage.type === "card_generator_requirements_saved") {
+      setPendingSaves((prev) => Math.max(0, prev - 1));
+      if (lastMessage.success) {
+        setOriginalRequirements(requirementsRef.current);
+        setIsOverride(lastMessage.isOverride);
+        setError(null);
+      } else {
+        setError(lastMessage.error ?? "Failed to save requirements");
+      }
+    } else if (lastMessage.type === "card_generator_config_saved") {
+      setPendingSaves((prev) => Math.max(0, prev - 1));
+      if (lastMessage.success) {
+        setOriginalByteLimit(byteLimitRef.current);
+        setError(null);
+      } else {
+        setError(lastMessage.error ?? "Failed to save config");
+      }
+    } else if (lastMessage.type === "card_generator_requirements_reset") {
+      setIsResetting(false);
+      if (lastMessage.success) {
+        setRequirements(lastMessage.content);
+        setOriginalRequirements(lastMessage.content);
+        setIsOverride(false);
+        setError(null);
+      } else {
+        setError(lastMessage.error ?? "Failed to reset requirements");
+      }
+    } else if (lastMessage.type === "card_generation_status") {
+      setGenerationStatus(lastMessage.status);
+      setGenerationMessage(lastMessage.message ?? null);
+      if (lastMessage.status === "error" && lastMessage.error) {
+        setError(lastMessage.error);
+      }
+      // Update bytes used on completion
+      if (lastMessage.status === "complete" && lastMessage.bytesProcessed !== undefined) {
+        const bytesProcessed = lastMessage.bytesProcessed;
+        setWeeklyBytesUsed((prev) => prev + bytesProcessed);
+      }
+      // Clear success message after a delay
+      if (lastMessage.status === "complete") {
+        setTimeout(() => {
+          setGenerationStatus("idle");
+          setGenerationMessage(null);
+        }, 5000);
+      }
+    } else if (lastMessage.type === "error") {
+      setIsLoading(false);
+      setPendingSaves(0);
+      setIsResetting(false);
+      setError(lastMessage.message);
+    }
+  }, [lastMessage]);
+
+  // Handle requirements change
+  const handleRequirementsChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setRequirements(e.target.value);
+      setError(null);
+    },
+    []
+  );
+
+  // Handle byte limit change
+  const handleByteLimitChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = parseInt(e.target.value, 10);
+      setWeeklyByteLimit(value);
+      setError(null);
+    },
+    []
+  );
+
+  // Handle save
+  const handleSave = useCallback(() => {
+    if (isSaving || isResetting) return;
+    setError(null);
+
+    let savesStarted = 0;
+
+    // Save requirements if changed
+    if (hasRequirementsChanges) {
+      sendMessage({ type: "save_card_generator_requirements", content: requirements });
+      savesStarted++;
+    }
+
+    // Save config if changed
+    if (hasConfigChanges) {
+      sendMessage({ type: "save_card_generator_config", weeklyByteLimit });
+      savesStarted++;
+    }
+
+    if (savesStarted > 0) {
+      setPendingSaves(savesStarted);
+    }
+  }, [sendMessage, requirements, weeklyByteLimit, hasRequirementsChanges, hasConfigChanges, isSaving, isResetting]);
+
+  // Handle reset requirements to default
+  const handleResetRequirements = useCallback(() => {
+    if (isSaving || isResetting) return;
+    setIsResetting(true);
+    setError(null);
+    sendMessage({ type: "reset_card_generator_requirements" });
+  }, [sendMessage, isSaving, isResetting]);
+
+  // Handle discard changes (revert to original)
+  const handleDiscard = useCallback(() => {
+    setRequirements(originalRequirements);
+    setWeeklyByteLimit(originalByteLimit);
+    setError(null);
+  }, [originalRequirements, originalByteLimit]);
+
+  // Handle run generation
+  const handleRunGeneration = useCallback(() => {
+    if (generationStatus === "running") return;
+    setError(null);
+    setGenerationMessage(null);
+    sendMessage({ type: "trigger_card_generation" });
+  }, [sendMessage, generationStatus]);
+
+  // Calculate usage percentage
+  const usagePercent = Math.min(100, Math.round((100 * weeklyBytesUsed) / weeklyByteLimit));
+  const remainingBytes = Math.max(0, weeklyByteLimit - weeklyBytesUsed);
+
+  return (
+    <div className="card-generator-editor">
+      {/* Header with info */}
+      <div className="card-generator-editor__header">
+        <div className="card-generator-editor__info">
+          <span className="card-generator-editor__label">
+            Card Generator Requirements
+            {isOverride && !isLoading && (
+              <span className="card-generator-editor__badge card-generator-editor__badge--override">
+                Custom
+              </span>
+            )}
+            {!isOverride && !isLoading && (
+              <span className="card-generator-editor__badge card-generator-editor__badge--default">
+                Default
+              </span>
+            )}
+          </span>
+          <span className="card-generator-editor__path">
+            {isOverride
+              ? "~/.config/memory-loop/card-generator-requirements.md"
+              : "Built-in default requirements"}
+          </span>
+        </div>
+      </div>
+
+      {/* Description */}
+      <p className="card-generator-editor__description">
+        These requirements instruct Claude how to extract Q&A pairs from your notes.
+        Modify them to customize what types of flashcards are generated.
+      </p>
+
+      {/* Editor area */}
+      <div className="card-generator-editor__content">
+        {isLoading ? (
+          <div className="card-generator-editor__loading">
+            <div className="card-generator-editor__spinner" />
+            <span>Loading configuration...</span>
+          </div>
+        ) : (
+          <textarea
+            className="card-generator-editor__textarea"
+            value={requirements}
+            onChange={handleRequirementsChange}
+            placeholder="Enter card generation requirements..."
+            spellCheck={false}
+          />
+        )}
+      </div>
+
+      {/* Weekly limit section */}
+      <div className="card-generator-editor__config">
+        <div className="card-generator-editor__config-header">
+          <span className="card-generator-editor__config-label">Weekly Byte Limit</span>
+          <span className="card-generator-editor__config-value">{formatBytes(weeklyByteLimit)}</span>
+        </div>
+        <input
+          type="range"
+          className="card-generator-editor__slider"
+          min={102400}
+          max={10485760}
+          step={102400}
+          value={weeklyByteLimit}
+          onChange={handleByteLimitChange}
+          disabled={isLoading}
+        />
+        <div className="card-generator-editor__usage">
+          <div className="card-generator-editor__usage-bar">
+            <div
+              className="card-generator-editor__usage-fill"
+              style={{ width: `${usagePercent}%` }}
+            />
+          </div>
+          <span className="card-generator-editor__usage-text">
+            Used: {formatBytes(weeklyBytesUsed)} of {formatBytes(weeklyByteLimit)} ({usagePercent}%)
+          </span>
+        </div>
+      </div>
+
+      {/* Generation section */}
+      <div className="card-generator-editor__generation">
+        <div className="card-generator-editor__generation-header">
+          <span className="card-generator-editor__generation-label">Manual Generation</span>
+          <button
+            type="button"
+            className={`card-generator-editor__btn card-generator-editor__btn--run${generationStatus === "running" ? " card-generator-editor__btn--loading" : ""}`}
+            onClick={handleRunGeneration}
+            disabled={generationStatus === "running" || isLoading || remainingBytes <= 0}
+            aria-busy={generationStatus === "running"}
+          >
+            {generationStatus === "running" ? "Running..." : "Run Generator"}
+          </button>
+        </div>
+        {remainingBytes <= 0 && (
+          <div className="card-generator-editor__generation-warning">
+            Weekly byte limit reached. Increase the limit or wait until next week.
+          </div>
+        )}
+        {generationMessage && (
+          <div
+            className={`card-generator-editor__generation-status card-generator-editor__generation-status--${generationStatus}`}
+            role="status"
+          >
+            {generationMessage}
+          </div>
+        )}
+      </div>
+
+      {/* Error display */}
+      {error && (
+        <div className="card-generator-editor__error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="card-generator-editor__actions">
+        {isOverride && (
+          <button
+            type="button"
+            className="card-generator-editor__btn card-generator-editor__btn--reset"
+            onClick={handleResetRequirements}
+            disabled={isSaving || isResetting}
+          >
+            {isResetting ? "Resetting..." : "Reset to Default"}
+          </button>
+        )}
+        <button
+          type="button"
+          className="card-generator-editor__btn card-generator-editor__btn--discard"
+          onClick={handleDiscard}
+          disabled={!hasChanges || isSaving || isResetting}
+        >
+          Discard
+        </button>
+        <button
+          type="button"
+          className={`card-generator-editor__btn card-generator-editor__btn--save${isSaving ? " card-generator-editor__btn--loading" : ""}`}
+          onClick={handleSave}
+          disabled={!hasChanges || isSaving || isResetting}
+        >
+          {isSaving ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/vault/__tests__/CardGeneratorEditor.test.tsx
+++ b/frontend/src/components/vault/__tests__/CardGeneratorEditor.test.tsx
@@ -1,0 +1,550 @@
+/**
+ * CardGeneratorEditor Component Tests
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import type { ServerMessage, ClientMessage } from "@memory-loop/shared";
+import { CardGeneratorEditor } from "../CardGeneratorEditor";
+
+describe("CardGeneratorEditor", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // Helper to create mock sendMessage
+  const createMockSendMessage = () => {
+    const messages: ClientMessage[] = [];
+    return {
+      sendMessage: (msg: ClientMessage) => {
+        messages.push(msg);
+      },
+      messages,
+    };
+  };
+
+  describe("initial state", () => {
+    it("shows loading state initially", () => {
+      const { sendMessage } = createMockSendMessage();
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={null} />);
+
+      expect(screen.getByText("Loading configuration...")).not.toBeNull();
+    });
+
+    it("sends get_card_generator_config request on mount", () => {
+      const { sendMessage, messages } = createMockSendMessage();
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={null} />);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual({ type: "get_card_generator_config" });
+    });
+  });
+
+  describe("when config is loaded", () => {
+    it("displays requirements in textarea", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Focus on key facts...",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      const textarea = screen.getByRole<HTMLTextAreaElement>("textbox");
+      expect(textarea.value).toBe("Focus on key facts...");
+    });
+
+    it("shows Default badge when using default requirements", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Default requirements",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      expect(screen.getByText("Default")).not.toBeNull();
+    });
+
+    it("shows Custom badge when using override", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Custom requirements",
+        isOverride: true,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      expect(screen.getByText("Custom")).not.toBeNull();
+    });
+
+    it("shows correct path for default requirements", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Default requirements",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      expect(screen.getByText("Built-in default requirements")).not.toBeNull();
+    });
+
+    it("shows correct path for override requirements", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Custom requirements",
+        isOverride: true,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      expect(screen.getByText("~/.config/memory-loop/card-generator-requirements.md")).not.toBeNull();
+    });
+
+    it("displays weekly byte limit value", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Requirements",
+        isOverride: false,
+        weeklyByteLimit: 1048576, // 1MB
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      // Look for the formatted byte value (1 MB)
+      expect(screen.getByText("1.0 MB")).not.toBeNull();
+    });
+
+    it("displays usage percentage", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Requirements",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 256000, // 50%
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      expect(screen.getByText(/50%/)).not.toBeNull();
+    });
+  });
+
+  describe("editing requirements", () => {
+    it("updates content when typing", async () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Initial content",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      const textarea = screen.getByRole<HTMLTextAreaElement>("textbox");
+      fireEvent.change(textarea, { target: { value: "Updated content" } });
+
+      await waitFor(() => {
+        expect(textarea.value).toBe("Updated content");
+      });
+    });
+
+    it("enables Save button when content changes", async () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Initial",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      // Save button should be disabled initially
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      expect(saveButton.hasAttribute("disabled")).toBe(true);
+
+      // Edit content
+      const textarea = screen.getByRole<HTMLTextAreaElement>("textbox");
+      fireEvent.change(textarea, { target: { value: "Changed" } });
+
+      // Save button should be enabled
+      await waitFor(() => {
+        expect(saveButton.hasAttribute("disabled")).toBe(false);
+      });
+    });
+
+    it("discards changes when Discard button is clicked", async () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Original content",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      // Edit content
+      const textarea = screen.getByRole<HTMLTextAreaElement>("textbox");
+      fireEvent.change(textarea, { target: { value: "Changed content" } });
+
+      await waitFor(() => {
+        expect(textarea.value).toBe("Changed content");
+      });
+
+      // Click discard
+      const discardButton = screen.getByRole("button", { name: /discard/i });
+      fireEvent.click(discardButton);
+
+      await waitFor(() => {
+        expect(textarea.value).toBe("Original content");
+      });
+    });
+  });
+
+  describe("saving", () => {
+    it("sends save_card_generator_requirements message when Save is clicked", async () => {
+      const { sendMessage, messages } = createMockSendMessage();
+      const loadMessage: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Initial",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={loadMessage} />);
+
+      // Clear initial get_card_generator_config message
+      messages.length = 0;
+
+      // Edit content
+      const textarea = screen.getByRole<HTMLTextAreaElement>("textbox");
+      fireEvent.change(textarea, { target: { value: "New content" } });
+
+      await waitFor(() => {
+        const saveButton = screen.getByRole("button", { name: /save/i });
+        expect(saveButton.hasAttribute("disabled")).toBe(false);
+      });
+
+      // Click save
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      fireEvent.click(saveButton);
+
+      // Should send requirements save message
+      expect(messages.some(m => m.type === "save_card_generator_requirements")).toBe(true);
+    });
+
+    it("shows 'Saving...' while save is in progress", async () => {
+      const { sendMessage, messages } = createMockSendMessage();
+      const loadMessage: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Initial",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={loadMessage} />);
+
+      messages.length = 0;
+
+      // Edit content
+      const textarea = screen.getByRole<HTMLTextAreaElement>("textbox");
+      fireEvent.change(textarea, { target: { value: "New content" } });
+
+      await waitFor(() => {
+        const saveButton = screen.getByRole("button", { name: /save/i });
+        expect(saveButton.hasAttribute("disabled")).toBe(false);
+      });
+
+      // Click save
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      fireEvent.click(saveButton);
+
+      expect(screen.getByText("Saving...")).not.toBeNull();
+    });
+
+    it("shows error on save failure", () => {
+      const { sendMessage } = createMockSendMessage();
+      const errorMessage: ServerMessage = {
+        type: "card_generator_requirements_saved",
+        success: false,
+        isOverride: false,
+        error: "Permission denied",
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={errorMessage} />);
+
+      expect(screen.getByRole("alert")).not.toBeNull();
+      expect(screen.getByText("Permission denied")).not.toBeNull();
+    });
+  });
+
+  describe("reset to default", () => {
+    it("shows Reset to Default button when using override", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Custom requirements",
+        isOverride: true,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      expect(screen.getByRole("button", { name: /reset to default/i })).not.toBeNull();
+    });
+
+    it("does not show Reset to Default button when using default", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Default requirements",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      expect(screen.queryByRole("button", { name: /reset to default/i })).toBeNull();
+    });
+
+    it("sends reset_card_generator_requirements message when Reset is clicked", () => {
+      const { sendMessage, messages } = createMockSendMessage();
+      const loadMessage: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Custom requirements",
+        isOverride: true,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={loadMessage} />);
+
+      // Clear initial message
+      messages.length = 0;
+
+      // Click reset
+      const resetButton = screen.getByRole("button", { name: /reset to default/i });
+      fireEvent.click(resetButton);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual({ type: "reset_card_generator_requirements" });
+    });
+
+    it("updates content after successful reset", () => {
+      const { sendMessage } = createMockSendMessage();
+      // First load with override
+      const loadMessage: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Custom requirements",
+        isOverride: true,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      const { rerender } = render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={loadMessage} />);
+
+      // Then send reset
+      const resetMessage: ServerMessage = {
+        type: "card_generator_requirements_reset",
+        success: true,
+        content: "Default requirements content",
+      };
+      rerender(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={resetMessage} />);
+
+      const textarea = screen.getByRole<HTMLTextAreaElement>("textbox");
+      expect(textarea.value).toBe("Default requirements content");
+    });
+
+    it("shows Default badge after successful reset", () => {
+      const { sendMessage } = createMockSendMessage();
+      // First load with override
+      const loadMessage: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Custom requirements",
+        isOverride: true,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      const { rerender } = render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={loadMessage} />);
+
+      // Then send reset
+      const resetMessage: ServerMessage = {
+        type: "card_generator_requirements_reset",
+        success: true,
+        content: "Default requirements content",
+      };
+      rerender(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={resetMessage} />);
+
+      expect(screen.getByText("Default")).not.toBeNull();
+    });
+  });
+
+  describe("generation trigger", () => {
+    it("shows Run Generator button", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Requirements content",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      expect(screen.getByRole("button", { name: /run generator/i })).not.toBeNull();
+    });
+
+    it("sends trigger_card_generation message when Run Generator is clicked", () => {
+      const { sendMessage, messages } = createMockSendMessage();
+      const loadMessage: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Requirements content",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 0,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={loadMessage} />);
+
+      // Clear initial message
+      messages.length = 0;
+
+      // Click Run Generator
+      const runButton = screen.getByRole("button", { name: /run generator/i });
+      fireEvent.click(runButton);
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual({ type: "trigger_card_generation" });
+    });
+
+    it("shows 'Running...' while generation is in progress", () => {
+      const { sendMessage } = createMockSendMessage();
+      const statusMessage: ServerMessage = {
+        type: "card_generation_status",
+        status: "running",
+        message: "Starting card generation...",
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={statusMessage} />);
+
+      expect(screen.getByText("Running...")).not.toBeNull();
+    });
+
+    it("disables Run Generator button while running", () => {
+      const { sendMessage } = createMockSendMessage();
+      const statusMessage: ServerMessage = {
+        type: "card_generation_status",
+        status: "running",
+        message: "Processing files...",
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={statusMessage} />);
+
+      const runButton = screen.getByRole("button", { name: /running/i });
+      expect(runButton.hasAttribute("disabled")).toBe(true);
+    });
+
+    it("shows generation status message", () => {
+      const { sendMessage } = createMockSendMessage();
+      const statusMessage: ServerMessage = {
+        type: "card_generation_status",
+        status: "running",
+        message: "Processing 5 files...",
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={statusMessage} />);
+
+      expect(screen.getByRole("status")).not.toBeNull();
+      expect(screen.getByText("Processing 5 files...")).not.toBeNull();
+    });
+
+    it("shows completion message on success", () => {
+      const { sendMessage } = createMockSendMessage();
+      const statusMessage: ServerMessage = {
+        type: "card_generation_status",
+        status: "complete",
+        message: "Processed 3 files, created 10 cards",
+        filesProcessed: 3,
+        cardsCreated: 10,
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={statusMessage} />);
+
+      expect(screen.getByText("Processed 3 files, created 10 cards")).not.toBeNull();
+    });
+
+    it("shows error on generation failure", () => {
+      const { sendMessage } = createMockSendMessage();
+      const statusMessage: ServerMessage = {
+        type: "card_generation_status",
+        status: "error",
+        message: "Generation failed",
+        error: "Weekly byte limit reached",
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={statusMessage} />);
+
+      expect(screen.getByRole("alert")).not.toBeNull();
+      expect(screen.getByText("Weekly byte limit reached")).not.toBeNull();
+    });
+
+    it("disables Run Generator when byte limit is reached", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Requirements",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 512000, // 100% used
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      const runButton = screen.getByRole("button", { name: /run generator/i });
+      expect(runButton.hasAttribute("disabled")).toBe(true);
+    });
+
+    it("shows warning when byte limit is reached", () => {
+      const { sendMessage } = createMockSendMessage();
+      const message: ServerMessage = {
+        type: "card_generator_config_content",
+        requirements: "Requirements",
+        isOverride: false,
+        weeklyByteLimit: 512000,
+        weeklyBytesUsed: 512000, // 100% used
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={message} />);
+
+      expect(screen.getByText(/weekly byte limit reached/i)).not.toBeNull();
+    });
+
+    it("button is disabled while loading config", () => {
+      const { sendMessage } = createMockSendMessage();
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={null} />);
+
+      // During loading, button should be disabled
+      const runButton = screen.getByRole("button", { name: /run generator/i });
+      expect(runButton.hasAttribute("disabled")).toBe(true);
+    });
+  });
+
+  describe("error handling", () => {
+    it("shows error message on error response", () => {
+      const { sendMessage } = createMockSendMessage();
+      const errorMessage: ServerMessage = {
+        type: "error",
+        code: "INTERNAL_ERROR",
+        message: "Failed to read card generator config",
+      };
+      render(<CardGeneratorEditor sendMessage={sendMessage} lastMessage={errorMessage} />);
+
+      expect(screen.getByRole("alert")).not.toBeNull();
+      expect(screen.getByText("Failed to read card generator config")).not.toBeNull();
+    });
+  });
+});

--- a/frontend/src/components/vault/__tests__/SettingsDialog.test.tsx
+++ b/frontend/src/components/vault/__tests__/SettingsDialog.test.tsx
@@ -36,7 +36,7 @@ describe("SettingsDialog", () => {
       render(<SettingsDialog isOpen={true} onClose={() => {}} />);
 
       expect(screen.getByRole("tablist")).not.toBeNull();
-      expect(screen.getAllByRole("tab")).toHaveLength(2);
+      expect(screen.getAllByRole("tab")).toHaveLength(3);
     });
 
     it("renders Memory tab", () => {
@@ -49,6 +49,12 @@ describe("SettingsDialog", () => {
       render(<SettingsDialog isOpen={true} onClose={() => {}} />);
 
       expect(screen.getByRole("tab", { name: /extraction prompt/i })).not.toBeNull();
+    });
+
+    it("renders Card Generator tab", () => {
+      render(<SettingsDialog isOpen={true} onClose={() => {}} />);
+
+      expect(screen.getByRole("tab", { name: /card generator/i })).not.toBeNull();
     });
 
     it("renders close buttons", () => {
@@ -104,12 +110,12 @@ describe("SettingsDialog", () => {
       expect(memoryPanel.getAttribute("hidden")).toBeNull();
     });
 
-    it("hides Prompt panel when Memory tab is active", () => {
+    it("hides other panels when Memory tab is active", () => {
       render(<SettingsDialog isOpen={true} onClose={() => {}} />);
 
-      // The hidden panel should have the hidden attribute
+      // The hidden panels should have the hidden attribute (Prompt and Card Generator)
       const hiddenPanels = document.querySelectorAll('.settings-dialog__panel[hidden]');
-      expect(hiddenPanels.length).toBe(1);
+      expect(hiddenPanels.length).toBe(2);
     });
   });
 
@@ -222,6 +228,7 @@ describe("SettingsDialog", () => {
       const tablist = screen.getByRole("tablist");
       const memoryTab = screen.getByRole("tab", { name: /memory/i });
       const promptTab = screen.getByRole("tab", { name: /extraction prompt/i });
+      const cardsTab = screen.getByRole("tab", { name: /card generator/i });
 
       // Initially Memory is active
       expect(memoryTab.getAttribute("aria-selected")).toBe("true");
@@ -230,9 +237,17 @@ describe("SettingsDialog", () => {
       fireEvent.keyDown(tablist, { key: "ArrowRight" });
       expect(promptTab.getAttribute("aria-selected")).toBe("true");
 
-      // Press ArrowLeft to switch back to Memory
-      fireEvent.keyDown(tablist, { key: "ArrowLeft" });
+      // Press ArrowRight to switch to Card Generator
+      fireEvent.keyDown(tablist, { key: "ArrowRight" });
+      expect(cardsTab.getAttribute("aria-selected")).toBe("true");
+
+      // Press ArrowRight to wrap back to Memory
+      fireEvent.keyDown(tablist, { key: "ArrowRight" });
       expect(memoryTab.getAttribute("aria-selected")).toBe("true");
+
+      // Press ArrowLeft to wrap to Card Generator
+      fireEvent.keyDown(tablist, { key: "ArrowLeft" });
+      expect(cardsTab.getAttribute("aria-selected")).toBe("true");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds third "Card Generator" tab to Settings dialog
- Configurable requirements prompt for Q&A extraction (stored at `~/.config/memory-loop/card-generator-requirements.md`)
- Configurable weekly byte limit (100KB - 10MB slider, default 500KB)
- Manual trigger button that runs card generation using remaining weekly budget
- Run-in-progress tracking with 2-hour stale timeout to prevent concurrent runs

## Test plan

- [ ] Open Settings dialog, verify third "Card Generator" tab appears
- [ ] Edit requirements, save, verify persistence (check config file exists)
- [ ] Adjust byte limit, verify config saves
- [ ] Click Run Generator, verify status shows "running" then completes
- [ ] Verify button is disabled while running
- [ ] Close/reopen dialog, verify state persists
- [ ] Reset to default, verify override file is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)