### PR TITLE
Bump CI actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -28,7 +28,7 @@ jobs:
       - run: bun run build
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: rjroy/memory-loop


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v5
- Bump `codecov/codecov-action` from v4 to v5

Both v4 releases run on Node.js 20, which GitHub is deprecating with forced Node.js 24 default starting June 2, 2026.

## Test plan
- [ ] CI workflow runs successfully with the updated action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)