### PR TITLE
docs: Add daily prep retro and preserve plan

### DIFF
--- a/.lore/plans/daily-prep-system.md
+++ b/.lore/plans/daily-prep-system.md
@@ -1,0 +1,149 @@
+---
+title: Daily Prep System Implementation Plan
+date: 2026-02-02
+status: executed
+tags: [skill-development, ui-component, rest-api, ground-tab]
+modules: [daily-prep-manager, session-actions-card, home-view, daily-prep-skill]
+related: [.lore/specs/daily-prep.md]
+---
+
+# Daily Prep System Implementation Plan
+
+**Spec**: `.lore/specs/daily-prep.md` (approved)
+**Branch**: `feat/daily-prep`
+
+## Overview
+
+Bookend planning system: morning commitment + evening closure. Ground tab restructure with REST endpoint for prep status.
+
+## Phases
+
+### Phase 1: REST Endpoint
+
+**New files:**
+- `backend/src/daily-prep-manager.ts` - Read/parse prep files
+- `backend/src/routes/daily-prep.ts` - `GET /daily-prep/today` endpoint
+- `backend/src/__tests__/daily-prep-manager.test.ts`
+- `backend/src/__tests__/routes-daily-prep.test.ts`
+
+**Modify:**
+- `backend/src/routes/index.ts` - Register route
+
+**Endpoint response:**
+```typescript
+{ exists: boolean, commitment?: string[], energy?: string, calendar?: string }
+```
+
+**File path:** `{contentRoot}/{inboxPath}/daily-prep/YYYY-MM-DD.md`
+
+---
+
+### Phase 2: Ground Tab Restructure
+
+**New files:**
+- `frontend/src/components/home/VaultInfoCard.tsx` - Name + subtitle only
+- `frontend/src/components/home/SessionActionsCard.tsx` - Buttons + commitment
+- `frontend/src/components/home/SessionActionsCard.css`
+- Tests for both components
+
+**Modify:**
+- `frontend/src/hooks/useHome.ts` - Add `getDailyPrepStatus()`
+- `frontend/src/components/home/HomeView.tsx` - Use new cards
+- `frontend/src/components/home/HomeView.css` - Two-card layout
+
+**Layout:**
+- Mobile: Stacked (Vault Info on top, Session Actions below)
+- Tablet+: Side-by-side (Vault Info left, Session Actions right)
+
+**Button logic:**
+- No prep file → "Daily Prep" button
+- Prep exists → "Daily Debrief" button
+- Weekly/Monthly unchanged
+
+---
+
+### Phase 3: Daily Prep Skill
+
+**Directory structure:**
+```
+backend/src/skills/daily-prep/
+├── SKILL.md              # Core instructions (~1,500-2,000 words)
+├── README.md             # Developer overview
+└── references/
+    └── file-format.md    # Detailed YAML frontmatter spec
+```
+
+**SKILL.md requirements (per plugin-dev:skill-development):**
+
+1. **Frontmatter** - Third-person description with specific triggers:
+```yaml
+---
+name: Daily Prep
+description: This skill should be used when the user says "/daily-prep", "daily prep", "morning prep", "what should I focus on today", "plan my day", "start my day", or wants help deciding what to work on. Creates a morning commitment with energy/calendar context.
+version: 0.1.0
+---
+```
+
+2. **Writing style** - Imperative/infinitive form, NOT second person:
+   - ✅ "To begin morning prep, use AskUserQuestion for energy level"
+   - ❌ "You should ask the user about their energy level"
+
+3. **Progressive disclosure** - Keep SKILL.md lean:
+   - Core workflow in SKILL.md (~1,500-2,000 words)
+   - Detailed file format spec in `references/file-format.md`
+   - Reference vault-task-management skill for task queries
+
+4. **Morning flow sections:**
+   - Energy Check (AskUserQuestion: Sharp/Steady/Low)
+   - Calendar Shape (AskUserQuestion: Clear/Scattered/Heavy)
+   - Surfacing (reference vault-task-management, Grep recent captures)
+   - Dialogue (allow corrections)
+   - Commitment (1-3 items, suggest not enforce)
+   - Save (Write tool to {inboxPath}/daily-prep/YYYY-MM-DD.md)
+
+5. **Evening closure** - Document integration with /daily-debrief:
+   - Check for prep file existence
+   - Show commitment, collect assessments
+   - Update file with closure data
+
+**Validation checklist (from skill-development):**
+- [x] Frontmatter has name and description
+- [x] Description uses third person with trigger phrases
+- [x] Body uses imperative form, not second person
+- [x] SKILL.md is lean (<2,000 words)
+- [x] References file-format.md for detailed spec
+- [x] References vault-task-management skill
+
+---
+
+### Phase 4: Integration
+
+- End-to-end manual testing
+- Edge case handling (empty files, missing directories)
+- Documentation updates
+
+## Critical Files
+
+| Purpose | Path |
+|---------|------|
+| Route pattern | `backend/src/routes/home.ts` |
+| HomeView structure | `frontend/src/components/home/HomeView.tsx` |
+| Hook pattern | `frontend/src/hooks/useHome.ts` |
+| Skill reference | `backend/src/skills/vault-task-management/SKILL.md` |
+| Card pattern | `frontend/src/components/home/GoalsCard.tsx` |
+
+## Verification
+
+Run after each phase:
+```bash
+bun run test
+bun run typecheck
+bun run lint
+```
+
+Manual verification:
+1. Ground tab shows correct button based on prep file existence
+2. `/daily-prep` creates file with correct format
+3. `/daily-debrief` detects prep and offers closure
+4. Commitment summary displays on Ground tab
+5. Mobile layout stacks, desktop side-by-side

--- a/.lore/retros/daily-prep-system.md
+++ b/.lore/retros/daily-prep-system.md
@@ -1,0 +1,55 @@
+---
+title: Emergent requirements in daily prep implementation
+date: 2026-02-02
+status: complete
+tags: [skill-development, ui-component, iterative-design, lore-workflow]
+modules: [daily-prep-manager, session-actions-card, ask-user-question-dialog, home-view]
+related: [.lore/brainstorm/daily-prep-system.md, .lore/research/daily-planning-science.md, .lore/specs/daily-prep.md, .lore/plans/daily-prep-system.md]
+---
+
+# Retro: Daily Prep System (#443)
+
+## Summary
+
+Built a skill-based bookend planning system for morning commitment and evening reflection. Includes Ground tab restructure (VaultInfoCard + SessionActionsCard), REST endpoint for prep status, daily-prep skill with file format documentation, and an emergent AskUserQuestion minimize feature.
+
+## What Went Well
+
+- **Brainstorm → Research → Spec cycle worked**: The brainstorm captured the core insight ("evaluable contract with yourself"), research validated it with psychology literature (implementation intentions, Zeigarnik effect, commitment devices), and spec translated that into requirements. Each phase refined the previous one.
+
+- **Research prevented over-engineering**: The psychology research explicitly warned against over-planning ("1-3 items, not a detailed schedule"). This constraint made it into the spec and skill. Without the research phase, the skill might have tried to do too much.
+
+- **Skill-based architecture avoided custom UI**: Original brainstorm explored complex surfacing endpoints and filtering algorithms. The insight that "this is a Claude skill that uses AskUserQuestion" dramatically simplified the implementation. No custom React components for the flow itself.
+
+- **Spec was detailed enough for implementation**: Requirements were numbered, data models were explicit, exit points were defined. Implementation could proceed without ambiguity about what "done" meant.
+
+- **Emergent feature caught during use**: The AskUserQuestion minimize feature wasn't in the spec. It emerged when using the daily-prep skill: "wait, I need to see my previous messages to know what I'm committing to." The need was discovered during implementation, not planning.
+
+## What Could Improve
+
+- **Plan document was not in .lore/**: The plan was originally captured in `~/.claude/plans/` (Claude Code's native plan mode location), not committed to the repo. Moved to `.lore/plans/daily-prep-system.md` during this retro. This is the same issue identified in the vi-mode retro: scratchpad plans aren't visible for drift detection unless explicitly preserved.
+
+- **Brainstorm/research required refinement passes**: The commit message notes "required refinement." The initial brainstorm was more scattered, and research needed curation to extract actionable insights. This is normal for the process but worth noting: first drafts of lore documents aren't final.
+
+- **Spec status not updated**: The spec still shows `status: approved` but should be `implemented` now that the work is complete. Lore hygiene slipped.
+
+## Lessons Learned
+
+1. **Research phase prevents scope creep**: External validation (psychology literature) provided constraints ("1-3 items") that shaped the design. Without research, the implementation might have gold-plated features that users don't need.
+
+2. **Skill-first thinking simplifies architecture**: Asking "can this be a Claude skill using existing tools?" before designing custom endpoints/components reduces implementation complexity. The daily-prep skill uses AskUserQuestion, Grep, Read, Write (standard tools) instead of custom surfacing APIs.
+
+3. **Use during implementation surfaces requirements**: The AskUserQuestion minimize feature was discovered by actually using the daily-prep skill. Some requirements only become visible when you try to use what you built.
+
+4. **Lore documents need refinement**: First drafts of brainstorms and research are raw material. Expect to iterate. The value is in the refinement, not the first pass.
+
+5. **Update spec status after implementation**: When work completes, update the spec's frontmatter status from `approved` to `implemented`. This is part of the definition of done.
+
+## Artifacts
+
+- Issue/PR: #443
+- Plan: `.lore/plans/daily-prep-system.md`
+- Brainstorm: `.lore/brainstorm/daily-prep-system.md`
+- Research: `.lore/research/daily-planning-science.md`
+- Spec: `.lore/specs/daily-prep.md`
+- Skill: `backend/src/skills/daily-prep/SKILL.md`

--- a/.lore/specs/daily-prep.md
+++ b/.lore/specs/daily-prep.md
@@ -1,7 +1,7 @@
 ---
 title: Daily Prep System
 date: 2026-02-02
-status: approved
+status: implemented
 tags: [daily-planning, bookend, energy, commitment, ground-tab, skill]
 modules: [home-view, vault-info-card, session-actions-card, daily-prep-skill, daily-debrief-skill, routes-daily-prep]
 related: [.lore/brainstorm/daily-prep-system.md, .lore/research/daily-planning-science.md]


### PR DESCRIPTION
## Summary

- Adds retro for daily prep system (#443)
- Moves implementation plan from `~/.claude/plans/` to `.lore/plans/` for preservation
- Updates spec status from `approved` to `implemented`

## Key Findings from Retro

**What went well:**
- Brainstorm → research → spec cycle worked; each phase refined the previous
- Research prevented over-engineering by providing the "1-3 items" constraint
- Skill-first architecture avoided custom UI complexity
- AskUserQuestion minimize feature emerged during use (not planned)

**Lessons:**
- Research phase prevents scope creep via external validation
- Skill-first thinking simplifies architecture
- Use during implementation surfaces hidden requirements
- Lore documents need refinement passes

## Test plan

- [x] All checks pass (typecheck, lint, tests)
- [x] Retro follows existing format in `.lore/retros/`
- [x] Plan has proper frontmatter with status: executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)