### PR TITLE
docs: Add vi mode retros and graduate lessons

### DIFF
--- a/.lore/plans/vi-mode-word-motions.md
+++ b/.lore/plans/vi-mode-word-motions.md
@@ -1,0 +1,137 @@
+---
+title: Vi mode word motions and operators
+date: 2026-01-30
+status: executed
+tags: [vi-mode, pair-writing, word-motions, operators]
+modules: [use-vi-mode]
+related: [.lore/retros/vi-mode-word-motions.md, .lore/plans/vi-mode-pair-writing.md]
+---
+
+# Plan: Vi Mode Word Motions and Operators
+
+**Issue:** #435 - high impact additions for vi mode
+**Related:** `.lore/plans/vi-mode-pair-writing.md`, `.lore/retros/vi-mode-pair-writing.md`
+
+## Context
+
+The vi mode v1 implementation explicitly deferred word motions (`w`, `b`, `e`) to keep scope focused. The `pendingOperator` state infrastructure already exists for `d`/`y` operators but currently only handles the double-press pattern (`dd`, `yy`). This work extends that pattern to support operator+motion combinations.
+
+## Approach
+
+Extend the existing `useViMode` hook with:
+1. Word boundary detection helpers
+2. Word motion commands (`w`, `b`)
+3. Operator+motion combinations (`dw`, `yw`, `db`, `yb`)
+4. `D` command (delete to end of line)
+
+The numeric prefix system already works, so `#w`, `#b`, `#dw`, `#yw` will work automatically once base commands are implemented.
+
+## Steps
+
+### 1. Add word boundary helpers
+
+Create two helper functions in `useViMode.ts`:
+
+```typescript
+function findNextWordStart(text: string, position: number): number
+function findPrevWordStart(text: string, position: number): number
+```
+
+Word definition (vim-like):
+- A "word" is a sequence of word characters (`[a-zA-Z0-9_]`) OR a sequence of non-whitespace punctuation
+- `w` moves to the start of the next word
+- `b` moves to the start of the previous word
+
+### 2. Add `w` and `b` to movement commands
+
+1. Add `"w"` and `"b"` to `MOVEMENT_KEYS` set
+2. Add cases in `executeMovementCommand` switch:
+   - `w`: call `findNextWordStart` count times
+   - `b`: call `findPrevWordStart` count times
+
+### 3. Add operator+motion handling
+
+Modify `handleNormalModeKey` to check if `pendingOperator` is set when a motion key is pressed:
+
+```typescript
+// Before executing regular movement
+if (pendingOperator && MOTION_KEYS.has(key) && textarea) {
+  e.preventDefault();
+  if (pendingOperator === "d") {
+    executeOperatorMotion("d", key, textarea, count, ...);
+  } else if (pendingOperator === "y") {
+    executeOperatorMotion("y", key, textarea, count, ...);
+  }
+  setPendingOperator(null);
+  clearPendingCount();
+  return;
+}
+```
+
+Create `executeOperatorMotion` that:
+- Calculates the motion range (from current position to where motion would land)
+- For `d`: deletes that range
+- For `y`: yanks that range to clipboard
+
+This enables: `dw`, `db`, `d$`, `d0`, `yw`, `yb`, `y$`, `y0`
+
+### 4. Add `D` command
+
+Add standalone `D` key handler (equivalent to `d$`):
+
+```typescript
+if (key === "D" && textarea) {
+  e.preventDefault();
+  clearPendingCount();
+  executeDeleteToEndOfLine(textarea, onContentChange, pushUndoState);
+  return;
+}
+```
+
+`D` deletes from cursor to end of line (does not delete the newline itself).
+
+### 5. Write tests
+
+Add test cases for:
+- `w` motion: forward word, across lines, at end of text, with count
+- `b` motion: backward word, across lines, at start of text, with count
+- `dw`: delete word, with count, at end of line
+- `yw`: yank word, paste verification
+- `db`, `yb`: backward variants
+- `d$`, `y$`: to end of line (enabled by operator+motion)
+- `D`: delete to end of line
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `frontend/src/hooks/useViMode.ts` | Add word helpers, extend movement switch, add operator+motion dispatch, add D command |
+| `frontend/src/hooks/__tests__/useViMode.test.ts` | Add test sections for word motions, operator+motion, D command |
+
+## Considerations
+
+**Word boundary definition:** Using vim's simplified model where a word is alphanumeric+underscore or punctuation sequence. Not implementing `W`/`B` (WORD motion using only whitespace boundaries) in this iteration.
+
+**Edge cases to handle:**
+- Cursor at end of text (motions should not error)
+- Empty lines (word motion should skip them)
+- Multiple spaces between words
+- Punctuation handling (e.g., `foo.bar` has 3 words: `foo`, `.`, `bar`)
+
+**Operator+motion with existing motions:** This automatically enables `d$` (delete to end of line), `d0` (delete to start of line), `dh`, `dl`, `dj`, `dk` and their yank equivalents. The operator+motion pattern is general.
+
+## AI Validation
+
+**Defaults:**
+- Unit tests with mocked textarea (no real DOM needed beyond createElement)
+- 90%+ coverage on new code paths
+- Code review by fresh-context sub-agent
+
+**Custom:**
+- Manual test in Pair Writing mode: type text, use `w`/`b` to navigate, `dw`/`yw` to edit
+- Verify numeric prefixes: `3w`, `2dw`, `5b` all work correctly
+- Verify `D` deletes to end of line without removing newline
+
+## Post-Execution Notes
+
+**Scope recovered during implementation:** `^` (first non-whitespace) and `J` (join lines) were discussed during issue review but missing from this plan. They were added during implementation. See `.lore/retros/vi-mode-word-motions.md` for lessons learned about plan-to-implementation drift.

--- a/.lore/retros/vi-mode-pair-writing.md
+++ b/.lore/retros/vi-mode-pair-writing.md
@@ -39,7 +39,7 @@ Added vi-style modal editing to Pair Writing mode. Implementation includes Norma
 
 1. **Visual components need visual testing**: Unit tests for cursor position calculation passed, but the actual cursor was invisible. For overlay/positioning code, add a manual test checkpoint before declaring the chunk complete.
 
-2. **Trace config changes end-to-end**: When adding a new config field, grep for all places the config object is constructed, copied, or merged. In this codebase: shared schema, backend config loading, frontend initialConfig props (multiple components), reducer cases, and post-save state updates.
+2. **Trace config changes end-to-end**: When adding a new config field, grep for all places the config object is constructed, copied, or merged. In this codebase: shared schema, backend config loading, frontend initialConfig props (multiple components), reducer cases, and post-save state updates. *(Graduated to project CLAUDE.md)*
 
 3. **Text wrapping breaks line math**: Any calculation involving "line N is at position Y pixels" needs to account for soft wrapping. Use the same measurement technique (mirror element) for both cursor rendering and scroll calculations.
 

--- a/.lore/retros/vi-mode-word-motions.md
+++ b/.lore/retros/vi-mode-word-motions.md
@@ -1,0 +1,50 @@
+---
+title: Plan-to-implementation drift in vi mode word motions
+date: 2026-01-31
+status: complete
+tags: [vi-mode, planning, scope-management, llm-limitations]
+modules: [use-vi-mode]
+related: [.lore/retros/vi-mode-pair-writing.md, .lore/plans/vi-mode-pair-writing.md]
+---
+
+# Retro: Vi Mode Word Motions (#435)
+
+## Summary
+
+Extended vi mode with word motions (`w`, `b`), operator+motion combinations (`dw`, `yw`, etc.), `D` command, `J` (join lines), and `^` (first non-whitespace). All commands support numeric prefixes and integrate with undo.
+
+## What Went Well
+
+- **Operator+motion pattern was general**: Building `executeOperatorMotion` enabled many commands beyond just `dw`/`yw`. The pattern automatically gave us `d$`, `d0`, `d^`, `y$`, `y0`, `y^` and existing motion combinations (`dh`, `dl`).
+
+- **Existing infrastructure held up**: The `pendingOperator` state and numeric prefix system from v1 worked exactly as expected. No refactoring needed to support the new patterns.
+
+- **Tests caught edge cases**: Word boundary detection across lines, empty lines, multiple spaces, punctuation boundaries. 250+ tests covering the combinations.
+
+- **Implementation recovered missing scope**: `^` and `J` were discussed during issue review but missing from the written plan. They were added during implementation anyway, showing the implementation process surfaced the gap.
+
+## What Could Improve
+
+- **Features discussed got lost before planning**: When reviewing issue #435 via compass-rose, we discussed `^` (first non-whitespace) and `J` (join lines) as high-impact additions. These didn't make it into the plan document (`encapsulated-crunching-metcalfe.md`). The PR shows they were implemented, so they were recovered during execution, but the plan was incomplete.
+
+- **Root cause unclear**: This could be:
+  1. Context window limits during plan generation (likely given plan was detailed)
+  2. Prioritization judgment (plan focused on word motions as the primary scope)
+  3. Transition friction between "discussion phase" and "planning phase"
+
+- **Plan document not versioned**: The plan file was a scratchpad document, not committed to the repo. No way to trace what was captured vs what was discussed.
+
+## Lessons Learned
+
+1. **LLMs can lose context between phases**: Transitioning from "brainstorm/discuss" to "write detailed plan" is a context switch. Information can be lost, especially with complex conversations. Explicit handoff artifacts (a feature list) reduce this risk.
+
+2. **Review plan against original discussion**: Before approving a plan, explicitly compare it against the issue and any discussion notes. "Does this plan cover everything we said we'd do?" *(Graduated to universal)*
+
+3. **Scratchpad plans should still be captured**: Even throwaway plan files should be snapshot somewhere (commit, paste into issue, whatever) so drift can be detected. *(Graduated to universal)*
+
+## Artifacts
+
+- Issue: #435
+- PR: #438
+- Plan: `.lore/plans/vi-mode-word-motions.md`
+- Prior retro: `.lore/retros/vi-mode-pair-writing.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,3 +157,7 @@ When making changes that affect user-facing behavior, update the relevant docs. 
 - Usage docs in `docs/usage/` when tab behavior changes
 - ADRs for significant architectural decisions
 - Reference docs in `.lore/reference/` when features are added or modified
+
+## Critical Lessons
+
+- Trace config changes end-to-end: When adding a new config field, grep for all places the config object is constructed, copied, or merged. In this codebase: shared schema, backend config loading, frontend initialConfig props (multiple components), reducer cases, and post-save state updates.


### PR DESCRIPTION
## Summary

- Add retrospective for vi mode word motions (#435) capturing plan-to-implementation drift
- File the word motions plan as a proper `.lore/` artifact with frontmatter
- Graduate lessons from both vi mode retros to appropriate scopes

## Graduated Lessons

**To project CLAUDE.md:**
- Config change tracing: grep for all places config objects are constructed/copied/merged

**To ~/.claude/rules/lessons-learned.md:**
- Review plan against original discussion before approval
- Scratchpad plans should still be captured for drift detection

## Test plan

- [x] Pre-commit hooks pass
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.ai/code)