### PR TITLE
fix: Correct AskUserQuestion dialog sizing

### DIFF
--- a/.lore/retros/ask-question-dialog-sizing.md
+++ b/.lore/retros/ask-question-dialog-sizing.md
@@ -1,0 +1,32 @@
+---
+title: Match dialog display area to page context
+date: 2026-02-02
+status: complete
+tags: [css, ui, responsive, dialog, communication]
+modules: [ask-user-question-dialog]
+---
+
+# Retro: AskUserQuestion Dialog Sizing Fix
+
+## Summary
+
+Fixed CSS sizing for AskUserQuestion dialog components. The modal dialog (`.ask-question`) was incorrectly changed to 800px max-width when it should have stayed at 560px. The minimized bar (`.ask-question--minimized`) needed to be 800px and centered on desktop.
+
+## What Went Well
+
+- Quick identification and fix once requirements were clarified
+- Mobile styling already looked correct, only desktop needed adjustment
+
+## What Could Improve
+
+- Original request was ambiguous ("the dialog" could mean either the modal or the minimized bar)
+- Should have asked clarifying questions before making the initial change
+
+## Lessons Learned
+
+- When working on UI components with multiple states (expanded/minimized), clarify which state needs modification
+- Match the display context: the minimized bar sits alongside the message area (800px), while the modal is a focused dialog (560px)
+
+## Artifacts
+
+None (quick fix, no prior spec/plan)

--- a/frontend/src/components/discussion/AskUserQuestionDialog.css
+++ b/frontend/src/components/discussion/AskUserQuestionDialog.css
@@ -28,7 +28,7 @@
 
 .ask-question {
   width: 100%;
-  max-width: 800px;
+  max-width: 560px;
   max-height: 85vh;
   display: flex;
   flex-direction: column;
@@ -299,8 +299,10 @@
 /* Minimized state - compact bar at bottom */
 .ask-question--minimized {
   position: fixed;
-  left: var(--spacing-md);
-  right: var(--spacing-md);
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - var(--spacing-md) * 2);
+  max-width: 800px;
   bottom: calc(var(--input-area-height, 80px) + var(--spacing-md));
   z-index: 200;
   display: flex;
@@ -344,8 +346,7 @@
 /* On mobile, position above the fixed input area */
 @media (max-width: 767px) {
   .ask-question--minimized {
-    left: var(--spacing-sm);
-    right: var(--spacing-sm);
+    width: calc(100% - var(--spacing-sm) * 2);
     bottom: calc(var(--input-area-height, 70px) + var(--spacing-sm));
   }
 }


### PR DESCRIPTION
## Summary

- Restore modal dialog (`.ask-question`) to 560px max-width for focused interaction
- Set minimized bar (`.ask-question--minimized`) to 800px max-width and centered on desktop to match message area width
- Mobile styling unchanged (already correct)

## Test plan

- [ ] Open AskUserQuestion dialog in modal state, verify 560px max-width
- [ ] Minimize dialog, verify 800px max-width and centered on desktop
- [ ] Check mobile view still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)