### PR TITLE
Add SSE auto-reconnect to survive connection drops

### DIFF
--- a/nextjs/hooks/__tests__/useChat.test.ts
+++ b/nextjs/hooks/__tests__/useChat.test.ts
@@ -181,7 +181,13 @@ describe("useChat", () => {
         expect(result.current.streamingState).toBe("idle");
       });
 
-      const postCall = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
+      // Find the POST /api/chat call (mount-reconnect may also call fetch for the stream)
+      const postCall = mockFetch.mock.calls.find(
+        (c) => {
+          const args = c as unknown as [string, RequestInit?];
+          return args[0] === "/api/chat" && args[1]?.method === "POST";
+        }
+      ) as unknown as [string, RequestInit];
       const body = JSON.parse(postCall[1].body as string) as Record<string, unknown>;
       expect(body.sessionId).toBe("sess_123");
       expect(body.vaultId).toBe("test-vault");
@@ -498,7 +504,10 @@ describe("useChat", () => {
         await result.current.resolvePermission("tool_123", true);
       });
 
-      const call = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
+      // Find the permission call (mount-reconnect may also call fetch for the stream)
+      const call = mockFetch.mock.calls.find(
+        (c) => (c as unknown as [string])[0].includes("/permission/")
+      ) as unknown as [string, RequestInit];
       expect(call[0]).toBe("/api/chat/sess_123/permission/tool_123");
       expect(call[1].method).toBe("POST");
       expect(JSON.parse(call[1].body as string) as Record<string, unknown>).toEqual({ allowed: true });
@@ -528,7 +537,10 @@ describe("useChat", () => {
         await result.current.resolveQuestion("tool_456", answers);
       });
 
-      const call = mockFetch.mock.calls[0] as unknown as [string, RequestInit];
+      // Find the answer call (mount-reconnect may also call fetch for the stream)
+      const call = mockFetch.mock.calls.find(
+        (c) => (c as unknown as [string])[0].includes("/answer/")
+      ) as unknown as [string, RequestInit];
       expect(call[0]).toBe("/api/chat/sess_123/answer/tool_456");
       expect(call[1].method).toBe("POST");
       expect(JSON.parse(call[1].body as string) as Record<string, unknown>).toEqual({ answers });
@@ -564,6 +576,195 @@ describe("useChat", () => {
 
       expect(result.current.lastError).toBeNull();
       expect(result.current.streamingState).toBe("idle");
+    });
+  });
+
+  describe("auto-reconnect", () => {
+    it("reconnects on mount when sessionId is present", async () => {
+      // Respond to the stream probe with a completed snapshot
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          createSSEResponse([
+            {
+              type: "snapshot",
+              sessionId: "existing_session",
+              isProcessing: false,
+              content: "Previous response",
+              toolInvocations: [],
+              pendingPrompts: [],
+            },
+          ])
+        )
+      );
+
+      const onEvent = mock(() => {});
+      const { result } = renderHook(() =>
+        useChat(testVault, "existing_session", { onEvent })
+      );
+
+      // Mount-reconnect should fire and deliver the snapshot
+      await waitFor(() => {
+        expect(onEvent).toHaveBeenCalled();
+      });
+
+      const snapshotCall = onEvent.mock.calls.find(
+        (c) => (c[0] as { type: string }).type === "snapshot"
+      );
+      expect(snapshotCall).toBeDefined();
+      expect((snapshotCall![0] as { content: string }).content).toBe("Previous response");
+
+      // Should settle to idle after non-processing snapshot
+      await waitFor(() => {
+        expect(result.current.streamingState).toBe("idle");
+      });
+    });
+
+    it("does not reconnect on mount without sessionId", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(new Response(JSON.stringify({})))
+      );
+
+      renderHook(() => useChat(testVault, null));
+
+      // No fetch should have been made (no session to reconnect to)
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("schedules reconnect on unexpected stream drop", async () => {
+      // Track which stream calls have happened
+      let streamCallCount = 0;
+      mockFetch.mockImplementation((...args: unknown[]) => {
+        const url = args[0] as string;
+
+        if (url.endsWith("/chat")) {
+          return Promise.resolve(createPostResponse("sess_reconnect"));
+        }
+
+        if (url.endsWith("/chat/stream")) {
+          streamCallCount++;
+          if (streamCallCount <= 1) {
+            // First stream: error after snapshot
+            return Promise.resolve(
+              new Response(
+                new ReadableStream({
+                  start(controller) {
+                    const snapshot = `data: ${JSON.stringify({
+                      type: "snapshot",
+                      sessionId: "sess_reconnect",
+                      isProcessing: true,
+                      content: "partial",
+                      toolInvocations: [],
+                      pendingPrompts: [],
+                    })}\n\n`;
+                    controller.enqueue(new TextEncoder().encode(snapshot));
+                    // Simulate connection drop
+                    controller.error(new Error("Connection reset"));
+                  },
+                }),
+                { headers: { "Content-Type": "text/event-stream" } }
+              )
+            );
+          }
+          // Reconnect stream: delivers completed response
+          return Promise.resolve(
+            createSSEResponse([
+              {
+                type: "snapshot",
+                sessionId: "sess_reconnect",
+                isProcessing: false,
+                content: "complete response",
+                toolInvocations: [],
+                pendingPrompts: [],
+              },
+            ])
+          );
+        }
+
+        return Promise.resolve(new Response(JSON.stringify({})));
+      });
+
+      const onEvent = mock(() => {});
+      const { result } = renderHook(() =>
+        useChat(testVault, null, { onEvent })
+      );
+
+      await act(async () => {
+        await result.current.sendMessage("Hello");
+      });
+
+      // Wait for the first stream to error and schedule reconnect
+      await waitFor(() => {
+        expect(streamCallCount).toBeGreaterThanOrEqual(1);
+      });
+
+      // Advance past the 1s reconnect backoff
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 1200));
+      });
+
+      // Wait for reconnect stream to complete
+      await waitFor(
+        () => {
+          expect(result.current.streamingState).toBe("idle");
+        },
+        { timeout: 3000 }
+      );
+
+      // The reconnect should have triggered a second stream call
+      expect(streamCallCount).toBeGreaterThanOrEqual(2);
+    });
+
+    it("does not reconnect after user abort", async () => {
+      mockFetch.mockImplementation((...args: unknown[]) => {
+        const url = args[0] as string;
+
+        if (url.endsWith("/chat")) {
+          return Promise.resolve(createPostResponse("sess_abort"));
+        }
+
+        if (url.includes("/abort")) {
+          return Promise.resolve(new Response(JSON.stringify({ ok: true })));
+        }
+
+        if (url.endsWith("/chat/stream")) {
+          // Slow stream that gives us time to abort
+          return Promise.resolve(
+            createSSEResponse([
+              {
+                type: "snapshot",
+                sessionId: "sess_abort",
+                isProcessing: true,
+                content: "",
+                toolInvocations: [],
+                pendingPrompts: [],
+              },
+            ])
+          );
+        }
+
+        return Promise.resolve(new Response(JSON.stringify({})));
+      });
+
+      const { result } = renderHook(() => useChat(testVault, null));
+
+      await act(async () => {
+        await result.current.sendMessage("Hello");
+      });
+
+      // Abort before stream completes
+      await act(async () => {
+        await result.current.abort();
+      });
+
+      expect(result.current.streamingState).toBe("idle");
+
+      // Wait a bit to verify no reconnect attempt
+      await new Promise((r) => setTimeout(r, 100));
+      const streamCalls = mockFetch.mock.calls.filter(
+        (c) => (c as unknown as [string])[0].endsWith("/chat/stream")
+      );
+      // Should only have 1 stream call (no reconnect after abort)
+      expect(streamCalls.length).toBe(1);
     });
   });
 });

--- a/nextjs/hooks/useChat.ts
+++ b/nextjs/hooks/useChat.ts
@@ -16,7 +16,8 @@
  * - Stream responses via SSE (separate GET endpoint)
  * - Resolve tool permissions and questions mid-stream
  * - Abort in-flight requests
- * - Reconnect to active stream on mount (via snapshot)
+ * - Auto-reconnect on SSE drop with exponential backoff
+ * - Reconnect to active/completed sessions on mount
  */
 
 import { useState, useCallback, useRef, useEffect } from "react";
@@ -140,6 +141,10 @@ export function useChat(
 
   // Refs for cleanup and stable callback references
   const abortControllerRef = useRef<AbortController | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const retryCountRef = useRef(0);
+  const userAbortedRef = useRef(false);
+  const mountReconnectedRef = useRef(false);
   const onEventRef = useRef(onEvent);
   const onStreamStartRef = useRef(onStreamStart);
   const onStreamEndRef = useRef(onStreamEnd);
@@ -216,12 +221,53 @@ export function useChat(
     onEventRef.current?.(event as unknown as ServerMessage);
   }
 
+  /** Max reconnect attempts before giving up */
+  const MAX_RETRIES = 5;
+
+  /**
+   * Cancels any pending reconnect timer.
+   */
+  function cancelReconnect(): void {
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }
+
+  /**
+   * Schedules a reconnect attempt with exponential backoff.
+   * Backoff: 1s, 2s, 4s, 8s, 16s (capped at MAX_RETRIES).
+   */
+  function scheduleReconnect(): void {
+    if (userAbortedRef.current) return;
+    if (retryCountRef.current >= MAX_RETRIES) {
+      log.warn(`Max reconnect attempts (${MAX_RETRIES}) reached, giving up`);
+      setStreamingState("error");
+      setLastError("Connection lost. Refresh to retry.");
+      onStreamEndRef.current?.();
+      return;
+    }
+
+    const delay = Math.min(1000 * Math.pow(2, retryCountRef.current), 16_000);
+    retryCountRef.current += 1;
+    log.info(`Reconnecting in ${delay}ms (attempt ${retryCountRef.current}/${MAX_RETRIES})`);
+
+    reconnectTimerRef.current = setTimeout(() => {
+      reconnectTimerRef.current = null;
+      connectToStream();
+    }, delay);
+  }
+
   /**
    * Connects to GET /api/chat/stream and reads SSE events.
    *
    * The stream starts with a snapshot event containing current state,
    * then sends live events while processing continues. Callable from
-   * sendMessage (after the POST) or from a reconnection effect.
+   * sendMessage (after the POST), from a reconnection timer, or from
+   * a mount effect to recover in-progress/completed sessions.
+   *
+   * On unexpected disconnection, automatically schedules a reconnect.
+   * The daemon's snapshot mechanism restores full state on each connect.
    *
    * This is fire-and-forget: it launches an async reader internally.
    * The AbortController in abortControllerRef controls its lifecycle.
@@ -239,6 +285,10 @@ export function useChat(
 
     // Fire-and-forget async reader
     void (async () => {
+      // Track whether this connection received any events (to distinguish
+      // "connected then dropped" from "couldn't connect at all")
+      let receivedSnapshot = false;
+
       try {
         const response = await fetch(`${apiBase}/chat/stream`, {
           signal: controller.signal,
@@ -266,6 +316,7 @@ export function useChat(
             if (!part.trim()) continue;
             const events = parseSSE(part);
             for (const event of events) {
+              if (event.type === "snapshot") receivedSnapshot = true;
               handleStreamEvent(event);
             }
           }
@@ -275,10 +326,13 @@ export function useChat(
         if (buffer.trim()) {
           const events = parseSSE(buffer);
           for (const event of events) {
+            if (event.type === "snapshot") receivedSnapshot = true;
             handleStreamEvent(event);
           }
         }
 
+        // Clean exit (stream closed normally after terminal event)
+        retryCountRef.current = 0;
         setStreamingState("idle");
         onStreamEndRef.current?.();
       } catch (err) {
@@ -287,11 +341,20 @@ export function useChat(
           onStreamEndRef.current?.();
           return;
         }
+
+        // Connection dropped unexpectedly. If we received a snapshot,
+        // the daemon is still processing. Reconnect to pick up where we left off.
         const error = err instanceof Error ? err.message : "Stream connection failed";
-        setLastError(error);
-        setStreamingState("error");
-        onErrorRef.current?.(error);
-        onStreamEndRef.current?.();
+        log.warn(`Stream connection lost: ${error} (hadSnapshot=${receivedSnapshot})`);
+
+        if (!userAbortedRef.current) {
+          scheduleReconnect();
+        } else {
+          setLastError(error);
+          setStreamingState("error");
+          onErrorRef.current?.(error);
+          onStreamEndRef.current?.();
+        }
       } finally {
         if (abortControllerRef.current === controller) {
           abortControllerRef.current = null;
@@ -316,6 +379,10 @@ export function useChat(
 
       setStreamingState("starting");
       setLastError(null);
+      retryCountRef.current = 0;
+      userAbortedRef.current = false;
+      mountReconnectedRef.current = true; // suppress mount-reconnect after sendMessage
+      cancelReconnect();
       onStreamStartRef.current?.();
 
       const currentSessionId = sessionIdRef.current;
@@ -373,6 +440,9 @@ export function useChat(
    * emit terminal events, then closes the SSE connection as cleanup.
    */
   const abort = useCallback(async (): Promise<void> => {
+    userAbortedRef.current = true;
+    cancelReconnect();
+
     // Notify server to abort (best-effort, before closing stream)
     const currentSessionId = sessionIdRef.current;
     if (currentSessionId) {
@@ -467,6 +537,7 @@ export function useChat(
 
     setLastError(null);
     setStreamingState("idle");
+    cancelReconnect();
 
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
@@ -474,9 +545,24 @@ export function useChat(
     }
   }, [vault?.id]);
 
+  // Reconnect on mount when there's an existing session.
+  // Probes the stream endpoint to recover in-progress or just-completed responses.
+  // The snapshot gives us full state regardless of whether the daemon is still
+  // processing or finished while we were away.
+  useEffect(() => {
+    if (mountReconnectedRef.current) return;
+    if (!sessionId || !vault) return;
+    if (abortControllerRef.current) return; // already connected
+
+    mountReconnectedRef.current = true;
+    log.info(`Mount reconnect: probing stream for session ${sessionId}`);
+    connectToStream();
+  }, [sessionId, vault]);
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      cancelReconnect();
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
       }


### PR DESCRIPTION
## Summary
- Adds exponential backoff reconnect (1s-16s, 5 attempts) to `useChat` when SSE stream drops unexpectedly (ECONNRESET)
- Adds mount-reconnect: returning to a session with an existing `sessionId` probes the stream to recover in-progress or completed responses
- Enables fire-and-forget usage: send a message, close the app, come back for the answer

## Test plan
- [x] Existing tests updated and passing (2035 total)
- [x] New tests: mount recovery, no-reconnect without session, reconnect on stream drop, no-reconnect after user abort
- [x] Typecheck, lint, build all pass
- [ ] Manual: send a message, kill the browser tab mid-stream, reopen and verify response appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)