### PR TITLE
docs: Add YAML frontmatter to all .lore documents

### DIFF
--- a/.lore/brainstorm/discussion-input-during-response.md
+++ b/.lore/brainstorm/discussion-input-during-response.md
@@ -1,6 +1,13 @@
-# Brainstorm: Allowing User Input During AI Response
+---
+title: Allowing User Input During AI Response
+date: 2026-01-28
+status: resolved
+tags: [ux, discussion, streaming, input-handling]
+modules: [frontend-discussion]
+resolution: Draft Mode implemented (PR #436, commit f57134a). Other ideas (full input, queue) not pursued.
+---
 
-**Status**: open
+# Brainstorm: Allowing User Input During AI Response
 
 ## Context
 

--- a/.lore/diagrams/gctr-mode-transitions.md
+++ b/.lore/diagrams/gctr-mode-transitions.md
@@ -1,3 +1,11 @@
+---
+title: GCTR Mode Transitions
+date: 2026-01-28
+status: current
+tags: [architecture, navigation, state-machine, gctr]
+modules: [frontend-app, session-context]
+---
+
 # Diagram: GCTR Mode Transitions
 
 ## Context

--- a/.lore/diagrams/session-auto-resume.md
+++ b/.lore/diagrams/session-auto-resume.md
@@ -1,3 +1,11 @@
+---
+title: Session Auto-Resume Flow
+date: 2026-01-28
+status: current
+tags: [architecture, session, websocket, rest-api]
+modules: [session-manager, vault-select]
+---
+
 # Diagram: Session Auto-Resume Flow
 
 ## Context

--- a/.lore/diagrams/websocket-connection-lifecycle.md
+++ b/.lore/diagrams/websocket-connection-lifecycle.md
@@ -1,3 +1,11 @@
+---
+title: WebSocket Connection Lifecycle
+date: 2026-01-28
+status: current
+tags: [architecture, websocket, connection, reconnect]
+modules: [websocket-handler, use-websocket]
+---
+
 # Diagram: WebSocket Connection Lifecycle
 
 ## Context

--- a/.lore/excavations/index.md
+++ b/.lore/excavations/index.md
@@ -1,3 +1,10 @@
+---
+title: Excavation Index
+date: 2026-01-28
+status: current
+tags: [excavation, index, documentation]
+---
+
 # Excavation Index
 
 **Codebase**: Memory Loop

--- a/.lore/lore-agents.md
+++ b/.lore/lore-agents.md
@@ -1,3 +1,10 @@
+---
+title: Lore Agents Registry
+date: 2026-01-29
+status: current
+tags: [agents, registry, tooling]
+---
+
 # Lore Agents
 
 Specialized agents available for lore-development work in this project.

--- a/.lore/plans/vi-mode-pair-writing.md
+++ b/.lore/plans/vi-mode-pair-writing.md
@@ -1,3 +1,12 @@
+---
+title: Vi Mode for Pair Writing
+date: 2026-01-29
+status: executed
+tags: [vi-mode, pair-writing, modal-editing, keyboard]
+modules: [pair-writing-editor, use-vi-mode]
+related: [.lore/specs/vi-mode-pair-writing.md, .lore/research/vi-mode-implementation.md]
+---
+
 # Plan: Vi Mode for Pair Writing
 
 ## Context

--- a/.lore/reference/_infrastructure/card-generator.md
+++ b/.lore/reference/_infrastructure/card-generator.md
@@ -1,3 +1,11 @@
+---
+title: Card Generator Infrastructure
+date: 2026-01-28
+status: current
+tags: [spaced-repetition, llm, scheduling, cost-control]
+modules: [card-generator, card-discovery-scheduler]
+---
+
 # Infrastructure: Card Generator
 
 ## What It Does

--- a/.lore/reference/_infrastructure/communication-layer.md
+++ b/.lore/reference/_infrastructure/communication-layer.md
@@ -1,3 +1,11 @@
+---
+title: Communication Layer Infrastructure
+date: 2026-01-28
+status: current
+tags: [websocket, rest-api, protocol, streaming]
+modules: [websocket-handler, server, protocol]
+---
+
 # Infrastructure: Communication Layer
 
 ## What It Does

--- a/.lore/reference/_infrastructure/configuration.md
+++ b/.lore/reference/_infrastructure/configuration.md
@@ -1,3 +1,11 @@
+---
+title: Configuration Infrastructure
+date: 2026-01-28
+status: current
+tags: [config, vault-settings, badges, per-vault]
+modules: [vault-config, config-editor-dialog]
+---
+
 # Infrastructure: Configuration
 
 ## What It Does

--- a/.lore/reference/_infrastructure/extraction.md
+++ b/.lore/reference/_infrastructure/extraction.md
@@ -1,3 +1,11 @@
+---
+title: Extraction Pipeline Infrastructure
+date: 2026-01-28
+status: current
+tags: [extraction, memory, llm, batch-processing]
+modules: [extraction-manager, fact-extractor, memory-writer]
+---
+
 # Infrastructure: Extraction Pipeline
 
 ## What It Does

--- a/.lore/reference/_infrastructure/system-settings.md
+++ b/.lore/reference/_infrastructure/system-settings.md
@@ -1,3 +1,11 @@
+---
+title: System Settings Infrastructure
+date: 2026-01-28
+status: current
+tags: [settings, memory-editor, extraction-prompt, card-generator]
+modules: [settings-dialog, memory-editor]
+---
+
 # Infrastructure: System Settings
 
 ## What It Does

--- a/.lore/reference/_infrastructure/vault-selection.md
+++ b/.lore/reference/_infrastructure/vault-selection.md
@@ -1,3 +1,11 @@
+---
+title: Vault Selection Infrastructure
+date: 2026-01-28
+status: current
+tags: [vault, discovery, session, setup-wizard]
+modules: [vault-manager, vault-select, session-manager]
+---
+
 # Infrastructure: Vault Selection
 
 ## What It Does

--- a/.lore/reference/_overview.md
+++ b/.lore/reference/_overview.md
@@ -1,3 +1,11 @@
+---
+title: Memory Loop System Overview
+date: 2026-01-28
+status: current
+tags: [architecture, gctr, overview, onboarding]
+modules: [backend, frontend, shared]
+---
+
 # Memory Loop: System Overview
 
 ## What It Is

--- a/.lore/reference/capture.md
+++ b/.lore/reference/capture.md
@@ -1,3 +1,11 @@
+---
+title: Capture Feature
+date: 2026-01-28
+status: current
+tags: [capture, daily-notes, meeting-mode, gctr]
+modules: [note-capture, meeting-capture]
+---
+
 # Feature: Capture
 
 ## What It Does

--- a/.lore/reference/home-dashboard.md
+++ b/.lore/reference/home-dashboard.md
@@ -1,3 +1,11 @@
+---
+title: Ground (Home Dashboard) Feature
+date: 2026-01-28
+status: current
+tags: [ground, dashboard, widgets, gctr]
+modules: [home-view, goals-card, health-panel, recent-activity]
+---
+
 # Feature: Ground (Home Dashboard)
 
 ## What It Does

--- a/.lore/reference/inspiration.md
+++ b/.lore/reference/inspiration.md
@@ -1,3 +1,11 @@
+---
+title: Inspiration Feature
+date: 2026-01-28
+status: current
+tags: [inspiration, prompts, quotes, llm-generation]
+modules: [inspiration-manager, inspiration-card]
+---
+
 # Feature: Inspiration
 
 ## What It Does

--- a/.lore/reference/navigation-bar.md
+++ b/.lore/reference/navigation-bar.md
@@ -1,3 +1,11 @@
+---
+title: Navigation Bar Feature
+date: 2026-01-28
+status: current
+tags: [navigation, gctr, mode-toggle, ui]
+modules: [mode-toggle]
+---
+
 # Feature: Navigation Bar
 
 ## What It Does

--- a/.lore/reference/pair-writing.md
+++ b/.lore/reference/pair-writing.md
@@ -1,3 +1,11 @@
+---
+title: Pair Writing Feature
+date: 2026-01-28
+status: current
+tags: [pair-writing, ai-editing, quick-actions, advisory-actions]
+modules: [pair-writing-mode, pair-writing-editor]
+---
+
 # Feature: Pair Writing
 
 ## What It Does

--- a/.lore/reference/recall.md
+++ b/.lore/reference/recall.md
@@ -1,3 +1,11 @@
+---
+title: Recall Feature
+date: 2026-01-28
+status: current
+tags: [recall, file-browser, markdown-viewer, search, gctr]
+modules: [browse-mode, file-tree, file-browser]
+---
+
 # Feature: Recall
 
 ## What It Does

--- a/.lore/reference/spaced-repetition.md
+++ b/.lore/reference/spaced-repetition.md
@@ -1,3 +1,11 @@
+---
+title: Spaced Repetition Feature
+date: 2026-01-28
+status: current
+tags: [spaced-repetition, sm2, flashcards, review]
+modules: [spaced-repetition-widget, card-manager, sm2-algorithm]
+---
+
 # Feature: Spaced Repetition
 
 ## What It Does

--- a/.lore/reference/task-list.md
+++ b/.lore/reference/task-list.md
@@ -1,3 +1,11 @@
+---
+title: Task List Feature
+date: 2026-01-28
+status: current
+tags: [tasks, checkbox, para, aggregation]
+modules: [task-list, task-manager]
+---
+
 # Feature: Task List
 
 ## What It Does

--- a/.lore/reference/think.md
+++ b/.lore/reference/think.md
@@ -1,3 +1,11 @@
+---
+title: Think Feature
+date: 2026-01-28
+status: current
+tags: [think, ai-conversation, streaming, claude-sdk, gctr]
+modules: [discussion, session-manager, websocket-handler]
+---
+
 # Feature: Think
 
 ## What It Does

--- a/.lore/research/vi-mode-implementation.md
+++ b/.lore/research/vi-mode-implementation.md
@@ -1,3 +1,12 @@
+---
+title: Vi Mode Implementation for Pair Writing
+date: 2026-01-29
+status: archived
+tags: [vi-mode, modal-editing, cursor-rendering, textarea]
+modules: [pair-writing-editor]
+related: [.lore/specs/vi-mode-pair-writing.md]
+---
+
 # Research: Vi Mode Implementation for Pair Writing
 
 ## Summary

--- a/.lore/retros/vi-mode-pair-writing.md
+++ b/.lore/retros/vi-mode-pair-writing.md
@@ -1,3 +1,12 @@
+---
+title: Vi Mode for Pair Writing
+date: 2026-01-29
+status: complete
+tags: [vi-mode, pair-writing, implementation, lessons-learned]
+modules: [pair-writing-editor, use-vi-mode, use-vi-cursor]
+related: [.lore/specs/vi-mode-pair-writing.md, .lore/plans/vi-mode-pair-writing.md]
+---
+
 # Retro: Vi Mode for Pair Writing
 
 ## Summary

--- a/.lore/specs/vi-mode-pair-writing.md
+++ b/.lore/specs/vi-mode-pair-writing.md
@@ -1,3 +1,12 @@
+---
+title: Vi Mode for Pair Writing
+date: 2026-01-29
+status: implemented
+tags: [vi-mode, pair-writing, modal-editing, keyboard, requirements]
+modules: [pair-writing-editor, use-vi-mode, vault-config]
+related: [.lore/research/vi-mode-implementation.md]
+---
+
 # Spec: Vi Mode for Pair Writing
 
 ## Overview

--- a/.lore/work/vi-mode-pair-writing.md
+++ b/.lore/work/vi-mode-pair-writing.md
@@ -1,3 +1,12 @@
+---
+title: Vi Mode for Pair Writing - Work Breakdown
+date: 2026-01-29
+status: complete
+tags: [vi-mode, pair-writing, task-tracking, implementation]
+modules: [pair-writing-editor, use-vi-mode]
+related: [.lore/specs/vi-mode-pair-writing.md, .lore/plans/vi-mode-pair-writing.md]
+---
+
 # Work Breakdown: Vi Mode for Pair Writing
 
 Spec: `.lore/specs/vi-mode-pair-writing.md`


### PR DESCRIPTION
## Summary

- Retrofitted YAML frontmatter to all 27 `.lore/` documents for searchability
- Added `title`, `date`, `status`, `tags`, `modules` fields per frontmatter schema
- Added `related` field for linked documents (vi-mode spec/plan/research/retro)
- Set appropriate status values by document type (current, implemented, executed, archived, complete, resolved)
- Migrated inline `**Status**: open` to frontmatter in brainstorm doc
- Marked discussion-input brainstorm as `resolved` (Draft Mode shipped in PR #436)

## Test plan

- [x] Pre-commit hooks pass (typecheck, lint, tests)
- [ ] Verify frontmatter renders correctly in any markdown viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)