### PR TITLE
fix: Use Sonnet instead of Haiku for card generation

### DIFF
--- a/backend/src/spaced-repetition/card-generator.ts
+++ b/backend/src/spaced-repetition/card-generator.ts
@@ -62,8 +62,8 @@ export interface CardTypeGenerator {
 // Constants
 // =============================================================================
 
-/** Model to use for card generation (cost-efficient) */
-export const GENERATION_MODEL = "haiku";
+/** Model to use for card generation */
+export const GENERATION_MODEL = "sonnet";
 
 /** Minimum content length to attempt extraction (characters) */
 export const MIN_CONTENT_LENGTH = 100;


### PR DESCRIPTION
## Summary
- Switches card generation model from Haiku to Sonnet for improved accuracy
- Haiku was producing too many incorrect flashcards

## Test plan
- [ ] Generate cards from a note and verify quality improvement
- [ ] Check that generation still completes in reasonable time

🤖 Generated with [Claude Code](https://claude.com/claude-code)