### PR TITLE
Add configurable discussion model registry

### DIFF
--- a/.lore/reference/_infrastructure/configuration.md
+++ b/.lore/reference/_infrastructure/configuration.md
@@ -44,7 +44,7 @@ Configuration manages per-vault settings via `.memory-loop.json`. Each vault can
 
 | Field | Type | Default | Purpose |
 |-------|------|---------|---------|
-| `discussionModel` | "opus" \| "sonnet" \| "haiku" | "opus" | Model for conversations |
+| `discussionModel` | string (key from global model registry) | undefined (uses pi-agent fallback) | Model for conversations |
 
 ### Inspiration
 
@@ -166,7 +166,7 @@ Zod schema enforces:
 - `recentDiscussions`: int, 1-20
 - `badges`: array max 5, text max 20 chars
 - `order`: int, min 1
-- `discussionModel`: enum ["opus", "sonnet", "haiku"]
+- `discussionModel`: any string; validation against registry happens at session creation.
 
 Invalid values return 400 error with message displayed inline in dialog.
 
@@ -191,6 +191,25 @@ This means `VaultInfo` always has resolved values; the frontend doesn't need to 
 | [Ground](../home-dashboard.md) | recentCaptures, recentDiscussions |
 | [Spaced Repetition](../spaced-repetition.md) | cardsEnabled |
 | [Think](../think.md) | discussionModel |
+
+## Global Config File
+
+A daemon-level config file defines the model registry available across all vaults.
+
+**Path**: `MEMORY_LOOP_CONFIG` env var overrides, otherwise `${VAULTS_DIR}/memory-loop-config.json`
+
+**Format**:
+```json
+{
+  "models": {
+    "<name>": { "provider": "...", "modelId": "..." }
+  }
+}
+```
+
+**Endpoint**: `GET /api/models` returns `{ "models": [{ "name": "...", "provider": "...", "modelId": "..." }] }`
+
+**Behavior when absent or malformed**: daemon logs a warning, continues with empty registry. `GET /api/models` returns `{ "models": [] }`.
 
 ## Notes
 

--- a/.lore/reference/think.md
+++ b/.lore/reference/think.md
@@ -183,8 +183,9 @@ Claude can ask structured questions:
 ## Model Selection
 
 **Config**: `.memory-loop.json` → `discussionModel`
-**Options**: `"opus"` | `"sonnet"` | `"haiku"`
-**Default**: `"opus"`
+**Options**: any key defined in the global model registry (see Global Config)
+**Default**: none — unset vaults fall back to the pi-agent default
+**Resolution**: at session creation, the daemon looks up the vault's `discussionModel` string in the runtime registry. Unknown names log a warning and fall back to pi-agent default.
 
 Passed to Claude SDK when creating session.
 

--- a/.lore/work/notes/configurable-discussion-models.html
+++ b/.lore/work/notes/configurable-discussion-models.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Notes: configurable discussion model registry</title>
+  <meta name="date" content="2026-05-21">
+  <meta name="status" content="complete">
+  <meta name="tags" content="notes, model-config, global-config, discussion, pi-agent">
+  <meta name="modules" content="session-manager, daemon-config, vault-config, config-editor-dialog">
+  <meta name="related" content=".lore/work/plans/configurable-discussion-models.html, .lore/work/specs/configurable-discussion-models.html">
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 15px;
+      line-height: 1.6;
+      color: #1a1a1a;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 5rem;
+    }
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    h2 { font-size: 1.1rem; margin-top: 2rem; border-bottom: 1px solid #ddd; padding-bottom: 0.3rem; }
+
+    .banner {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      padding: 1rem 1.25rem;
+      border-radius: 8px;
+      margin: 1.5rem 0;
+      font-size: 0.9rem;
+    }
+    .banner.in-progress { background: #eff6ff; border: 2px solid #3b82f6; }
+    .banner.complete { background: #f0fdf4; border: 2px solid #22c55e; }
+    .banner.failed { background: #fef2f2; border: 2px solid #ef4444; }
+    .banner-state {
+      font-weight: 700;
+      font-size: 1rem;
+      white-space: nowrap;
+    }
+
+    .phase-list { list-style: none; padding: 0; margin: 1rem 0; }
+    .phase-item {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid #e5e7eb;
+      border-radius: 6px;
+      margin: 0.4rem 0;
+      cursor: pointer;
+      user-select: none;
+    }
+    .phase-item:hover { background: #f9fafb; }
+    .chip {
+      display: inline-block;
+      padding: 2px 10px;
+      border-radius: 12px;
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      white-space: nowrap;
+    }
+    .chip-pending  { background: #f3f4f6; color: #6b7280; }
+    .chip-progress { background: #dbeafe; color: #1d4ed8; }
+    .chip-done     { background: #d1fae5; color: #065f46; }
+    .chip-failed   { background: #fee2e2; color: #991b1b; }
+
+    .phase-label { flex: 1; font-size: 0.9rem; }
+
+    .log-panel {
+      display: none;
+      background: #f8fafc;
+      border: 1px solid #e5e7eb;
+      border-top: none;
+      padding: 0.75rem 1rem;
+      font-size: 0.85rem;
+      color: #374151;
+      border-radius: 0 0 6px 6px;
+      margin-top: -4px;
+    }
+    .log-panel.open { display: block; }
+    .log-panel p { margin: 0.35rem 0; }
+    .log-panel code { background: #e5e7eb; padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; }
+    .log-panel ul { padding-left: 1.2rem; margin: 0.35rem 0; }
+    .log-panel li { margin: 0.2rem 0; }
+
+    .empty { color: #9ca3af; font-style: italic; font-size: 0.85rem; }
+  </style>
+</head>
+<body>
+
+<h1>Notes: configurable discussion model registry</h1>
+<p style="color:#888;font-size:0.85rem;">Plan: <a href="../plans/configurable-discussion-models.html">configurable-discussion-models.html</a></p>
+
+<div class="banner complete" id="banner">
+  <div class="banner-state">COMPLETE</div>
+  <div>All 6 phases done. 2042 tests pass, 0 failures. Typecheck and lint clean. No non-conformances against spec.</div>
+</div>
+
+<h2>Phase Progress</h2>
+
+<ul class="phase-list">
+  <li>
+    <div class="phase-item" onclick="toggle('log-1')">
+      <span class="chip chip-done" id="chip-1">done</span>
+      <span class="phase-label">Phase 1 — Create <code>global-config.ts</code> + tests</span>
+    </div>
+    <div class="log-panel" id="log-1">
+      <p>✓ Created <code>daemon/src/global-config.ts</code> — registry with loadGlobalConfig, getRegistry, configureRegistryForTesting, _resetRegistryForTesting.</p>
+      <p>✓ Created <code>daemon/src/__tests__/global-config.test.ts</code> — 5/5 tests pass.</p>
+      <p>✓ Typecheck clean.</p>
+    </div>
+  </li>
+  <li>
+    <div class="phase-item" onclick="toggle('log-2')">
+      <span class="chip chip-done" id="chip-2">done</span>
+      <span class="phase-label">Phase 2 — Daemon startup wiring + <code>GET /models</code> route</span>
+    </div>
+    <div class="log-panel" id="log-2">
+      <p>✓ Wired <code>await loadGlobalConfig()</code> after <code>initVaultCache()</code> in <code>daemon/src/index.ts</code>.</p>
+      <p>✓ Created <code>daemon/src/routes/models.ts</code> with <code>getModelsHandler</code>.</p>
+      <p>✓ Registered <code>GET /models</code> in <code>daemon/src/router.ts</code>.</p>
+      <p>✓ Created <code>daemon/src/routes/__tests__/models.test.ts</code> — 2/2 tests pass.</p>
+      <p>✓ Typecheck clean.</p>
+    </div>
+  </li>
+  <li>
+    <div class="phase-item" onclick="toggle('log-3')">
+      <span class="chip chip-done" id="chip-3">done</span>
+      <span class="phase-label">Phase 3 — Shared type purge (atomic breaking change)</span>
+    </div>
+    <div class="log-panel" id="log-3">
+      <p>✓ Removed VALID_DISCUSSION_MODELS, DiscussionModelLocal, DEFAULT_DISCUSSION_MODEL, resolveDiscussionModel() from packages/shared/src/vault-config.ts.</p>
+      <p>✓ Removed their exports from packages/shared/src/index.ts.</p>
+      <p>✓ Removed DiscussionModelSchema, DiscussionModel from packages/shared/src/schemas/protocol.ts; updated both fields to z.string().optional().</p>
+      <p>✓ Cascading: removed re-exports from packages/shared/src/schemas/index.ts; updated VaultInfo.discussionModel type in schemas/types.ts.</p>
+      <p>✓ Simplified vault-config.ts enum guard to plain string check; updated vault-manager.ts to pass config.discussionModel directly.</p>
+      <p>✓ Rewrote resolveModelForPiAgent() in session-manager.ts to use getRegistry() lookup; removed DISCUSSION_MODEL_MAP.</p>
+      <p>✓ Cascading: Phase 3 agent also fixed vault-config.test.ts (removed deleted imports, updated discussionModel tests) and fixed ConfigEditorDialog.tsx local type.</p>
+      <p>✓ Typecheck clean. grep shows zero matches for all removed symbols.</p>
+    </div>
+  </li>
+  <li>
+    <div class="phase-item" onclick="toggle('log-4')">
+      <span class="chip chip-done" id="chip-4">done</span>
+      <span class="phase-label">Phase 4 — Next.js layer (proxy route, daemon client, frontend)</span>
+    </div>
+    <div class="log-panel" id="log-4">
+      <p>✓ Created nextjs/app/api/models/route.ts — proxy to daemon /models.</p>
+      <p>✓ Created nextjs/lib/daemon/models.ts — ModelEntry interface + getModels().</p>
+      <p>✓ Updated nextjs/lib/daemon/index.ts barrel export.</p>
+      <p>✓ Updated ConfigEditorDialog.tsx: added availableModels state + useEffect fetch, dynamic select with unknown-model handling.</p>
+      <p>✓ Typecheck clean.</p>
+    </div>
+  </li>
+  <li>
+    <div class="phase-item" onclick="toggle('log-5')">
+      <span class="chip chip-done" id="chip-5">done</span>
+      <span class="phase-label">Phase 5 — Update existing tests</span>
+    </div>
+    <div class="log-panel" id="log-5">
+      <p>✓ session-manager.test.ts: added registry imports + _resetRegistryForTesting to afterEach; injected haiku registry for "uses vault config model" test; updated "no discussionModel" assertion to toBeUndefined().</p>
+      <p>✓ ConfigEditorDialog.test.tsx: added global fetch mock (opus/sonnet/haiku); updated assertions from descriptive labels to plain name keys; added waitFor for async useEffect; added unknown-model test.</p>
+      <p>✓ vault-config.test.ts already done by Phase 3 agent.</p>
+      <p>✓ Full suite: 2042 tests, 0 failures.</p>
+    </div>
+  </li>
+  <li>
+    <div class="phase-item" onclick="toggle('log-6')">
+      <span class="chip chip-done" id="chip-6">done</span>
+      <span class="phase-label">Phase 6 — Documentation updates</span>
+    </div>
+    <div class="log-panel" id="log-6">
+      <p>✓ configuration.md: updated discussionModel type/default, updated validation note, added Global Config File section.</p>
+      <p>✓ think.md: updated Model Selection section to reference registry instead of hardcoded enum.</p>
+      <p>✓ Typecheck clean.</p>
+    </div>
+  </li>
+</ul>
+
+<h2>Decisions &amp; Divergences</h2>
+<ul>
+  <li>Pre-existing change to <code>session-manager.ts</code>: DISCUSSION_MODEL_MAP had model IDs updated (claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-6) and two fallback entries added (basic, text). Phase 3 removes DISCUSSION_MODEL_MAP entirely, so these changes are subsumed.</li>
+</ul>
+
+<script>
+  function toggle(id) {
+    const panel = document.getElementById(id);
+    panel.classList.toggle('open');
+  }
+</script>
+</body>
+</html>

--- a/.lore/work/notes/simplify-configurable-discussion-models.html
+++ b/.lore/work/notes/simplify-configurable-discussion-models.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Simplify: configurable discussion model registry</title>
+  <meta name="date" content="2026-05-21">
+  <meta name="status" content="complete">
+  <meta name="tags" content="simplify, model-config, global-config, discussion">
+  <meta name="modules" content="session-manager, daemon-config, vault-config, config-editor-dialog">
+  <meta name="related" content=".lore/work/notes/configurable-discussion-models.html">
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 15px; line-height: 1.6; color: #1a1a1a;
+      max-width: 900px; margin: 0 auto; padding: 2rem 1.5rem 5rem;
+    }
+    h1 { font-size: 1.4rem; margin-bottom: 0.25rem; }
+    h2 { font-size: 1.05rem; margin-top: 1.8rem; border-bottom: 1px solid #ddd; padding-bottom: 0.25rem; }
+
+    .banner {
+      display: flex; align-items: center; gap: 1rem;
+      padding: 0.85rem 1.1rem; border-radius: 7px; margin: 1.25rem 0; font-size: 0.9rem;
+    }
+    .banner.in-progress { background: #eff6ff; border: 2px solid #3b82f6; }
+    .banner.complete    { background: #f0fdf4; border: 2px solid #22c55e; }
+    .banner-state { font-weight: 700; font-size: 0.95rem; white-space: nowrap; }
+
+    .file-list { list-style: none; padding: 0; margin: 0.75rem 0; }
+    .file-row {
+      display: flex; align-items: center; gap: 0.6rem;
+      padding: 0.4rem 0.7rem; border: 1px solid #e5e7eb; border-radius: 5px;
+      margin: 0.3rem 0; cursor: pointer; user-select: none; font-size: 0.88rem;
+    }
+    .file-row:hover { background: #f9fafb; }
+    .file-name { flex: 1; font-family: monospace; font-size: 0.82rem; }
+
+    .chip {
+      display: inline-block; padding: 1px 9px; border-radius: 10px;
+      font-size: 0.69rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; white-space: nowrap;
+    }
+    .chip-pending    { background: #f3f4f6; color: #6b7280; }
+    .chip-simplified { background: #d1fae5; color: #065f46; }
+    .chip-unchanged  { background: #f0f9ff; color: #0369a1; }
+    .chip-failed     { background: #fee2e2; color: #991b1b; }
+    .chip-running    { background: #dbeafe; color: #1d4ed8; }
+
+    .detail {
+      display: none; background: #f8fafc; border: 1px solid #e5e7eb; border-top: none;
+      padding: 0.6rem 0.9rem; font-size: 0.83rem; color: #374151;
+      border-radius: 0 0 5px 5px; margin-top: -3px;
+    }
+    .detail.open { display: block; }
+    .detail p { margin: 0.25rem 0; }
+
+    .escalation { background: #fef2f2; border: 2px solid #ef4444; border-radius: 6px; padding: 0.8rem 1rem; margin: 1rem 0; font-size: 0.88rem; }
+  </style>
+</head>
+<body>
+
+<h1>Simplify: configurable discussion model registry</h1>
+
+<div class="banner in-progress" id="banner">
+  <div class="banner-state">IN PROGRESS</div>
+  <div>Cleanup pass on all 23 changed files from the implementation. Three parallel simplifier groups, then test and review.</div>
+</div>
+
+<h2>Group A — Daemon core (7 files)</h2>
+<ul class="file-list">
+  <li><div class="file-row" onclick="toggle('d-global-config')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/global-config.ts</span></div><div class="detail" id="d-global-config"></div></li>
+  <li><div class="file-row" onclick="toggle('d-index')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/index.ts</span></div><div class="detail" id="d-index"></div></li>
+  <li><div class="file-row" onclick="toggle('d-router')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/router.ts</span></div><div class="detail" id="d-router"></div></li>
+  <li><div class="file-row" onclick="toggle('d-session-manager')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/session-manager.ts</span></div><div class="detail" id="d-session-manager"></div></li>
+  <li><div class="file-row" onclick="toggle('d-routes-models')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/routes/models.ts</span></div><div class="detail" id="d-routes-models"></div></li>
+  <li><div class="file-row" onclick="toggle('d-vault-config')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/vault/vault-config.ts</span></div><div class="detail" id="d-vault-config"></div></li>
+  <li><div class="file-row" onclick="toggle('d-vault-manager')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/vault/vault-manager.ts</span></div><div class="detail" id="d-vault-manager"></div></li>
+</ul>
+
+<h2>Group B — Daemon tests (4 files)</h2>
+<ul class="file-list">
+  <li><div class="file-row" onclick="toggle('t-global-config')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/__tests__/global-config.test.ts</span></div><div class="detail" id="t-global-config"></div></li>
+  <li><div class="file-row" onclick="toggle('t-session-manager')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/__tests__/session-manager.test.ts</span></div><div class="detail" id="t-session-manager"></div></li>
+  <li><div class="file-row" onclick="toggle('t-vault-config')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/vault/__tests__/vault-config.test.ts</span></div><div class="detail" id="t-vault-config"></div></li>
+  <li><div class="file-row" onclick="toggle('t-models-route')"><span class="chip chip-running">running</span><span class="file-name">daemon/src/routes/__tests__/models.test.ts</span></div><div class="detail" id="t-models-route"></div></li>
+</ul>
+
+<h2>Group C — Shared + Next.js (12 files)</h2>
+<ul class="file-list">
+  <li><div class="file-row" onclick="toggle('s-shared-index')"><span class="chip chip-running">running</span><span class="file-name">packages/shared/src/index.ts</span></div><div class="detail" id="s-shared-index"></div></li>
+  <li><div class="file-row" onclick="toggle('s-schemas-index')"><span class="chip chip-running">running</span><span class="file-name">packages/shared/src/schemas/index.ts</span></div><div class="detail" id="s-schemas-index"></div></li>
+  <li><div class="file-row" onclick="toggle('s-protocol')"><span class="chip chip-running">running</span><span class="file-name">packages/shared/src/schemas/protocol.ts</span></div><div class="detail" id="s-protocol"></div></li>
+  <li><div class="file-row" onclick="toggle('s-types')"><span class="chip chip-running">running</span><span class="file-name">packages/shared/src/schemas/types.ts</span></div><div class="detail" id="s-types"></div></li>
+  <li><div class="file-row" onclick="toggle('s-vault-config')"><span class="chip chip-running">running</span><span class="file-name">packages/shared/src/vault-config.ts</span></div><div class="detail" id="s-vault-config"></div></li>
+  <li><div class="file-row" onclick="toggle('n-config-editor')"><span class="chip chip-running">running</span><span class="file-name">nextjs/components/vault/ConfigEditorDialog.tsx</span></div><div class="detail" id="n-config-editor"></div></li>
+  <li><div class="file-row" onclick="toggle('n-config-editor-test')"><span class="chip chip-running">running</span><span class="file-name">nextjs/components/vault/__tests__/ConfigEditorDialog.test.tsx</span></div><div class="detail" id="n-config-editor-test"></div></li>
+  <li><div class="file-row" onclick="toggle('n-daemon-index')"><span class="chip chip-running">running</span><span class="file-name">nextjs/lib/daemon/index.ts</span></div><div class="detail" id="n-daemon-index"></div></li>
+  <li><div class="file-row" onclick="toggle('n-daemon-models')"><span class="chip chip-running">running</span><span class="file-name">nextjs/lib/daemon/models.ts</span></div><div class="detail" id="n-daemon-models"></div></li>
+  <li><div class="file-row" onclick="toggle('n-api-models')"><span class="chip chip-running">running</span><span class="file-name">nextjs/app/api/models/route.ts</span></div><div class="detail" id="n-api-models"></div></li>
+</ul>
+
+<h2>Test &amp; Review</h2>
+<ul class="file-list">
+  <li><div class="file-row"><span class="chip chip-pending">pending</span><span class="file-name">bun run test (full suite)</span></div></li>
+  <li><div class="file-row"><span class="chip chip-pending">pending</span><span class="file-name">code review — behavior preservation check</span></div></li>
+</ul>
+
+<script>
+  function toggle(id) {
+    document.getElementById(id).classList.toggle('open');
+  }
+</script>
+</body>
+</html>

--- a/.lore/work/plans/configurable-discussion-models.html
+++ b/.lore/work/plans/configurable-discussion-models.html
@@ -1,0 +1,1130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Implementation plan: configurable discussion model registry</title>
+  <meta name="date" content="2026-05-21">
+  <meta name="status" content="draft">
+  <meta name="tags" content="plan, model-config, global-config, discussion, pi-agent">
+  <meta name="modules" content="session-manager, daemon-config, vault-config, config-editor-dialog">
+  <meta name="related" content=".lore/work/specs/configurable-discussion-models.html">
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 15px;
+      line-height: 1.6;
+      color: #1a1a1a;
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 5rem;
+    }
+
+    h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+    h2 { font-size: 1.15rem; margin-top: 2.5rem; border-bottom: 1px solid #ddd; padding-bottom: 0.3rem; }
+    h3 { font-size: 0.95rem; margin-top: 1.2rem; margin-bottom: 0.4rem; }
+
+    .spec-link {
+      display: inline-block;
+      font-size: 0.82rem;
+      color: #555;
+      margin-bottom: 1.5rem;
+      background: #f1f5f9;
+      padding: 3px 10px;
+      border-radius: 3px;
+      text-decoration: none;
+    }
+    .spec-link:hover { background: #e2e8f0; }
+
+    /* Phase track */
+    .phase-track {
+      display: flex;
+      gap: 0;
+      overflow-x: auto;
+      margin: 2rem 0 0.5rem;
+      border-radius: 6px;
+      overflow: hidden;
+      border: 1px solid #ddd;
+    }
+    .phase-tab {
+      flex: 1;
+      min-width: 90px;
+      padding: 0.5rem 0.4rem;
+      text-align: center;
+      font-size: 0.72rem;
+      font-weight: 600;
+      cursor: pointer;
+      background: #f8fafc;
+      border-right: 1px solid #ddd;
+      user-select: none;
+      color: #555;
+      transition: background 0.1s;
+    }
+    .phase-tab:last-child { border-right: none; }
+    .phase-tab:hover { background: #e2e8f0; }
+    .phase-tab.active { background: #1e40af; color: #fff; }
+
+    /* Phase panels */
+    .phase-panel { display: none; }
+    .phase-panel.active { display: block; }
+
+    /* Steps */
+    .step {
+      border: 1px solid #e5e5e5;
+      border-radius: 6px;
+      margin: 1rem 0;
+      overflow: hidden;
+    }
+    .step-header {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      padding: 0.75rem 1rem;
+      background: #fafafa;
+      cursor: pointer;
+      user-select: none;
+    }
+    .step-header:hover { background: #f3f4f6; }
+    .step-num {
+      font-family: monospace;
+      font-size: 0.75rem;
+      font-weight: 700;
+      color: #fff;
+      background: #1e40af;
+      border-radius: 3px;
+      padding: 1px 6px;
+      white-space: nowrap;
+      margin-top: 2px;
+      flex-shrink: 0;
+    }
+    .step-num.gate { background: #d97706; }
+    .step-num.test { background: #059669; }
+    .step-num.doc { background: #7c3aed; }
+    .step-title { font-weight: 500; flex: 1; }
+    .step-files { font-size: 0.78rem; color: #888; margin-top: 2px; font-family: monospace; }
+    .chevron { font-size: 0.75rem; margin-top: 3px; color: #888; transition: transform 0.15s; flex-shrink: 0; }
+    .chevron.open { transform: rotate(90deg); }
+    .step-body {
+      display: none;
+      padding: 0.85rem 1rem;
+      border-top: 1px solid #e5e5e5;
+      background: #fff;
+    }
+    .step-body.open { display: block; }
+    .step-body p { margin: 0.5rem 0; font-size: 0.9rem; color: #333; }
+    .step-body ul, .step-body ol { padding-left: 1.25rem; font-size: 0.9rem; color: #333; }
+    .step-body li { margin: 0.3rem 0; }
+    .step-body code { background: #f1f5f9; padding: 1px 5px; border-radius: 3px; font-size: 0.83rem; font-family: monospace; }
+    .step-body pre {
+      background: #f8fafc;
+      border: 1px solid #e5e5e5;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      font-size: 0.81rem;
+      overflow-x: auto;
+      margin: 0.6rem 0;
+    }
+    .step-body strong { font-weight: 600; }
+
+    /* Gate box */
+    .gate-box {
+      background: #fffbeb;
+      border: 2px solid #f59e0b;
+      border-radius: 6px;
+      padding: 0.9rem 1.1rem;
+      margin: 1.2rem 0;
+    }
+    .gate-box h4 { margin: 0 0 0.4rem; font-size: 0.9rem; color: #92400e; }
+    .gate-box ol { padding-left: 1.2rem; margin: 0; font-size: 0.87rem; color: #555; }
+    .gate-box li { margin: 0.25rem 0; }
+    .gate-box code { background: #fef3c7; padding: 1px 5px; border-radius: 3px; font-size: 0.82rem; }
+
+    /* Context callout */
+    .context {
+      background: #f0f9ff;
+      border-left: 3px solid #38bdf8;
+      padding: 0.65rem 0.9rem;
+      margin: 0.8rem 0;
+      font-size: 0.88rem;
+      color: #333;
+    }
+
+    /* Summary table */
+    table { border-collapse: collapse; width: 100%; font-size: 0.87rem; margin: 1rem 0; }
+    th { background: #f1f5f9; text-align: left; padding: 6px 10px; border: 1px solid #ddd; font-weight: 600; }
+    td { padding: 6px 10px; border: 1px solid #ddd; vertical-align: top; }
+    td code { background: #f1f5f9; padding: 1px 4px; border-radius: 3px; font-size: 0.8rem; }
+
+    /* Badge */
+    .badge {
+      display: inline-block;
+      padding: 2px 7px;
+      border-radius: 3px;
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .badge-new  { background: #d1fae5; color: #065f46; }
+    .badge-mod  { background: #dbeafe; color: #1e40af; }
+    .badge-del  { background: #fee2e2; color: #991b1b; }
+    .badge-test { background: #ede9fe; color: #6d28d9; }
+    .badge-doc  { background: #fef3c7; color: #92400e; }
+
+    /* Validation section */
+    .final-validation {
+      background: #fffbeb;
+      border: 2px solid #f59e0b;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-top: 2.5rem;
+    }
+    .final-validation h2 { color: #92400e; border-bottom-color: #f59e0b; margin-top: 0; }
+    .final-validation ol { padding-left: 1.25rem; }
+    .final-validation li { margin: 0.4rem 0; font-size: 0.9rem; }
+    .final-validation code { background: #fef3c7; padding: 1px 5px; border-radius: 3px; font-size: 0.83rem; }
+  </style>
+</head>
+<body>
+
+<h1>Implementation plan: configurable discussion model registry</h1>
+<a class="spec-link" href="../specs/configurable-discussion-models.html">Source spec: REQ-MODELS-1 through REQ-MODELS-10</a>
+
+<p>
+  Six phases. The first three are additive (new files, no deletions). Phase 3 is the breaking change:
+  it removes the shared enum and all its callers atomically. Run <code>bun run typecheck</code> after
+  each phase to confirm clean output before moving on.
+</p>
+
+<h2>Affected files at a glance</h2>
+
+<table>
+  <tr>
+    <th>File</th>
+    <th>Action</th>
+    <th>Phase</th>
+  </tr>
+  <tr><td><code>daemon/src/global-config.ts</code></td><td><span class="badge badge-new">new</span></td><td>1</td></tr>
+  <tr><td><code>daemon/src/__tests__/global-config.test.ts</code></td><td><span class="badge badge-new">new</span></td><td>1</td></tr>
+  <tr><td><code>daemon/src/index.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>2</td></tr>
+  <tr><td><code>daemon/src/routes/models.ts</code></td><td><span class="badge badge-new">new</span></td><td>2</td></tr>
+  <tr><td><code>daemon/src/routes/__tests__/models.test.ts</code></td><td><span class="badge badge-new">new</span></td><td>2</td></tr>
+  <tr><td><code>daemon/src/router.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>2</td></tr>
+  <tr><td><code>packages/shared/src/schemas/protocol.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>3</td></tr>
+  <tr><td><code>packages/shared/src/vault-config.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>3</td></tr>
+  <tr><td><code>packages/shared/src/index.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>3</td></tr>
+  <tr><td><code>daemon/src/vault/vault-config.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>3</td></tr>
+  <tr><td><code>daemon/src/vault/vault-manager.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>3</td></tr>
+  <tr><td><code>daemon/src/session-manager.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>3</td></tr>
+  <tr><td><code>nextjs/app/api/models/route.ts</code></td><td><span class="badge badge-new">new</span></td><td>4</td></tr>
+  <tr><td><code>nextjs/lib/daemon/models.ts</code></td><td><span class="badge badge-new">new</span></td><td>4</td></tr>
+  <tr><td><code>nextjs/lib/daemon/index.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>4</td></tr>
+  <tr><td><code>nextjs/components/vault/ConfigEditorDialog.tsx</code></td><td><span class="badge badge-mod">mod</span></td><td>4</td></tr>
+  <tr><td><code>daemon/src/__tests__/session-manager.test.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>5</td></tr>
+  <tr><td><code>daemon/src/vault/__tests__/vault-config.test.ts</code></td><td><span class="badge badge-mod">mod</span></td><td>5</td></tr>
+  <tr><td><code>nextjs/components/vault/__tests__/ConfigEditorDialog.test.tsx</code></td><td><span class="badge badge-mod">mod</span></td><td>5</td></tr>
+  <tr><td><code>.lore/reference/_infrastructure/configuration.md</code></td><td><span class="badge badge-doc">doc</span></td><td>6</td></tr>
+  <tr><td><code>.lore/reference/think.md</code></td><td><span class="badge badge-doc">doc</span></td><td>6</td></tr>
+</table>
+
+<!-- ═══════════════ PHASE TABS ═══════════════ -->
+
+<div class="phase-track">
+  <div class="phase-tab active" onclick="showPhase(1)">Phase 1<br>global-config</div>
+  <div class="phase-tab" onclick="showPhase(2)">Phase 2<br>startup + route</div>
+  <div class="phase-tab" onclick="showPhase(3)">Phase 3<br>shared purge</div>
+  <div class="phase-tab" onclick="showPhase(4)">Phase 4<br>Next.js</div>
+  <div class="phase-tab" onclick="showPhase(5)">Phase 5<br>test updates</div>
+  <div class="phase-tab" onclick="showPhase(6)">Phase 6<br>docs</div>
+</div>
+
+<!-- ═══════════════ PHASE 1 ═══════════════ -->
+
+<div class="phase-panel active" id="phase-1">
+  <h2>Phase 1 — Create <code>global-config.ts</code></h2>
+  <p>
+    New isolated module. No existing code is touched. All subsequent phases depend on it.
+  </p>
+
+  <div class="step" id="step-1-1">
+    <div class="step-header" onclick="toggle('step-1-1')">
+      <span class="step-num">1.1</span>
+      <div>
+        <div class="step-title">Write <code>daemon/src/global-config.ts</code></div>
+        <div class="step-files">daemon/src/global-config.ts (new)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>Create the module with these exports:</p>
+      <ul>
+        <li><code>ModelEntry = { provider: string; modelId: string }</code> — interface for one registry entry.</li>
+        <li><code>ModelRegistry = Record&lt;string, ModelEntry&gt;</code> — the full registry map.</li>
+        <li>Module-level <code>let registry: ModelRegistry = {}</code> — mutable state, not exported directly.</li>
+        <li><code>getRegistry(): ModelRegistry</code> — returns current registry. Called by <code>resolveModelForPiAgent()</code> and the models route handler.</li>
+        <li><code>loadGlobalConfig(): Promise&lt;void&gt;</code> — called once at startup. Reads the config file, populates registry.</li>
+        <li><code>configureRegistryForTesting(r: ModelRegistry): () =&gt; void</code> — sets registry, returns cleanup function that resets it. Follows <code>configurePiSessionForTesting</code> pattern.</li>
+        <li><code>_resetRegistryForTesting(): void</code> — direct reset to <code>{}</code>. Called in <code>afterEach</code>.</li>
+      </ul>
+      <h3>Config file resolution (inside <code>loadGlobalConfig</code>, not at module top)</h3>
+      <pre>function getConfigFilePath(): string {
+  return (
+    process.env.MEMORY_LOOP_CONFIG ??
+    join(getVaultsDir(), "memory-loop-config.json")
+  );
+}</pre>
+      <p>
+        <code>getVaultsDir()</code> is imported from the vault module (already exported). Call it inside the function, not at module import time — matching the pattern in <code>vault-manager.ts</code> so tests can set <code>VAULTS_DIR</code> in <code>beforeEach</code>.
+      </p>
+      <h3>loadGlobalConfig logic</h3>
+      <pre>export async function loadGlobalConfig(): Promise&lt;void&gt; {
+  const path = getConfigFilePath();
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch {
+    log.warn(`Global config not found at ${path}, model registry is empty`);
+    registry = {};
+    return;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    log.warn(`Global config at ${path} is not valid JSON, model registry is empty`);
+    registry = {};
+    return;
+  }
+  if (typeof parsed !== "object" || parsed === null || !("models" in parsed)) {
+    registry = {};
+    return;
+  }
+  const modelsRaw = (parsed as Record&lt;string, unknown&gt;).models;
+  if (typeof modelsRaw !== "object" || modelsRaw === null) {
+    registry = {};
+    return;
+  }
+  const result: ModelRegistry = {};
+  for (const [name, entry] of Object.entries(modelsRaw)) {
+    if (
+      typeof entry === "object" && entry !== null &&
+      "provider" in entry && typeof (entry as Record&lt;string, unknown&gt;).provider === "string" &&
+      "modelId" in entry && typeof (entry as Record&lt;string, unknown&gt;).modelId === "string"
+    ) {
+      result[name] = entry as ModelEntry;
+    } else {
+      log.warn(`Skipping invalid model entry "${name}" in global config`);
+    }
+  }
+  registry = result;
+  log.info(`Loaded ${Object.keys(registry).length} model(s) from global config`);
+}</pre>
+      <div class="context">
+        Unknown top-level keys (anything other than <code>models</code>) are silently ignored per REQ-MODELS-1.
+      </div>
+    </div>
+  </div>
+
+  <div class="step" id="step-1-2">
+    <div class="step-header" onclick="toggle('step-1-2')">
+      <span class="step-num test">1.2</span>
+      <div>
+        <div class="step-title">Write <code>daemon/src/__tests__/global-config.test.ts</code></div>
+        <div class="step-files">daemon/src/__tests__/global-config.test.ts (new)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>Five test cases matching REQ-MODELS-9:</p>
+      <ol>
+        <li>File not found → <code>getRegistry()</code> returns <code>{}</code>, no throw.</li>
+        <li>Malformed JSON → <code>getRegistry()</code> returns <code>{}</code>, no throw.</li>
+        <li>Valid file with three entries → registry populated with all three, correct shape.</li>
+        <li>File with one malformed entry (missing <code>modelId</code>) and one valid → valid entry retained, malformed skipped.</li>
+        <li>Empty <code>models</code> object (<code>{"models":{}}</code>) → registry is <code>{}</code>.</li>
+      </ol>
+      <p>
+        Use a temp dir for config file writes. Set <code>MEMORY_LOOP_CONFIG</code> env var in <code>beforeEach</code> to point at the temp file path, clear it in <code>afterEach</code>. Call <code>_resetRegistryForTesting()</code> in every <code>afterEach</code>.
+      </p>
+    </div>
+  </div>
+
+  <div class="gate-box">
+    <h4>Phase 1 gate</h4>
+    <ol>
+      <li><code>bun run --cwd daemon test src/__tests__/global-config.test.ts</code> — all 5 tests pass.</li>
+      <li><code>bun run typecheck</code> — zero errors.</li>
+    </ol>
+  </div>
+</div>
+
+<!-- ═══════════════ PHASE 2 ═══════════════ -->
+
+<div class="phase-panel" id="phase-2">
+  <h2>Phase 2 — Daemon startup wiring and <code>GET /models</code> route</h2>
+  <p>
+    Still additive. No existing behavior is removed. After this phase, <code>GET /api/models</code>
+    is functional even before the shared type purge.
+  </p>
+
+  <div class="step" id="step-2-1">
+    <div class="step-header" onclick="toggle('step-2-1')">
+      <span class="step-num">2.1</span>
+      <div>
+        <div class="step-title">Wire <code>loadGlobalConfig()</code> into daemon startup</div>
+        <div class="step-files">daemon/src/index.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>
+        In <code>daemon/src/index.ts</code>, add an <code>import { loadGlobalConfig } from "./global-config"</code>.
+      </p>
+      <p>
+        Call <code>await loadGlobalConfig()</code> after <code>await initVaultCache()</code> (line ~40) and before <code>startServer()</code> (line ~70). Position matters: the registry must be populated before the HTTP server accepts requests.
+      </p>
+      <pre>await initVaultCache();
+await loadGlobalConfig();   // ← add this line
+// ... background schedulers ...
+startServer();</pre>
+      <p>
+        The call is fire-and-forget-safe: <code>loadGlobalConfig()</code> never throws; a missing or bad config file is handled internally with a warning log.
+      </p>
+    </div>
+  </div>
+
+  <div class="step" id="step-2-2">
+    <div class="step-header" onclick="toggle('step-2-2')">
+      <span class="step-num">2.2</span>
+      <div>
+        <div class="step-title">Create <code>daemon/src/routes/models.ts</code></div>
+        <div class="step-files">daemon/src/routes/models.ts (new)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>Single exported handler:</p>
+      <pre>import type { Context } from "hono";
+import { getRegistry } from "../global-config";
+
+export function getModelsHandler(c: Context) {
+  const registry = getRegistry();
+  const models = Object.entries(registry).map(([name, entry]) => ({
+    name,
+    provider: entry.provider,
+    modelId: entry.modelId,
+  }));
+  return c.json({ models });
+}</pre>
+      <p>
+        Order matches V8/Bun insertion order of JSON.parse keys (non-integer string keys preserve insertion order). No sorting needed per REQ-MODELS-3.
+      </p>
+    </div>
+  </div>
+
+  <div class="step" id="step-2-3">
+    <div class="step-header" onclick="toggle('step-2-3')">
+      <span class="step-num">2.3</span>
+      <div>
+        <div class="step-title">Register <code>GET /models</code> in router</div>
+        <div class="step-files">daemon/src/router.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>
+        Add the import and registration to <code>registerRoutes()</code>. Follow the existing pattern (other GET routes near the top of the function):
+      </p>
+      <pre>import { getModelsHandler } from "./routes/models";
+
+// inside registerRoutes():
+app.get("/models", getModelsHandler);</pre>
+      <p>Place it near the other resource-listing GET routes (e.g., alongside <code>GET /vaults</code>).</p>
+    </div>
+  </div>
+
+  <div class="step" id="step-2-4">
+    <div class="step-header" onclick="toggle('step-2-4')">
+      <span class="step-num test">2.4</span>
+      <div>
+        <div class="step-title">Write <code>daemon/src/routes/__tests__/models.test.ts</code></div>
+        <div class="step-files">daemon/src/routes/__tests__/models.test.ts (new)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>Two test cases per REQ-MODELS-9:</p>
+      <ol>
+        <li>
+          Empty registry (<code>_resetRegistryForTesting()</code> only) → <code>GET /models</code> returns
+          <code>200</code> with <code>{ models: [] }</code>.
+        </li>
+        <li>
+          Registry populated via <code>configureRegistryForTesting({ opus: { provider: "anthropic", modelId: "claude-opus-4-7" } })</code>
+          → response is <code>{ models: [{ name: "opus", provider: "anthropic", modelId: "claude-opus-4-7" }] }</code>.
+        </li>
+      </ol>
+      <p>
+        Follow the pattern in <code>daemon/src/routes/__tests__/health.test.ts</code>: create a Hono test app,
+        register just the models route, hit it with a <code>Request</code> object.
+      </p>
+      <p>Call <code>_resetRegistryForTesting()</code> in <code>afterEach</code>.</p>
+    </div>
+  </div>
+
+  <div class="gate-box">
+    <h4>Phase 2 gate</h4>
+    <ol>
+      <li><code>bun run --cwd daemon test src/routes/__tests__/models.test.ts</code> — both tests pass.</li>
+      <li><code>bun run typecheck</code> — zero errors.</li>
+    </ol>
+  </div>
+</div>
+
+<!-- ═══════════════ PHASE 3 ═══════════════ -->
+
+<div class="phase-panel" id="phase-3">
+  <h2>Phase 3 — Shared type purge (breaking change, all callers fixed atomically)</h2>
+  <p>
+    This phase removes the hardcoded enum and updates every caller. Do all steps before running typecheck;
+    the intermediate state will not compile.
+  </p>
+  <div class="context">
+    REQ-MODELS-4 drives steps 3.1 and 3.2. REQ-MODELS-5 and REQ-MODELS-8 drive steps 3.3 through 3.5.
+  </div>
+
+  <div class="step" id="step-3-1">
+    <div class="step-header" onclick="toggle('step-3-1')">
+      <span class="step-num">3.1</span>
+      <div>
+        <div class="step-title">Remove enum, type, and helpers from <code>packages/shared/src/vault-config.ts</code></div>
+        <div class="step-files">packages/shared/src/vault-config.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>Remove the following from <code>packages/shared/src/vault-config.ts</code>:</p>
+      <ul>
+        <li><code>VALID_DISCUSSION_MODELS</code> constant (line ~49)</li>
+        <li><code>type DiscussionModelLocal</code> (line ~50)</li>
+        <li><code>DEFAULT_DISCUSSION_MODEL</code> constant (line ~51)</li>
+        <li><code>resolveDiscussionModel()</code> function (lines ~127-129)</li>
+      </ul>
+      <p>
+        The <code>VaultConfig</code> interface's <code>discussionModel?: string</code> field
+        stays as-is — it's already typed as plain <code>string | undefined</code>.
+      </p>
+      <p>
+        Also edit <code>packages/shared/src/index.ts</code> (the barrel export) to remove
+        the named exports for all four deleted symbols:
+        <code>VALID_DISCUSSION_MODELS</code>, <code>DiscussionModelLocal</code>,
+        <code>DEFAULT_DISCUSSION_MODEL</code>, and <code>resolveDiscussionModel</code>.
+        Leaving them in the barrel export while deleting the definitions will cause a typecheck error.
+      </p>
+    </div>
+  </div>
+
+  <div class="step" id="step-3-2">
+    <div class="step-header" onclick="toggle('step-3-2')">
+      <span class="step-num">3.2</span>
+      <div>
+        <div class="step-title">Remove enum and type from <code>packages/shared/src/schemas/protocol.ts</code></div>
+        <div class="step-files">packages/shared/src/schemas/protocol.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>Three changes:</p>
+      <ol>
+        <li>
+          Delete <code>DiscussionModelSchema = z.enum(["opus", "sonnet", "haiku"])</code> (line ~52).
+        </li>
+        <li>
+          In <code>EditableVaultConfigSchema</code>: change <code>discussionModel: DiscussionModelSchema.optional()</code>
+          to <code>discussionModel: z.string().optional()</code>.
+        </li>
+        <li>
+          In <code>VaultInfoSchema</code>: change <code>discussionModel: DiscussionModelSchema.optional()</code>
+          to <code>discussionModel: z.string().optional()</code>.
+        </li>
+        <li>
+          Delete the exported type <code>type DiscussionModel = z.infer&lt;typeof DiscussionModelSchema&gt;</code>
+          (line ~1082).
+        </li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="step" id="step-3-3">
+    <div class="step-header" onclick="toggle('step-3-3')">
+      <span class="step-num">3.3</span>
+      <div>
+        <div class="step-title">Remove enum validation from <code>daemon/src/vault/vault-config.ts</code></div>
+        <div class="step-files">daemon/src/vault/vault-config.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>
+        In <code>loadVaultConfig()</code>, the block at lines ~69-74 currently does this:
+      </p>
+      <pre>if (
+  typeof obj.discussionModel === "string" &&
+  VALID_DISCUSSION_MODELS.includes(obj.discussionModel as ...)
+) {
+  config.discussionModel = obj.discussionModel;
+}</pre>
+      <p>
+        <strong>Replace</strong> this block (do not delete it) with a simpler check that accepts any string:
+      </p>
+      <pre>if (typeof obj.discussionModel === "string") {
+  config.discussionModel = obj.discussionModel;
+}</pre>
+      <p>
+        Deleting the block entirely would silently drop <code>discussionModel</code> from all loaded
+        vault configs. Non-string values (e.g. <code>123</code>) are still ignored — the <code>z.string()</code>
+        guard does that job. The enum whitelist check is the only thing removed.
+      </p>
+      <p>Remove the import of <code>VALID_DISCUSSION_MODELS</code> from shared.</p>
+      <div class="context">
+        The vault-config test currently has a test "ignores invalid discussionModel value" that
+        expects non-enum strings to be rejected. After this change, any string is valid; update
+        that test to confirm the string is passed through rather than dropped. The test "ignores
+        non-string discussionModel value" (e.g. <code>123</code>) remains correct — <code>z.string()</code>
+        still rejects non-strings. See Phase 5 for exact test edits.
+      </div>
+    </div>
+  </div>
+
+  <div class="step" id="step-3-4">
+    <div class="step-header" onclick="toggle('step-3-4')">
+      <span class="step-num">3.4</span>
+      <div>
+        <div class="step-title">Update <code>parseVault()</code> in <code>daemon/src/vault/vault-manager.ts</code></div>
+        <div class="step-files">daemon/src/vault/vault-manager.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>
+        In <code>parseVault()</code> at line ~169, change:
+      </p>
+      <pre>// before
+discussionModel: resolveDiscussionModel(config),
+
+// after
+discussionModel: config.discussionModel,</pre>
+      <p>
+        Remove the <code>import { resolveDiscussionModel }</code> from <code>@memory-loop/shared</code>.
+        A vault with no <code>discussionModel</code> set now returns <code>undefined</code> in the
+        <code>VaultInfo</code> response instead of the hardcoded <code>"opus"</code> default.
+        This is the intentional behavior change described in the spec.
+      </p>
+    </div>
+  </div>
+
+  <div class="step" id="step-3-5">
+    <div class="step-header" onclick="toggle('step-3-5')">
+      <span class="step-num">3.5</span>
+      <div>
+        <div class="step-title">Rewrite <code>resolveModelForPiAgent()</code> in <code>daemon/src/session-manager.ts</code></div>
+        <div class="step-files">daemon/src/session-manager.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>Two deletions and one rewrite:</p>
+      <ol>
+        <li>Delete <code>DISCUSSION_MODEL_MAP</code> constant (lines ~65-71).</li>
+        <li>Remove the import of <code>resolveDiscussionModel</code> from <code>@memory-loop/shared</code>.</li>
+        <li>Rewrite <code>resolveModelForPiAgent()</code>:</li>
+      </ol>
+      <pre>function resolveModelForPiAgent(
+  vaultPath: string,
+  config: Awaited&lt;ReturnType&lt;typeof loadVaultConfig&gt;&gt;
+): PiAgentModel | undefined {
+  const modelName = config.discussionModel;
+  if (!modelName) return undefined;
+
+  const entry = getRegistry()[modelName];
+  if (!entry) {
+    log.warn(`Unknown discussion model "${modelName}" for vault at ${vaultPath}, using pi-agent fallback`);
+    return undefined;
+  }
+  return entry;
+}</pre>
+      <p>Add import at top of file:</p>
+      <pre>import { getRegistry } from "./global-config";</pre>
+      <p>
+        The <code>openPiSessionForVault()</code> caller (lines ~679-701) needs no changes — it already
+        handles <code>model</code> being <code>undefined</code> and logs appropriately.
+      </p>
+    </div>
+  </div>
+
+  <div class="gate-box">
+    <h4>Phase 3 gate</h4>
+    <ol>
+      <li><code>bun run typecheck</code> — zero errors. Confirm with grep:
+        <code>grep -r "DiscussionModelLocal\|DiscussionModelSchema\|VALID_DISCUSSION_MODELS\|DISCUSSION_MODEL_MAP" packages/ daemon/src/</code>
+        → zero matches.
+      </li>
+      <li><code>bun run lint</code> — zero errors.</li>
+    </ol>
+  </div>
+</div>
+
+<!-- ═══════════════ PHASE 4 ═══════════════ -->
+
+<div class="phase-panel" id="phase-4">
+  <h2>Phase 4 — Next.js layer (proxy route, daemon client, frontend)</h2>
+  <p>Three independent changes that can be written in any order within the phase.</p>
+
+  <div class="step" id="step-4-1">
+    <div class="step-header" onclick="toggle('step-4-1')">
+      <span class="step-num">4.1</span>
+      <div>
+        <div class="step-title">Create <code>nextjs/app/api/models/route.ts</code></div>
+        <div class="step-files">nextjs/app/api/models/route.ts (new)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>Minimal proxy following the pattern in <code>nextjs/app/api/vaults/[vaultId]/config/route.ts</code>:</p>
+      <pre>import { NextResponse } from "next/server";
+import { daemonFetch } from "@/lib/daemon/fetch";
+
+export async function GET() {
+  const res = await daemonFetch("/models");
+  return NextResponse.json(await res.json(), { status: res.status });
+}</pre>
+      <p>
+        No auth wrapper needed — consistent with other read-only daemon proxy routes. The browser calls
+        <code>GET /api/models</code>; this handler forwards to the daemon and relays the response.
+      </p>
+    </div>
+  </div>
+
+  <div class="step" id="step-4-2">
+    <div class="step-header" onclick="toggle('step-4-2')">
+      <span class="step-num">4.2</span>
+      <div>
+        <div class="step-title">Create <code>nextjs/lib/daemon/models.ts</code> and update barrel export</div>
+        <div class="step-files">nextjs/lib/daemon/models.ts (new), nextjs/lib/daemon/index.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>New file <code>nextjs/lib/daemon/models.ts</code>:</p>
+      <pre>import { daemonFetch } from "./fetch";
+
+export interface ModelEntry {
+  name: string;
+  provider: string;
+  modelId: string;
+}
+
+export async function getModels(): Promise&lt;ModelEntry[]&gt; {
+  const res = await daemonFetch("/models");
+  const json = await res.json() as { models: ModelEntry[] };
+  return json.models;
+}</pre>
+      <p>
+        Add to <code>nextjs/lib/daemon/index.ts</code>:
+      </p>
+      <pre>export * from "./models";</pre>
+    </div>
+  </div>
+
+  <div class="step" id="step-4-3">
+    <div class="step-header" onclick="toggle('step-4-3')">
+      <span class="step-num">4.3</span>
+      <div>
+        <div class="step-title">Update model dropdown in <code>ConfigEditorDialog.tsx</code></div>
+        <div class="step-files">nextjs/components/vault/ConfigEditorDialog.tsx (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>The current dropdown (lines ~547-574) is hardcoded. Replace with a dynamic fetch.</p>
+
+      <h3>State and fetch</h3>
+      <pre>const [availableModels, setAvailableModels] = useState&lt;ModelEntry[]&gt;([]);
+
+useEffect(() =&gt; {
+  fetch("/api/models")
+    .then((r) =&gt; r.json())
+    .then((data: { models: ModelEntry[] }) =&gt; setAvailableModels(data.models))
+    .catch(() =&gt; setAvailableModels([]));
+}, []);</pre>
+      <p>Import <code>ModelEntry</code> from <code>@/lib/daemon/models</code>.</p>
+
+      <h3>Dropdown markup</h3>
+      <pre>&lt;select
+  id={discussionModelId}
+  className="config-editor__select"
+  value={formState.discussionModel ?? ""}
+  onChange={(e) =&gt; setFormState(prev =&gt; ({
+    ...prev,
+    discussionModel: e.target.value || undefined,
+  }))}
+&gt;
+  {availableModels.length === 0 ? (
+    &lt;option value="" disabled&gt;No models configured.&lt;/option&gt;
+  ) : (
+    &lt;&gt;
+      &lt;option value=""&gt;— unset —&lt;/option&gt;
+      {/* Current value not in list: show it with (unknown) indicator */}
+      {formState.discussionModel &amp;&amp;
+        !availableModels.some(m =&gt; m.name === formState.discussionModel) &amp;&amp; (
+        &lt;option value={formState.discussionModel}&gt;
+          {formState.discussionModel} (unknown)
+        &lt;/option&gt;
+      )}
+      {availableModels.map(m =&gt; (
+        &lt;option key={m.name} value={m.name}&gt;{m.name}&lt;/option&gt;
+      ))}
+    &lt;/&gt;
+  )}
+&lt;/select&gt;</pre>
+
+      <h3>Type cleanup</h3>
+      <p>
+        Remove any remaining references to the <code>"opus" | "sonnet" | "haiku"</code> literal type
+        cast in the <code>onChange</code> handler (the current cast on line ~570). The field is now
+        <code>string | undefined</code> per the updated schema.
+      </p>
+
+      <div class="context">
+        REQ-MODELS-6: when the stored value is not in the API list, it renders with " (unknown)" and
+        remains selectable and saveable. The select's <code>value</code> will match the option
+        added above, so the browser renders it correctly without custom styling.
+      </div>
+    </div>
+  </div>
+
+  <div class="gate-box">
+    <h4>Phase 4 gate</h4>
+    <ol>
+      <li><code>bun run typecheck</code> — zero errors.</li>
+      <li><code>bun run lint</code> — zero errors.</li>
+      <li>Manual smoke test: <code>bun run daemon:dev</code> + <code>bun run --cwd nextjs dev</code>.
+        Open vault settings. Confirm dropdown is empty ("No models configured.") when no config file is present.</li>
+      <li>Write <code>${VAULTS_DIR}/memory-loop-config.json</code> with two model entries, restart daemon.
+        Reopen vault settings. Confirm dropdown shows both model names.</li>
+    </ol>
+  </div>
+</div>
+
+<!-- ═══════════════ PHASE 5 ═══════════════ -->
+
+<div class="phase-panel" id="phase-5">
+  <h2>Phase 5 — Update existing tests</h2>
+  <p>
+    Two existing test files need updates. No new behavior is tested here — only the tests that
+    depended on the removed constants and the old default-model behavior.
+  </p>
+
+  <div class="step" id="step-5-1">
+    <div class="step-header" onclick="toggle('step-5-1')">
+      <span class="step-num test">5.1</span>
+      <div>
+        <div class="step-title">Update <code>daemon/src/__tests__/session-manager.test.ts</code></div>
+        <div class="step-files">daemon/src/__tests__/session-manager.test.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <h3>Imports</h3>
+      <p>Add to the import block:</p>
+      <pre>import {
+  configureRegistryForTesting,
+  _resetRegistryForTesting,
+} from "../global-config";</pre>
+
+      <h3>afterEach</h3>
+      <p>Add <code>_resetRegistryForTesting()</code> to the existing <code>afterEach</code>:</p>
+      <pre>afterEach(async () =&gt; {
+  _resetPiSessionForTesting();
+  _resetRegistryForTesting();   // ← add this
+  await rm(tempDir, { recursive: true, force: true });
+});</pre>
+
+      <h3>Test: "uses vault config model when present" (line ~173)</h3>
+      <p>
+        Before the test body, inject a registry with the haiku entry. The assertion value must match
+        whatever is in the injected registry (not the old hardcoded map):
+      </p>
+      <pre>test("uses vault config model when present", async () =&gt; {
+  configureRegistryForTesting({
+    haiku: { provider: "anthropic", modelId: "claude-haiku-4-5" },
+  });
+  await writeFile(
+    join(tempDir, ".memory-loop.json"),
+    JSON.stringify({ discussionModel: "haiku" })
+  );
+  // ... rest of test unchanged ...
+  expect(capturedOpts.model).toEqual({ provider: "anthropic", modelId: "claude-haiku-4-5" });
+});</pre>
+
+      <h3>Test: "passes no model when vault config has no discussionModel" (line ~193)</h3>
+      <p>
+        This is the deliberate behavior change per REQ-MODELS-9. No registry injection needed
+        (empty registry by default). Update the assertion:
+      </p>
+      <pre>// before
+expect(capturedOpts.model).toEqual({ provider: "anthropic", modelId: "claude-opus-4-5" });
+
+// after
+expect(capturedOpts.model).toBeUndefined();</pre>
+      <p>Also update the test name to reflect the new behavior (optional but keeps the comment accurate).</p>
+    </div>
+  </div>
+
+  <div class="step" id="step-5-2">
+    <div class="step-header" onclick="toggle('step-5-2')">
+      <span class="step-num test">5.2</span>
+      <div>
+        <div class="step-title">Update <code>daemon/src/vault/__tests__/vault-config.test.ts</code></div>
+        <div class="step-files">daemon/src/vault/__tests__/vault-config.test.ts (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <h3>Remove deleted imports</h3>
+      <pre>// Remove these imports (line 30, 42):
+import { VALID_DISCUSSION_MODELS } from "@memory-loop/shared";
+import { resolveDiscussionModel } from "@memory-loop/shared";</pre>
+
+      <h3>Remove test for <code>VALID_DISCUSSION_MODELS</code> constant (line ~91)</h3>
+      <p>Delete the entire test block that asserts the constant equals <code>["opus", "sonnet", "haiku"]</code>.</p>
+
+      <h3>Update "discussionModel" test suite (lines ~244-266)</h3>
+      <p>Three specific changes:</p>
+      <ol>
+        <li>
+          <strong>"loads valid discussionModel"</strong> parameterized test: the current set of valid values
+          is just <code>["opus", "sonnet", "haiku"]</code>. After the change, any string is valid.
+          Keep the test but expand or simplify to test a couple of arbitrary strings (e.g. <code>"opus"</code>,
+          <code>"custom-model"</code>, <code>"some-other-string"</code>).
+        </li>
+        <li>
+          <strong>"ignores invalid discussionModel value"</strong>: remove this test entirely.
+          A string that was previously "invalid" (i.e., not in the enum) is now a valid string.
+          There is no longer a concept of an invalid string value.
+        </li>
+        <li>
+          <strong>"ignores non-string discussionModel value"</strong> (line ~262): keep as-is.
+          The Zod schema still rejects non-strings (e.g. <code>123</code>).
+        </li>
+      </ol>
+
+      <h3>Remove <code>resolveDiscussionModel</code> test suite (lines ~500-507)</h3>
+      <p>Delete the entire <code>describe("resolveDiscussionModel", ...)</code> block. The function no longer exists.</p>
+    </div>
+  </div>
+
+  <div class="step" id="step-5-3">
+    <div class="step-header" onclick="toggle('step-5-3')">
+      <span class="step-num test">5.3</span>
+      <div>
+        <div class="step-title">Update <code>nextjs/components/vault/__tests__/ConfigEditorDialog.test.tsx</code></div>
+        <div class="step-files">nextjs/components/vault/__tests__/ConfigEditorDialog.test.tsx (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>
+        The dialog's dropdown now fetches from <code>/api/models</code> in a <code>useEffect</code>.
+        In a jsdom test environment, <code>fetch</code> either fails or needs to be mocked.
+        Without a mock, <code>availableModels</code> will be <code>[]</code> and the dropdown
+        renders "No models configured." rather than the hardcoded options. All existing assertions
+        about the model select element will fail.
+      </p>
+
+      <h3>Mock strategy</h3>
+      <p>
+        Use a global <code>fetch</code> mock at the top of the test file. The dialog fetches
+        <code>/api/models</code> once on mount. Intercept it and return a controlled model list:
+      </p>
+      <pre>const mockFetch = mock(async (url: string) =&gt; {
+  if (url === "/api/models") {
+    return new Response(
+      JSON.stringify({ models: [
+        { name: "opus",   provider: "anthropic", modelId: "claude-opus-4-7" },
+        { name: "sonnet", provider: "anthropic", modelId: "claude-sonnet-4-6" },
+        { name: "haiku",  provider: "anthropic", modelId: "claude-haiku-4-5" },
+      ]}),
+      { headers: { "Content-Type": "application/json" } }
+    );
+  }
+  throw new Error(`Unexpected fetch: ${url}`);
+});
+
+beforeAll(() =&gt; { global.fetch = mockFetch as typeof fetch; });
+afterAll(() =&gt; { jest.restoreAllMocks(); });</pre>
+
+      <h3>Assertion updates</h3>
+      <ul>
+        <li>
+          Any assertion like <code>expect(modelSelect.value).toBe("sonnet")</code> remains valid if
+          the mock returns "sonnet" as an available option and the initial config has <code>discussionModel: "sonnet"</code>.
+          The select value comes from <code>formState.discussionModel</code> (unchanged), and the matching
+          option will be present because the mock returns it.
+        </li>
+        <li>
+          Remove assertions like <code>expect(screen.getByText("Opus (Most capable)")).toBeDefined()</code>.
+          The new option labels are plain model name keys (e.g. <code>"opus"</code>), not descriptive strings.
+          Replace with <code>expect(screen.getByRole("option", { name: "opus" })).toBeDefined()</code>.
+        </li>
+        <li>
+          Any test that changes the select to a model name (e.g. "opus") and saves should still pass
+          because the option exists in the mocked list.
+        </li>
+        <li>
+          Add one new test: render with <code>initialConfig.discussionModel: "unknown-model"</code>,
+          confirm the select shows "unknown-model (unknown)" as an option and it is selected.
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="gate-box">
+    <h4>Phase 5 gate</h4>
+    <ol>
+      <li><code>bun run test</code> — full suite passes. All existing tests that depended on the
+        hardcoded structures are updated, not deleted.</li>
+      <li>Confirm zero skipped tests related to model resolution.</li>
+    </ol>
+  </div>
+</div>
+
+<!-- ═══════════════ PHASE 6 ═══════════════ -->
+
+<div class="phase-panel" id="phase-6">
+  <h2>Phase 6 — Documentation updates</h2>
+
+  <div class="step" id="step-6-1">
+    <div class="step-header" onclick="toggle('step-6-1')">
+      <span class="step-num doc">6.1</span>
+      <div>
+        <div class="step-title">Update <code>.lore/reference/_infrastructure/configuration.md</code></div>
+        <div class="step-files">.lore/reference/_infrastructure/configuration.md (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>Three edits:</p>
+      <ol>
+        <li>
+          In the "AI Model" settings table, change the <code>discussionModel</code> type from
+          <code>"opus" | "sonnet" | "haiku"</code> and default <code>"opus"</code> to
+          <code>string (key from global model registry)</code> and default
+          <code>undefined (uses pi-agent fallback)</code>.
+        </li>
+        <li>
+          In the "Validation" section, remove the line that lists <code>discussionModel: enum ["opus", "sonnet", "haiku"]</code>.
+          Replace with: <code>discussionModel: any string; validation against registry happens at session creation.</code>
+        </li>
+        <li>
+          Add a new section "Global Config File" describing:
+          <ul>
+            <li>Path: <code>MEMORY_LOOP_CONFIG</code> env var, or <code>${VAULTS_DIR}/memory-loop-config.json</code></li>
+            <li>Format: <code>{ "models": { "name": { "provider": "...", "modelId": "..." } } }</code></li>
+            <li>The new <code>GET /api/models</code> endpoint and its response shape</li>
+            <li>Behavior when the file is absent or malformed</li>
+          </ul>
+        </li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="step" id="step-6-2">
+    <div class="step-header" onclick="toggle('step-6-2')">
+      <span class="step-num doc">6.2</span>
+      <div>
+        <div class="step-title">Update <code>.lore/reference/think.md</code></div>
+        <div class="step-files">.lore/reference/think.md (mod)</div>
+      </div>
+      <span class="chevron">▶</span>
+    </div>
+    <div class="step-body">
+      <p>In the "Model Selection" section:</p>
+      <pre># before
+**Options**: `"opus"` | `"sonnet"` | `"haiku"`
+**Default**: `"opus"`
+Passed to Claude SDK when creating session.
+
+# after
+**Options**: any key defined in the global model registry (see Global Config)
+**Default**: none — unset vaults fall back to the pi-agent default (`("fallback", "text")`)
+**Resolution**: at session creation time, the daemon looks up the vault's `discussionModel`
+string in the runtime registry. Unknown names log a warning and fall back to pi-agent default.</pre>
+    </div>
+  </div>
+</div>
+
+<!-- ═══════════════ FINAL VALIDATION ═══════════════ -->
+
+<div class="final-validation">
+  <h2>Final validation (mirrors spec validation section)</h2>
+  <p>Run these after all six phases are complete. They are drawn from the spec's AI Validation checklist.</p>
+
+  <h3>Static checks</h3>
+  <ol>
+    <li>
+      <code>bun run typecheck</code> passes with zero errors.
+    </li>
+    <li>
+      <code>grep -r "DiscussionModelLocal\|DiscussionModelSchema\|VALID_DISCUSSION_MODELS\|DISCUSSION_MODEL_MAP" packages/ daemon/src/</code>
+      → zero matches.
+    </li>
+    <li><code>bun run lint</code> passes with zero errors.</li>
+    <li><code>bun run test</code> passes. No tests deleted; the two modified session-manager tests
+      still cover the same behavior via the injectable registry.</li>
+  </ol>
+
+  <h3>Runtime behavior</h3>
+  <ol start="5">
+    <li>Start the daemon with no global config file. Logs show a warning about missing config,
+      no fatal error, daemon accepts requests. <code>GET /api/models</code> returns <code>{ "models": [] }</code>.</li>
+    <li>Write a valid <code>memory-loop-config.json</code> with two model entries.
+      Restart daemon. <code>GET /api/models</code> returns both entries in insertion order.</li>
+    <li>Add an entry with a missing <code>modelId</code> to the config. Restart.
+      Logs show one "Skipping invalid model entry" warning. Valid entries still appear in <code>GET /api/models</code>.</li>
+    <li>Configure a vault with a model name in the registry. Start a discussion.
+      Logs contain <code>provider</code> and <code>modelId</code> from the registry entry.</li>
+    <li>Configure a vault with a model name NOT in the registry. Start a discussion.
+      Logs show "Unknown discussion model" warning. Session completes without error.</li>
+    <li>Leave <code>discussionModel</code> unset on a vault. Start a discussion.
+      No "Unknown discussion model" warning in logs. Session completes.</li>
+  </ol>
+
+  <h3>Frontend</h3>
+  <ol start="11">
+    <li>Open vault settings. Dropdown options match exactly what <code>GET /api/models</code> returns.</li>
+    <li>With empty registry, open vault settings. Dropdown shows "No models configured." Saving
+      leaves the vault with <code>discussionModel: undefined</code>.</li>
+    <li>Manually set a vault's <code>.memory-loop.json</code> to a model name not in the registry.
+      Open vault settings. The stored name appears with "(unknown)" appended.</li>
+  </ol>
+</div>
+
+<script>
+  function showPhase(n) {
+    document.querySelectorAll(".phase-panel").forEach(p => p.classList.remove("active"));
+    document.querySelectorAll(".phase-tab").forEach(t => t.classList.remove("active"));
+    document.getElementById("phase-" + n).classList.add("active");
+    document.querySelectorAll(".phase-tab")[n - 1].classList.add("active");
+  }
+
+  function toggle(id) {
+    const body = document.querySelector(`#${id} .step-body`);
+    const chevron = document.querySelector(`#${id} .chevron`);
+    const isOpen = body.classList.contains("open");
+    body.classList.toggle("open", !isOpen);
+    chevron.classList.toggle("open", !isOpen);
+  }
+</script>
+</body>
+</html>

--- a/.lore/work/specs/configurable-discussion-models.html
+++ b/.lore/work/specs/configurable-discussion-models.html
@@ -1,0 +1,568 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Configurable discussion model registry</title>
+  <meta name="date" content="2026-05-21">
+  <meta name="status" content="draft">
+  <meta name="tags" content="model-config, global-config, discussion, pi-agent, session-manager">
+  <meta name="modules" content="session-manager, daemon-config, vault-config, config-editor-dialog">
+  <meta name="related" content=".lore/reference/_infrastructure/configuration.md, .lore/reference/think.md, .lore/research/pi-agent-sdk.md">
+  <meta name="req-prefix" content="MODELS">
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 15px;
+      line-height: 1.6;
+      color: #1a1a1a;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+    h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+    h2 { font-size: 1.2rem; margin-top: 2.5rem; border-bottom: 1px solid #ddd; padding-bottom: 0.3rem; }
+    h3 { font-size: 1rem; margin-top: 1.5rem; margin-bottom: 0.5rem; }
+
+    /* Sticky header */
+    .spec-header {
+      position: sticky;
+      top: 0;
+      background: #fff;
+      border-bottom: 1px solid #e5e5e5;
+      padding: 0.5rem 0;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      z-index: 100;
+      margin-bottom: 2rem;
+    }
+    .spec-title { font-weight: 600; font-size: 0.9rem; color: #333; }
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 3px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .badge-draft { background: #fef3c7; color: #92400e; }
+    .badge-approved { background: #d1fae5; color: #065f46; }
+    .badge-req { background: #eff6ff; color: #1e40af; font-family: monospace; font-size: 0.8rem; }
+    .prefix-label { font-size: 0.8rem; color: #666; }
+
+    /* Requirements */
+    .req {
+      border: 1px solid #e5e5e5;
+      border-radius: 6px;
+      margin: 1rem 0;
+      overflow: hidden;
+    }
+    .req-header {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      padding: 0.75rem 1rem;
+      background: #fafafa;
+      cursor: pointer;
+      user-select: none;
+    }
+    .req-header:hover { background: #f3f4f6; }
+    .req-id {
+      font-family: monospace;
+      font-size: 0.8rem;
+      font-weight: 700;
+      color: #1e40af;
+      white-space: nowrap;
+      margin-top: 2px;
+    }
+    .req-status { margin-left: auto; white-space: nowrap; }
+    .req-status .badge { font-size: 0.7rem; }
+    .badge-pending { background: #f1f5f9; color: #475569; }
+    .req-text { font-weight: 500; flex: 1; }
+    .req-body {
+      padding: 0.75rem 1rem;
+      border-top: 1px solid #e5e5e5;
+      background: #fff;
+      display: none;
+    }
+    .req-body.open { display: block; }
+    .req-body p { margin: 0.5rem 0; font-size: 0.9rem; color: #444; }
+    .req-body code { background: #f1f5f9; padding: 1px 5px; border-radius: 3px; font-size: 0.85rem; }
+    .req-body pre {
+      background: #f8fafc;
+      border: 1px solid #e5e5e5;
+      border-radius: 4px;
+      padding: 0.75rem;
+      font-size: 0.82rem;
+      overflow-x: auto;
+    }
+
+    /* Validation section */
+    .validation {
+      background: #fffbeb;
+      border: 2px solid #f59e0b;
+      border-radius: 8px;
+      padding: 1.25rem 1.5rem;
+      margin-top: 2.5rem;
+    }
+    .validation h2 {
+      color: #92400e;
+      border-bottom-color: #f59e0b;
+      margin-top: 0;
+    }
+    .validation ol { padding-left: 1.25rem; }
+    .validation li { margin: 0.5rem 0; font-size: 0.92rem; }
+    .validation code { background: #fef3c7; padding: 1px 5px; border-radius: 3px; font-size: 0.85rem; }
+
+    /* Context / rationale boxes */
+    .context {
+      background: #f8fafc;
+      border-left: 3px solid #94a3b8;
+      padding: 0.75rem 1rem;
+      margin: 1rem 0;
+      font-size: 0.9rem;
+      color: #444;
+    }
+
+    /* Anchor links */
+    .req-id a { color: inherit; text-decoration: none; }
+    .req-id a:hover { text-decoration: underline; }
+
+    /* Toggle chevron */
+    .chevron { font-size: 0.75rem; margin-top: 3px; transition: transform 0.15s; color: #888; }
+    .chevron.open { transform: rotate(90deg); }
+  </style>
+</head>
+<body>
+
+<div class="spec-header">
+  <span class="spec-title">Configurable discussion model registry</span>
+  <span class="badge badge-draft">draft</span>
+  <span class="prefix-label">prefix:</span>
+  <span class="badge badge-req">MODELS</span>
+</div>
+
+<h1>Configurable discussion model registry</h1>
+
+<p>
+  Model names like <code>"opus"</code>, <code>"sonnet"</code>, <code>"haiku"</code> are currently hardcoded in two places:
+  a Zod enum in <code>packages/shared</code> and a translation map in <code>daemon/src/session-manager.ts</code>.
+  Adding, renaming, or repointing a model (e.g. to a different provider) requires a code change and a redeploy.
+</p>
+<p>
+  This spec replaces those hardcoded structures with a runtime registry loaded from a global config file.
+  The config file maps arbitrary names to <code>{ provider, modelId }</code> pairs. The daemon reads it on startup.
+  Per-vault config continues to reference models by name; the dropdown in the UI is populated from whatever
+  names are in the registry at runtime.
+</p>
+
+<div class="context">
+  <strong>Behavior change:</strong> Vaults with no <code>discussionModel</code> set currently use Opus
+  (the hardcoded default). After this change they use the pi-agent fallback. Sites that want Opus as
+  the default must configure their vaults or set <code>discussionModel</code> explicitly in
+  <code>.memory-loop.json</code>.
+</div>
+
+<div class="context">
+  <strong>Out of scope:</strong> Hot-reloading the model registry without a daemon restart. The registry is
+  read once on startup. A restart is acceptable and already required for other daemon config changes.
+</div>
+
+<h2>Requirements</h2>
+
+<!-- REQ-MODELS-1 -->
+<div class="req" id="REQ-MODELS-1">
+  <div class="req-header" onclick="toggle('REQ-MODELS-1')">
+    <span class="req-id"><a href="#REQ-MODELS-1">REQ-MODELS-1</a></span>
+    <span class="req-text">Global config file defines the model registry</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-1">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-1">
+    <p>
+      A global config file for the memory-loop daemon defines a <code>models</code> object.
+      Each key is a model name (arbitrary string); each value is a <code>{ provider, modelId }</code> pair.
+    </p>
+    <pre>{
+  "models": {
+    "opus":   { "provider": "anthropic", "modelId": "claude-opus-4-7" },
+    "sonnet": { "provider": "anthropic", "modelId": "claude-sonnet-4-6" },
+    "haiku":  { "provider": "anthropic", "modelId": "claude-haiku-4-5" }
+  }
+}</pre>
+    <p>
+      The file path is determined by the env var <code>MEMORY_LOOP_CONFIG</code>, defaulting to
+      <code>${VAULTS_DIR}/memory-loop-config.json</code> when unset. The path is resolved when
+      <code>loadGlobalConfig()</code> is called, not at module import time — mirroring the pattern
+      in <code>vault-manager.ts</code> where <code>getVaultsDir()</code> is called inside functions
+      so that test <code>beforeEach</code> can set <code>VAULTS_DIR</code> before the path is resolved.
+    </p>
+    <p>
+      The file is optional: if absent, the model registry is empty and all sessions fall back
+      to the pi-agent default (REQ-MODELS-7).
+    </p>
+    <p>Unknown top-level keys in the file are ignored (forward-compatible).</p>
+  </div>
+</div>
+
+<!-- REQ-MODELS-2 -->
+<div class="req" id="REQ-MODELS-2">
+  <div class="req-header" onclick="toggle('REQ-MODELS-2')">
+    <span class="req-id"><a href="#REQ-MODELS-2">REQ-MODELS-2</a></span>
+    <span class="req-text">Daemon loads the model registry once on startup</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-2">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-2">
+    <p>
+      During daemon startup (<code>daemon/src/index.ts</code>), the global config is loaded before
+      the HTTP server accepts requests. The loaded model registry is stored as module-level state
+      in a new <code>daemon/src/global-config.ts</code> module, accessed via a <code>getRegistry()</code>
+      export.
+    </p>
+    <p>
+      The module exports a <code>configureRegistryForTesting(registry)</code> /
+      <code>_resetRegistryForTesting()</code> pair following the same pattern as
+      <code>pi-session-factory.ts</code>. This allows tests to inject a mock registry without
+      using <code>mock.module()</code>, which is prohibited in this codebase.
+    </p>
+    <p>
+      A missing or malformed config file is not a fatal error. The daemon logs a warning and
+      continues with an empty registry. A valid file with zero model entries is also accepted.
+    </p>
+    <p>
+      Individual model entries with an invalid shape (missing <code>provider</code> or <code>modelId</code>,
+      non-string values) are skipped with a warning; valid entries in the same file are retained.
+    </p>
+  </div>
+</div>
+
+<!-- REQ-MODELS-3 -->
+<div class="req" id="REQ-MODELS-3">
+  <div class="req-header" onclick="toggle('REQ-MODELS-3')">
+    <span class="req-id"><a href="#REQ-MODELS-3">REQ-MODELS-3</a></span>
+    <span class="req-text">Model registry exposed via REST API</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-3">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-3">
+    <p>
+      A new daemon endpoint <code>GET /api/models</code> returns the runtime model registry as a
+      JSON array of entries, suitable for populating a dropdown. Order matches the insertion order
+      of keys as parsed by <code>JSON.parse</code> (preserved by V8/Bun for non-integer keys).
+    </p>
+    <pre>// Response shape
+{
+  "models": [
+    { "name": "opus",   "provider": "anthropic", "modelId": "claude-opus-4-7" },
+    { "name": "sonnet", "provider": "anthropic", "modelId": "claude-sonnet-4-6" },
+    { "name": "haiku",  "provider": "anthropic", "modelId": "claude-haiku-4-5" }
+  ]
+}</pre>
+    <p>
+      When the registry is empty (no config file or empty <code>models</code> object), the response
+      is <code>{ "models": [] }</code>. The frontend handles this gracefully (REQ-MODELS-6).
+    </p>
+    <p>
+      A Next.js proxy route <code>nextjs/app/api/models/route.ts</code> forwards
+      <code>GET /api/models</code> to the daemon, consistent with all other daemon-proxied
+      endpoints. The browser calls the Next.js proxy; the proxy calls the daemon via Unix socket.
+    </p>
+  </div>
+</div>
+
+<!-- REQ-MODELS-4 -->
+<div class="req" id="REQ-MODELS-4">
+  <div class="req-header" onclick="toggle('REQ-MODELS-4')">
+    <span class="req-id"><a href="#REQ-MODELS-4">REQ-MODELS-4</a></span>
+    <span class="req-text">Remove hardcoded model enum and translation map</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-4">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-4">
+    <p>The following hardcoded structures are removed:</p>
+    <ul>
+      <li><code>VALID_DISCUSSION_MODELS</code> constant in <code>packages/shared/src/vault-config.ts</code></li>
+      <li><code>DiscussionModelLocal</code> type alias (<code>"opus" | "sonnet" | "haiku"</code>)</li>
+      <li><code>DEFAULT_DISCUSSION_MODEL</code> constant (no longer meaningful without a fixed set)</li>
+      <li><code>DISCUSSION_MODEL_MAP</code> in <code>daemon/src/session-manager.ts</code>, including
+          its <code>"basic"</code> and <code>"text"</code> fallback-provider entries. Those entries
+          mapped to <code>("fallback", "basic")</code> and <code>("fallback", "text")</code> respectively.
+          Any vault that stored <code>discussionModel: "text"</code> will now hit the warning-then-fallback
+          path in REQ-MODELS-5, which resolves to <code>("fallback", "text")</code> anyway — functionally
+          equivalent, one extra warning log line.</li>
+      <li>The <code>DiscussionModelSchema</code> Zod enum in <code>packages/shared/src/schemas/protocol.ts</code></li>
+      <li>The <code>DiscussionModel</code> type export from shared</li>
+    </ul>
+    <p>
+      <code>VaultConfig.discussionModel</code> and <code>EditableVaultConfig.discussionModel</code>
+      both become <code>string | undefined</code> (or <code>z.string().optional()</code> in Zod).
+      The per-vault config stores the model name as a plain string. Validation against the registry
+      happens at session-creation time, not at config-save time (REQ-MODELS-5).
+    </p>
+    <p>
+      <code>resolveDiscussionModel(config)</code> is removed. Call sites read
+      <code>config.discussionModel</code> directly, treating <code>undefined</code> as "use fallback."
+    </p>
+  </div>
+</div>
+
+<!-- REQ-MODELS-5 -->
+<div class="req" id="REQ-MODELS-5">
+  <div class="req-header" onclick="toggle('REQ-MODELS-5')">
+    <span class="req-id"><a href="#REQ-MODELS-5">REQ-MODELS-5</a></span>
+    <span class="req-text">Session creation resolves model from runtime registry</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-5">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-5">
+    <p>
+      In <code>session-manager.ts</code>, <code>resolveModelForPiAgent()</code> is rewritten to
+      look up the vault config's <code>discussionModel</code> name in the runtime registry loaded
+      by <code>global-config.ts</code>.
+    </p>
+    <p>If the name is found, its <code>{ provider, modelId }</code> is passed to <code>createPiSession()</code>.</p>
+    <p>
+      If the name is not found in the registry (unknown name, or registry is empty), a warning is
+      logged and <code>undefined</code> is passed as the <code>model</code> option to
+      <code>createPiSession()</code>. The existing fallback in <code>pi-session-factory.ts</code>
+      then applies: pi-agent tries <code>("fallback", "text")</code> and throws only if that is also
+      unavailable.
+    </p>
+    <p>
+      If <code>discussionModel</code> is unset on the vault config, the same fallback path applies
+      without logging a warning.
+    </p>
+  </div>
+</div>
+
+<!-- REQ-MODELS-6 -->
+<div class="req" id="REQ-MODELS-6">
+  <div class="req-header" onclick="toggle('REQ-MODELS-6')">
+    <span class="req-id"><a href="#REQ-MODELS-6">REQ-MODELS-6</a></span>
+    <span class="req-text">Frontend model dropdown populated from API</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-6">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-6">
+    <p>
+      The model dropdown in <code>ConfigEditorDialog.tsx</code> is populated by fetching
+      <code>GET /api/models</code> rather than from a hardcoded list. The display label for each
+      option is the model name key (e.g. <code>"opus"</code>). No user-friendly description is
+      generated — the name is the label.
+    </p>
+    <p>
+      When the API returns an empty list, the dropdown shows a single disabled option:
+      "No models configured." Saving the vault config with no model selected sets
+      <code>discussionModel</code> to <code>undefined</code>.
+    </p>
+    <p>
+      If a vault's stored <code>discussionModel</code> value is not present in the list returned
+      by the API (e.g. registry was edited since the vault was configured), the dropdown shows
+      the stored value as the currently selected option, styled to indicate it is unrecognized
+      (e.g. appended with " (unknown)"). It remains selectable and saveable without change.
+    </p>
+    <p>
+      The daemon client in <code>nextjs/lib/daemon/</code> gains a <code>getModels()</code> function.
+    </p>
+  </div>
+</div>
+
+<!-- REQ-MODELS-7 -->
+<div class="req" id="REQ-MODELS-7">
+  <div class="req-header" onclick="toggle('REQ-MODELS-7')">
+    <span class="req-id"><a href="#REQ-MODELS-7">REQ-MODELS-7</a></span>
+    <span class="req-text">Fallback is pi-agent default, not a hardcoded pair</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-7">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-7">
+    <p>
+      When no model is resolved from the registry, <code>undefined</code> is passed as the
+      <code>model</code> option to <code>createPiSession()</code>. The factory's existing fallback
+      (<code>FALLBACK_MODEL = { provider: "fallback", modelId: "text" }</code>) handles the rest.
+    </p>
+    <p>
+      The <code>FALLBACK_MODEL</code> constant in <code>pi-session-factory.ts</code> is not removed
+      or changed. It remains the last-resort safety net inside the factory, independent of whether
+      the model registry is populated.
+    </p>
+    <p>
+      No default model name is baked into the daemon. If a site wants Opus as the default,
+      it configures vaults accordingly. If all vaults are unconfigured, they all fall back to
+      the pi-agent default silently.
+    </p>
+  </div>
+</div>
+
+<!-- REQ-MODELS-8 -->
+<div class="req" id="REQ-MODELS-8">
+  <div class="req-header" onclick="toggle('REQ-MODELS-8')">
+    <span class="req-id"><a href="#REQ-MODELS-8">REQ-MODELS-8</a></span>
+    <span class="req-text">VaultInfo no longer carries discussionModel as a typed enum</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-8">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-8">
+    <p>
+      <code>VaultInfoSchema</code> in <code>packages/shared/src/schemas/protocol.ts</code> changes
+      <code>discussionModel</code> from a <code>DiscussionModelSchema</code> enum to
+      <code>z.string().optional()</code>.
+    </p>
+    <p>
+      <code>parseVault()</code> in <code>vault-manager.ts</code> passes the raw string through
+      directly rather than calling <code>resolveDiscussionModel()</code>. A vault with no
+      <code>discussionModel</code> set sends <code>undefined</code> in the VaultInfo response.
+    </p>
+    <p>
+      The frontend stores and displays the vault's <code>discussionModel</code> as a string.
+      The typed <code>DiscussionModel</code> type export from shared is removed.
+    </p>
+  </div>
+</div>
+
+<!-- REQ-MODELS-9 -->
+<div class="req" id="REQ-MODELS-9">
+  <div class="req-header" onclick="toggle('REQ-MODELS-9')">
+    <span class="req-id"><a href="#REQ-MODELS-9">REQ-MODELS-9</a></span>
+    <span class="req-text">Tests cover the new global config module</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-9">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-9">
+    <p>Unit tests for <code>daemon/src/global-config.ts</code> cover:</p>
+    <ul>
+      <li>File not found → empty registry, no throw</li>
+      <li>Malformed JSON → empty registry, no throw</li>
+      <li>Valid file → registry populated correctly</li>
+      <li>File with some invalid entries → valid entries retained, invalid entries skipped</li>
+      <li>Empty <code>models</code> object → empty registry</li>
+    </ul>
+    <p>
+      Existing session-manager tests are updated to inject a mock registry via
+      <code>configureRegistryForTesting()</code>. One existing test requires a semantic assertion
+      change: the test currently named "passes no model when vault config has no discussionModel"
+      currently asserts <code>capturedOpts.model</code> equals the Opus mapping (because
+      <code>resolveDiscussionModel</code> fills in the default). After this change, when
+      <code>discussionModel</code> is <code>undefined</code>, no registry lookup occurs and
+      <code>capturedOpts.model</code> must be <code>undefined</code>. Update the assertion
+      accordingly — this is a deliberate behavior change, not a bug.
+    </p>
+    <p>
+      A unit test for the <code>GET /api/models</code> route covers empty registry and populated registry responses.
+    </p>
+  </div>
+</div>
+
+<!-- REQ-MODELS-10 -->
+<div class="req" id="REQ-MODELS-10">
+  <div class="req-header" onclick="toggle('REQ-MODELS-10')">
+    <span class="req-id"><a href="#REQ-MODELS-10">REQ-MODELS-10</a></span>
+    <span class="req-text">Reference documentation updated</span>
+    <span class="req-status"><span class="badge badge-pending">pending</span></span>
+    <span class="chevron" id="chevron-REQ-MODELS-10">▶</span>
+  </div>
+  <div class="req-body" id="body-REQ-MODELS-10">
+    <p>The following reference docs are updated to reflect the new behavior:</p>
+    <ul>
+      <li>
+        <code>.lore/reference/_infrastructure/configuration.md</code>: add the global config file,
+        its location, format, and the new <code>GET /api/models</code> endpoint. Update the
+        <code>discussionModel</code> field description from "enum" to "string key from global registry."
+      </li>
+      <li>
+        <code>.lore/reference/think.md</code>: update the Model Selection section to describe
+        runtime registry lookup rather than enum validation.
+      </li>
+    </ul>
+  </div>
+</div>
+
+<div class="validation">
+  <h2>AI Validation</h2>
+  <p>After implementation, verify correctness by running the following checks in order.</p>
+
+  <h3>Static checks</h3>
+  <ol>
+    <li>
+      <code>bun run typecheck</code> passes with zero errors. Confirm <code>DiscussionModelLocal</code>,
+      <code>DiscussionModelSchema</code>, and <code>VALID_DISCUSSION_MODELS</code> no longer exist
+      anywhere in the codebase: <code>grep -r "DiscussionModelLocal\|DiscussionModelSchema\|VALID_DISCUSSION_MODELS\|DISCUSSION_MODEL_MAP" packages/ daemon/src/</code> → no matches.
+    </li>
+    <li>
+      <code>bun run lint</code> passes with zero errors.
+    </li>
+    <li>
+      <code>bun run test</code> passes. All existing tests that depended on the hardcoded
+      map/enum are updated (not deleted) and still test the same behavior via the injectable registry.
+    </li>
+  </ol>
+
+  <h3>Config load behavior</h3>
+  <ol start="4">
+    <li>
+      Start the daemon with no global config file present. Confirm in the logs:
+      no fatal error, warning is logged about missing config, daemon accepts requests normally.
+    </li>
+    <li>
+      Write a valid <code>memory-loop-config.json</code> with two model entries.
+      Restart the daemon. Confirm <code>GET /api/models</code> returns both entries in order.
+    </li>
+    <li>
+      Add an entry with a missing <code>modelId</code> field to the config file.
+      Restart. Confirm the bad entry is skipped (warning in logs), valid entries still present
+      in <code>GET /api/models</code>.
+    </li>
+  </ol>
+
+  <h3>Session behavior</h3>
+  <ol start="7">
+    <li>
+      Configure a vault with a model name that exists in the registry. Start a discussion session.
+      Confirm a log line from <code>[Session]</code> or <code>[PiSessionFactory]</code> contains
+      the expected <code>provider</code> and <code>modelId</code> values.
+    </li>
+    <li>
+      Configure a vault with a model name that does NOT exist in the registry. Start a discussion.
+      Confirm: a warning containing "Unknown discussion model" appears in daemon logs; session
+      completes without error (falls through to pi-agent default).
+    </li>
+    <li>
+      Leave <code>discussionModel</code> unset on a vault. Start a discussion.
+      Confirm: no "Unknown discussion model" warning in daemon logs; session completes.
+    </li>
+  </ol>
+
+  <h3>Frontend behavior</h3>
+  <ol start="10">
+    <li>
+      Open the vault settings dialog. Confirm the model dropdown options match exactly
+      the names returned by <code>GET /api/models</code>.
+    </li>
+    <li>
+      With an empty registry (<code>{ "models": {} }</code> or no config file), open the dialog.
+      Confirm the dropdown shows "No models configured." and saving leaves the vault with
+      <code>discussionModel: undefined</code>.
+    </li>
+    <li>
+      Manually set a vault's <code>discussionModel</code> in its <code>.memory-loop.json</code>
+      to a name not in the registry. Open vault settings. Confirm the stored name is shown in
+      the dropdown with an "(unknown)" indicator.
+    </li>
+  </ol>
+</div>
+
+<script>
+  function toggle(id) {
+    const body = document.getElementById('body-' + id);
+    const chevron = document.getElementById('chevron-' + id);
+    const isOpen = body.classList.contains('open');
+    body.classList.toggle('open', !isOpen);
+    chevron.classList.toggle('open', !isOpen);
+  }
+</script>
+
+</body>
+</html>

--- a/daemon/src/__tests__/global-config.test.ts
+++ b/daemon/src/__tests__/global-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  loadGlobalConfig,
+  getRegistry,
+  _resetRegistryForTesting,
+} from "../global-config";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "global-config-test-"));
+  process.env.MEMORY_LOOP_CONFIG = join(tempDir, "config.json");
+});
+
+afterEach(async () => {
+  delete process.env.MEMORY_LOOP_CONFIG;
+  _resetRegistryForTesting();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("loadGlobalConfig", () => {
+  test("file not found → registry is empty, no throw", async () => {
+    process.env.MEMORY_LOOP_CONFIG = join(tempDir, "nonexistent.json");
+
+    await loadGlobalConfig();
+
+    expect(getRegistry()).toEqual({});
+  });
+
+  test("malformed JSON → registry is empty, no throw", async () => {
+    await writeFile(join(tempDir, "config.json"), "{ this is not json }", "utf-8");
+
+    await loadGlobalConfig();
+
+    expect(getRegistry()).toEqual({});
+  });
+
+  test("valid file with 3 entries → all 3 are loaded with correct shape", async () => {
+    const config = {
+      models: {
+        fast: { provider: "anthropic", modelId: "claude-haiku-3" },
+        smart: { provider: "anthropic", modelId: "claude-sonnet-4" },
+        local: { provider: "ollama", modelId: "llama3.2" },
+      },
+    };
+    await writeFile(join(tempDir, "config.json"), JSON.stringify(config), "utf-8");
+
+    await loadGlobalConfig();
+
+    const reg = getRegistry();
+    expect(Object.keys(reg)).toHaveLength(3);
+    expect(reg["fast"]).toEqual({ provider: "anthropic", modelId: "claude-haiku-3" });
+    expect(reg["smart"]).toEqual({ provider: "anthropic", modelId: "claude-sonnet-4" });
+    expect(reg["local"]).toEqual({ provider: "ollama", modelId: "llama3.2" });
+  });
+
+  test("one malformed entry (missing modelId) + one valid → valid retained, malformed skipped", async () => {
+    const config = {
+      models: {
+        broken: { provider: "anthropic" },
+        good: { provider: "anthropic", modelId: "claude-sonnet-4" },
+      },
+    };
+    await writeFile(join(tempDir, "config.json"), JSON.stringify(config), "utf-8");
+
+    await loadGlobalConfig();
+
+    const reg = getRegistry();
+    expect(Object.keys(reg)).toHaveLength(1);
+    expect(reg["good"]).toEqual({ provider: "anthropic", modelId: "claude-sonnet-4" });
+    expect(reg["broken"]).toBeUndefined();
+  });
+
+  test("empty models object → registry is empty", async () => {
+    const config = { models: {} };
+    await writeFile(join(tempDir, "config.json"), JSON.stringify(config), "utf-8");
+
+    await loadGlobalConfig();
+
+    expect(getRegistry()).toEqual({});
+  });
+});

--- a/daemon/src/__tests__/session-manager.test.ts
+++ b/daemon/src/__tests__/session-manager.test.ts
@@ -1,11 +1,3 @@
-/**
- * Session Manager Tests
- *
- * Tests session lifecycle, resume failure handling, and piSessionPath storage.
- * Uses real filesystem (temp dirs) for vault config and session metadata.
- * Uses mock pi-session factory via configurePiSessionForTesting.
- */
-
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, writeFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -22,15 +14,15 @@ import {
   _resetPiSessionForTesting,
   type PiSessionResult,
 } from "../pi-session-factory";
+import {
+  configureRegistryForTesting,
+  _resetRegistryForTesting,
+} from "../global-config";
 import type { SessionMetadata, VaultInfo } from "@memory-loop/shared";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 
 let tempDir: string;
 
-/**
- * Minimal AgentSession mock that satisfies the interface shape.
- * Only the fields actually accessed by session-manager are needed.
- */
 function makeMockAgentSession(): AgentSession {
   return {
     sessionFile: undefined,
@@ -49,9 +41,6 @@ function makeMockAgentSession(): AgentSession {
   } as unknown as AgentSession;
 }
 
-/**
- * Builds a PiSessionResult for injection into the mock factory.
- */
 function makeMockPiSessionResult(jsonlPath: string | null = "/tmp/test.jsonl"): PiSessionResult {
   return {
     session: makeMockAgentSession(),
@@ -65,12 +54,9 @@ beforeEach(async () => {
 
 afterEach(async () => {
   _resetPiSessionForTesting();
+  _resetRegistryForTesting();
   await rm(tempDir, { recursive: true, force: true });
 });
-
-// =============================================================================
-// DISCUSSION_TOOLS constant
-// =============================================================================
 
 describe("DISCUSSION_TOOLS", () => {
   test("contains the expected pi-agent built-in tool names", () => {
@@ -80,7 +66,6 @@ describe("DISCUSSION_TOOLS", () => {
   });
 
   test("does not contain legacy SDK tool names", () => {
-    // These were in DISCUSSION_MODE_OPTIONS.allowedTools but have no pi-agent equivalent
     expect(DISCUSSION_TOOLS).not.toContain("WebFetch");
     expect(DISCUSSION_TOOLS).not.toContain("WebSearch");
     expect(DISCUSSION_TOOLS).not.toContain("Task");
@@ -88,147 +73,127 @@ describe("DISCUSSION_TOOLS", () => {
   });
 });
 
-// =============================================================================
-// createSession
-// =============================================================================
-
 describe("createSession", () => {
   const mockVault: VaultInfo = {
     id: "test-vault",
-    path: "",       // set in beforeEach
+    path: "",
     name: "Test Vault",
     contentRoot: "",
   } as VaultInfo;
+
+  let cleanupPiSession: (() => void) | undefined;
 
   beforeEach(() => {
     mockVault.path = tempDir;
     mockVault.contentRoot = tempDir;
   });
 
+  afterEach(() => {
+    cleanupPiSession?.();
+    cleanupPiSession = undefined;
+  });
+
+  function mockPiSession(factory: Parameters<typeof configurePiSessionForTesting>[0]): void {
+    cleanupPiSession = configurePiSessionForTesting(factory);
+  }
+
   test("stores piSessionPath in metadata when factory returns a path", async () => {
-    const mockResult = makeMockPiSessionResult("/tmp/pi-sessions/test.jsonl");
-    const cleanup = configurePiSessionForTesting(async () => mockResult);
+    mockPiSession(async () => makeMockPiSessionResult("/tmp/pi-sessions/test.jsonl"));
 
-    try {
-      const result = await createSession(mockVault);
+    const result = await createSession(mockVault);
 
-      const metadata = await loadSession(tempDir, result.sessionId);
-      expect(metadata).not.toBeNull();
-      expect(metadata!.piSessionPath).toBe("/tmp/pi-sessions/test.jsonl");
-    } finally {
-      cleanup();
-    }
+    const metadata = await loadSession(tempDir, result.sessionId);
+    expect(metadata).not.toBeNull();
+    expect(metadata!.piSessionPath).toBe("/tmp/pi-sessions/test.jsonl");
   });
 
   test("stores undefined piSessionPath when factory returns null jsonlPath", async () => {
-    const mockResult = makeMockPiSessionResult(null);
-    const cleanup = configurePiSessionForTesting(async () => mockResult);
+    mockPiSession(async () => makeMockPiSessionResult(null));
 
-    try {
-      const result = await createSession(mockVault);
+    const result = await createSession(mockVault);
 
-      const metadata = await loadSession(tempDir, result.sessionId);
-      expect(metadata).not.toBeNull();
-      expect(metadata!.piSessionPath).toBeUndefined();
-    } finally {
-      cleanup();
-    }
+    const metadata = await loadSession(tempDir, result.sessionId);
+    expect(metadata).not.toBeNull();
+    expect(metadata!.piSessionPath).toBeUndefined();
   });
 
   test("returns the session ID and piSession from the factory result", async () => {
     const fakeSession = makeMockAgentSession();
-    const cleanup = configurePiSessionForTesting(async () => ({
-      session: fakeSession,
-      jsonlPath: "/tmp/pi-sessions/test.jsonl",
-    }));
+    mockPiSession(async () => ({ session: fakeSession, jsonlPath: "/tmp/pi-sessions/test.jsonl" }));
 
-    try {
-      const result = await createSession(mockVault);
+    const result = await createSession(mockVault);
 
-      expect(result.sessionId).toBeTruthy();
-      expect(result.piSession).toBe(fakeSession);
-      expect(result.previousMessages).toBeUndefined();
-    } finally {
-      cleanup();
-    }
+    expect(result.sessionId).toBeTruthy();
+    expect(result.piSession).toBe(fakeSession);
+    expect(result.previousMessages).toBeUndefined();
   });
 
   test("session metadata is persisted on disk", async () => {
-    const cleanup = configurePiSessionForTesting(async () => makeMockPiSessionResult());
+    mockPiSession(async () => makeMockPiSessionResult());
 
-    try {
-      const result = await createSession(mockVault);
+    const result = await createSession(mockVault);
 
-      const loaded = await loadSession(tempDir, result.sessionId);
-      expect(loaded).not.toBeNull();
-      expect(loaded!.id).toBe(result.sessionId);
-      expect(loaded!.vaultId).toBe(mockVault.id);
-      expect(loaded!.vaultPath).toBe(tempDir);
-      expect(loaded!.messages).toEqual([]);
-    } finally {
-      cleanup();
-    }
+    const loaded = await loadSession(tempDir, result.sessionId);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.id).toBe(result.sessionId);
+    expect(loaded!.vaultId).toBe(mockVault.id);
+    expect(loaded!.vaultPath).toBe(tempDir);
+    expect(loaded!.messages).toEqual([]);
   });
 
   test("uses vault config model when present", async () => {
+    configureRegistryForTesting({
+      haiku: { provider: "anthropic", modelId: "claude-haiku-4-5" },
+    });
     await writeFile(
       join(tempDir, ".memory-loop.json"),
       JSON.stringify({ discussionModel: "haiku" })
     );
 
     let capturedOpts: { model?: { provider: string; modelId: string } } = {};
-    const cleanup = configurePiSessionForTesting(async (opts) => {
+    mockPiSession(async (opts) => {
       capturedOpts = opts;
       return makeMockPiSessionResult();
     });
 
-    try {
-      await createSession(mockVault);
-      expect(capturedOpts.model).toEqual({ provider: "anthropic", modelId: "claude-haiku-4-5" });
-    } finally {
-      cleanup();
-    }
+    await createSession(mockVault);
+    expect(capturedOpts.model).toEqual({ provider: "anthropic", modelId: "claude-haiku-4-5" });
   });
 
   test("passes no model when vault config has no discussionModel", async () => {
-    // No .memory-loop.json — uses default "opus" which maps to anthropic/claude-opus-4-5
     let capturedOpts: { model?: { provider: string; modelId: string } } = {};
-    const cleanup = configurePiSessionForTesting(async (opts) => {
+    mockPiSession(async (opts) => {
       capturedOpts = opts;
       return makeMockPiSessionResult();
     });
 
-    try {
-      await createSession(mockVault);
-      // Default is "opus"
-      expect(capturedOpts.model).toEqual({ provider: "anthropic", modelId: "claude-opus-4-5" });
-    } finally {
-      cleanup();
-    }
+    await createSession(mockVault);
+    expect(capturedOpts.model).toBeUndefined();
   });
 
   test("wraps factory errors in SessionError with SDK_ERROR code", async () => {
-    const cleanup = configurePiSessionForTesting(async () => {
+    mockPiSession(async () => {
       throw new Error("rate_limit exceeded");
     });
 
-    try {
-      await createSession(mockVault);
-      expect(true).toBe(false); // should not reach here
-    } catch (err) {
-      expect(err).toBeInstanceOf(SessionError);
-      expect((err as SessionError).code).toBe("SDK_ERROR");
-    } finally {
-      cleanup();
-    }
+    const promise = createSession(mockVault);
+    await expect(promise).rejects.toBeInstanceOf(SessionError);
+    await expect(promise).rejects.toMatchObject({ code: "SDK_ERROR" });
   });
 });
 
-// =============================================================================
-// resumeSession failure detection
-// =============================================================================
-
 describe("resumeSession failure detection", () => {
+  let cleanupPiSession: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanupPiSession?.();
+    cleanupPiSession = undefined;
+  });
+
+  function mockPiSession(factory: Parameters<typeof configurePiSessionForTesting>[0]): void {
+    cleanupPiSession = configurePiSessionForTesting(factory);
+  }
+
   async function createTestSession(sessionId: string, piSessionPath?: string): Promise<void> {
     const sessionsDir = join(tempDir, ".memory-loop", "sessions");
     await mkdir(sessionsDir, { recursive: true });
@@ -245,81 +210,56 @@ describe("resumeSession failure detection", () => {
   }
 
   test("throws RESUME_FAILED when piSessionPath is absent from metadata", async () => {
-    await createTestSession("sess-no-path"); // no piSessionPath
+    await createTestSession("sess-no-path");
 
-    try {
-      await resumeSession(tempDir, "sess-no-path");
-      expect(true).toBe(false); // should not reach here
-    } catch (err) {
-      expect(err).toBeInstanceOf(SessionError);
-      const sessionErr = err as SessionError;
-      expect(sessionErr.code).toBe("RESUME_FAILED");
-      expect(sessionErr.message).toContain("no pi-agent session path");
-    }
+    const promise = resumeSession(tempDir, "sess-no-path");
+    await expect(promise).rejects.toBeInstanceOf(SessionError);
+    await expect(promise).rejects.toMatchObject({
+      code: "RESUME_FAILED",
+      message: expect.stringContaining("no pi-agent session path"),
+    });
   });
 
   test("throws SESSION_NOT_FOUND when session metadata does not exist", async () => {
-    try {
-      await resumeSession(tempDir, "nonexistent-session");
-      expect(true).toBe(false);
-    } catch (err) {
-      expect(err).toBeInstanceOf(SessionError);
-      expect((err as SessionError).code).toBe("SESSION_NOT_FOUND");
-    }
+    const promise = resumeSession(tempDir, "nonexistent-session");
+    await expect(promise).rejects.toBeInstanceOf(SessionError);
+    await expect(promise).rejects.toMatchObject({ code: "SESSION_NOT_FOUND" });
   });
 
   test("returns piSession and previousMessages on successful resume", async () => {
     await createTestSession("sess-with-path", "/tmp/pi-sessions/existing.jsonl");
 
     const fakeSession = makeMockAgentSession();
-    const cleanup = configurePiSessionForTesting(async () => ({
+    mockPiSession(async () => ({
       session: fakeSession,
       jsonlPath: "/tmp/pi-sessions/existing.jsonl",
     }));
 
-    try {
-      const result = await resumeSession(tempDir, "sess-with-path");
-      expect(result.sessionId).toBe("sess-with-path");
-      expect(result.piSession).toBe(fakeSession);
-      expect(result.previousMessages).toEqual([]);
-    } finally {
-      cleanup();
-    }
+    const result = await resumeSession(tempDir, "sess-with-path");
+    expect(result.sessionId).toBe("sess-with-path");
+    expect(result.piSession).toBe(fakeSession);
+    expect(result.previousMessages).toEqual([]);
   });
 
   test("wraps factory errors in SessionError with SDK_ERROR code", async () => {
     await createTestSession("sess-factory-error", "/tmp/pi-sessions/missing.jsonl");
-
-    const cleanup = configurePiSessionForTesting(async () => {
+    mockPiSession(async () => {
       throw new Error("ENOENT: file not found");
     });
 
-    try {
-      await resumeSession(tempDir, "sess-factory-error");
-      expect(true).toBe(false);
-    } catch (err) {
-      expect(err).toBeInstanceOf(SessionError);
-      expect((err as SessionError).code).toBe("SDK_ERROR");
-    } finally {
-      cleanup();
-    }
+    const promise = resumeSession(tempDir, "sess-factory-error");
+    await expect(promise).rejects.toBeInstanceOf(SessionError);
+    await expect(promise).rejects.toMatchObject({ code: "SDK_ERROR" });
   });
 
   test("SessionError thrown by factory propagates unchanged", async () => {
     await createTestSession("sess-session-error", "/tmp/pi-sessions/test.jsonl");
-
-    const cleanup = configurePiSessionForTesting(async () => {
+    mockPiSession(async () => {
       throw new SessionError("internal failure", "STORAGE_ERROR");
     });
 
-    try {
-      await resumeSession(tempDir, "sess-session-error");
-      expect(true).toBe(false);
-    } catch (err) {
-      expect(err).toBeInstanceOf(SessionError);
-      expect((err as SessionError).code).toBe("STORAGE_ERROR");
-    } finally {
-      cleanup();
-    }
+    const promise = resumeSession(tempDir, "sess-session-error");
+    await expect(promise).rejects.toBeInstanceOf(SessionError);
+    await expect(promise).rejects.toMatchObject({ code: "STORAGE_ERROR" });
   });
 });

--- a/daemon/src/global-config.ts
+++ b/daemon/src/global-config.ts
@@ -1,0 +1,89 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger } from "@memory-loop/shared";
+import { getVaultsDir } from "./vault/vault-manager";
+
+const log = createLogger("GlobalConfig");
+
+export interface ModelEntry {
+  provider: string;
+  modelId: string;
+}
+
+export type ModelRegistry = Record<string, ModelEntry>;
+
+let registry: ModelRegistry = {};
+
+function getConfigFilePath(): string {
+  return (
+    process.env.MEMORY_LOOP_CONFIG ??
+    join(getVaultsDir(), "memory-loop-config.json")
+  );
+}
+
+function isModelEntry(value: unknown): value is ModelEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.provider === "string" && typeof entry.modelId === "string";
+}
+
+function parseRegistry(parsed: unknown): ModelRegistry {
+  if (typeof parsed !== "object" || parsed === null || !("models" in parsed)) {
+    return {};
+  }
+  const modelsRaw = (parsed as Record<string, unknown>).models;
+  if (typeof modelsRaw !== "object" || modelsRaw === null) {
+    return {};
+  }
+
+  const result: ModelRegistry = {};
+  for (const [name, entry] of Object.entries(modelsRaw)) {
+    if (isModelEntry(entry)) {
+      result[name] = entry;
+    } else {
+      log.warn(`Skipping invalid model entry "${name}" in global config`);
+    }
+  }
+  return result;
+}
+
+export function getRegistry(): ModelRegistry {
+  return registry;
+}
+
+export async function loadGlobalConfig(): Promise<void> {
+  const path = getConfigFilePath();
+
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch {
+    log.warn(`Global config not found at ${path}, model registry is empty`);
+    registry = {};
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    log.warn(`Global config at ${path} is not valid JSON, model registry is empty`);
+    registry = {};
+    return;
+  }
+
+  registry = parseRegistry(parsed);
+  log.info(`Loaded ${Object.keys(registry).length} model(s) from global config`);
+}
+
+export function configureRegistryForTesting(r: ModelRegistry): () => void {
+  const prev = registry;
+  registry = r;
+  return () => {
+    registry = prev;
+  };
+}
+
+export function _resetRegistryForTesting(): void {
+  registry = {};
+}

--- a/daemon/src/index.ts
+++ b/daemon/src/index.ts
@@ -1,14 +1,7 @@
-/**
- * Memory Loop daemon entry point.
- *
- * Starts the HTTP server on a Unix socket (default) or localhost TCP port.
- * Initializes SDK, vault cache, and background schedulers on boot.
- * Handles SIGTERM/SIGINT for clean shutdown.
- */
-
 import { createLogger } from "@memory-loop/shared";
 import { startServer } from "./server";
 import { initVaultCache } from "./vault";
+import { loadGlobalConfig } from "./global-config";
 import { checkCwebpAvailability } from "./files/utils/image-converter";
 import {
   startScheduler as startExtractionScheduler,
@@ -26,25 +19,21 @@ const startTime = Date.now();
 
 function getDefaultSocketPath(): string {
   const xdgRuntime = process.env.XDG_RUNTIME_DIR;
-  if (xdgRuntime) {
-    return `${xdgRuntime}/memory-loop.sock`;
-  }
-  return "/tmp/memory-loop.sock";
+  return xdgRuntime ? `${xdgRuntime}/memory-loop.sock` : "/tmp/memory-loop.sock";
 }
 
-const socketPath = process.env.DAEMON_SOCKET ?? (process.env.DAEMON_PORT ? undefined : getDefaultSocketPath());
+const socketPath =
+  process.env.DAEMON_SOCKET ?? (process.env.DAEMON_PORT ? undefined : getDefaultSocketPath());
 const port = process.env.DAEMON_PORT ? parseInt(process.env.DAEMON_PORT, 10) : undefined;
 
-// Initialize vault cache before accepting requests to prevent
-// early requests hitting an empty cache.
+// Initialize caches before accepting requests so early requests don't hit empty state.
 await initVaultCache();
+await loadGlobalConfig();
 
-// Check cwebp binary availability (REQ-IMAGE-WEBP-15)
-// Server continues regardless of result (REQ-IMAGE-WEBP-16)
+// REQ-IMAGE-WEBP-15/16: probe binary but continue regardless of result.
 await checkCwebpAvailability();
 
-// Start background schedulers. Failures are logged but don't prevent startup.
-
+// Scheduler failures are logged but don't prevent startup.
 try {
   const started = await startExtractionScheduler();
   if (started) {
@@ -58,10 +47,7 @@ try {
 
 try {
   const hour = getDiscoveryHourFromEnv();
-  await startCardDiscoveryScheduler({
-    discoveryHour: hour,
-    catchUpOnStartup: true,
-  });
+  await startCardDiscoveryScheduler({ discoveryHour: hour, catchUpOnStartup: true });
   log.info(`Card discovery scheduler started (daily at ${hour}:00)`);
 } catch (error: unknown) {
   log.error("Failed to start card discovery scheduler", error);
@@ -71,7 +57,7 @@ const server = startServer({ socketPath, port, startTime });
 
 log.info("Memory Loop daemon started");
 
-function shutdown() {
+function shutdown(): void {
   log.info("Shutting down...");
   stopExtractionScheduler();
   stopCardDiscoveryScheduler();

--- a/daemon/src/router.ts
+++ b/daemon/src/router.ts
@@ -1,9 +1,3 @@
-/**
- * Request router for the daemon API.
- *
- * Registers all routes on a Hono app instance.
- */
-
 import type { Hono } from "hono";
 import { healthHandler } from "./routes/health";
 import { helpHandler } from "./routes/help";
@@ -80,6 +74,7 @@ import {
 import { assetHandler } from "./routes/assets";
 import { setupHandler } from "./routes/setup";
 import { inspirationHandler } from "./routes/inspiration";
+import { getModelsHandler } from "./routes/models";
 import {
   chatSendHandler,
   chatStreamHandler,
@@ -97,6 +92,7 @@ export function registerRoutes(app: Hono, startTime: number): void {
   // Health and help
   app.get("/health", (c) => healthHandler(c, startTime));
   app.get("/help", (c) => helpHandler(c));
+  app.get("/models", (c) => getModelsHandler(c));
 
   // Vault routes (order matters: /vaults/help before /vaults/:id)
   app.get("/vaults", (c) => listVaultsHandler(c));

--- a/daemon/src/routes/__tests__/models.test.ts
+++ b/daemon/src/routes/__tests__/models.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { createApp } from "../../server";
+import {
+  configureRegistryForTesting,
+  _resetRegistryForTesting,
+} from "../../global-config";
+
+afterEach(() => {
+  _resetRegistryForTesting();
+});
+
+describe("GET /models", () => {
+  test("returns empty array when registry is empty", async () => {
+    const app = createApp(Date.now());
+    const response = await app.request("/models");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ models: [] });
+  });
+
+  test("returns model entries from registry", async () => {
+    configureRegistryForTesting({
+      opus: { provider: "anthropic", modelId: "claude-opus-4-7" },
+    });
+    const app = createApp(Date.now());
+    const response = await app.request("/models");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      models: [{ name: "opus", provider: "anthropic", modelId: "claude-opus-4-7" }],
+    });
+  });
+});

--- a/daemon/src/routes/models.ts
+++ b/daemon/src/routes/models.ts
@@ -1,0 +1,11 @@
+import type { Context } from "hono";
+import { getRegistry } from "../global-config";
+
+export function getModelsHandler(c: Context): Response {
+  const models = Object.entries(getRegistry()).map(([name, entry]) => ({
+    name,
+    provider: entry.provider,
+    modelId: entry.modelId,
+  }));
+  return c.json({ models });
+}

--- a/daemon/src/session-manager.ts
+++ b/daemon/src/session-manager.ts
@@ -1,9 +1,5 @@
-/**
- * Session Manager
- *
- * Manages pi-agent session lifecycle: create, resume, and persistence.
- * Sessions are stored in `.memory-loop/sessions/` as JSON files.
- */
+// Pi-agent session lifecycle: create, resume, persistence.
+// Sessions are stored in `.memory-loop/sessions/<id>.json`.
 
 import { mkdir, readFile, writeFile, readdir, unlink } from "node:fs/promises";
 import { join } from "node:path";
@@ -19,7 +15,6 @@ import {
   createLogger,
   formatDateForFilename,
   formatTimeForTimestamp,
-  resolveDiscussionModel,
   resolveRecentDiscussions,
   type ConversationMessage,
   type RecentDiscussionEntry,
@@ -37,8 +32,8 @@ import {
 import { createVaultTransferTools } from "./vault-transfer";
 import { loadVaultConfig } from "./vault/vault-config";
 import { createPiSession } from "./pi-session-factory";
+import { getRegistry } from "./global-config";
 
-// Re-export types from shared for convenience
 export type { SessionMetadata, ConversationMessage } from "@memory-loop/shared";
 
 const log = createLogger("Session");
@@ -46,55 +41,32 @@ const log = createLogger("Session");
 /**
  * Built-in tool allowlist for Discussion mode.
  *
- * Restricts to read-only operations and bash. Task/subagent tools are excluded
- * because they inherit parent tools and could bypass permission checks.
- * Web tools (WebFetch, WebSearch) are excluded because they require the
- * pi-web-access extension which is not available to daemon sessions.
+ * Read-only operations plus bash. Task/subagent tools are excluded because they
+ * inherit parent tools and could bypass permission checks. Web tools (WebFetch,
+ * WebSearch) require the pi-web-access extension, which isn't wired in here.
  */
 export const DISCUSSION_TOOLS = ["read", "grep", "bash"] as const;
 
-/**
- * Pi-agent model coordinates. Matches the `model` field accepted by createPiSession.
- */
 type PiAgentModel = { provider: string; modelId: string };
 
-/**
- * Maps vault config discussion model names to pi-agent { provider, modelId } pairs.
- * Used by createSession() and resumeSession() when building the createPiSession call.
- */
-const DISCUSSION_MODEL_MAP: Record<string, PiAgentModel> = {
-  opus: { provider: "anthropic", modelId: "claude-opus-4-5" },
-  sonnet: { provider: "anthropic", modelId: "claude-sonnet-4-5" },
-  haiku: { provider: "anthropic", modelId: "claude-haiku-4-5" },
-};
-
-/**
- * Relative path within vault for storing session metadata.
- */
 export const SESSIONS_DIR = ".memory-loop/sessions";
 
-/**
- * Error thrown when session operations fail.
- */
+type SessionErrorCode =
+  | "SESSION_NOT_FOUND"
+  | "SESSION_INVALID"
+  | "SDK_ERROR"
+  | "STORAGE_ERROR"
+  | "RESUME_FAILED";
+
 export class SessionError extends Error {
-  constructor(
-    message: string,
-    public readonly code:
-      | "SESSION_NOT_FOUND"
-      | "SESSION_INVALID"
-      | "SDK_ERROR"
-      | "STORAGE_ERROR"
-      | "RESUME_FAILED"
-  ) {
+  constructor(message: string, public readonly code: SessionErrorCode) {
     super(message);
     this.name = "SessionError";
   }
 }
 
-/**
- * Substrings that identify known SDK error categories, paired with a user-friendly
- * explanation. First match wins; order matters only if patterns overlap.
- */
+// Substrings that identify known SDK error categories, paired with user-friendly
+// explanations. First match wins; order matters only when patterns overlap.
 const SDK_ERROR_PATTERNS: ReadonlyArray<readonly [needle: string, message: string]> = [
   ["ENOENT", "Claude Code executable not found. Please ensure Claude Code is installed."],
   ["EACCES", "Permission denied. Unable to access required resources."],
@@ -105,12 +77,6 @@ const SDK_ERROR_PATTERNS: ReadonlyArray<readonly [needle: string, message: strin
   ["server_error", "Server error. The Anthropic API is temporarily unavailable."],
 ];
 
-/**
- * Maps SDK errors to user-friendly error messages.
- *
- * @param error - The error from the SDK
- * @returns User-friendly error message
- */
 export function mapSdkError(error: unknown): string {
   if (!(error instanceof Error)) {
     return "An unknown error occurred while communicating with Claude.";
@@ -119,51 +85,31 @@ export function mapSdkError(error: unknown): string {
   return match?.[1] ?? error.message;
 }
 
-/**
- * Gets the absolute path to the sessions directory for a vault.
- * Creates the directory if it doesn't exist.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @returns Absolute path to sessions directory within the vault
- */
 export async function getSessionsDir(vaultPath: string): Promise<string> {
   const sessionsDir = join(vaultPath, SESSIONS_DIR);
-
-  // Ensure directory exists
   await mkdir(sessionsDir, { recursive: true });
-
   return sessionsDir;
 }
 
 /**
- * Validates a session ID to prevent path traversal attacks.
- * Session IDs must contain only alphanumeric characters, hyphens, and underscores.
- *
- * @param sessionId - The session ID to validate
- * @returns true if valid
- * @throws SessionError if invalid
+ * Throws SessionError if `sessionId` is unsafe to use as a filesystem path
+ * segment. Returns true on success so callers can use it as a guard.
  */
 export function validateSessionId(sessionId: string): boolean {
-  // Session IDs from SDK are typically UUIDs or similar safe formats.
-  // Allow alphanumeric, hyphens, underscores, and periods (for UUIDs).
+  // Session IDs from the SDK are typically UUIDs. Permit alphanumeric,
+  // hyphen, underscore, and period (UUIDs use hyphens; periods seen in some IDs).
   // `/` and `\` cannot match this regex, so path traversal via separator is rejected here.
   const safePattern = /^[a-zA-Z0-9_.-]+$/;
 
   if (!sessionId || sessionId.length === 0) {
     throw new SessionError("Session ID cannot be empty", "SESSION_INVALID");
   }
-
   if (sessionId.length > 256) {
     throw new SessionError("Session ID is too long", "SESSION_INVALID");
   }
-
   if (!safePattern.test(sessionId)) {
-    throw new SessionError(
-      "Session ID contains invalid characters",
-      "SESSION_INVALID"
-    );
+    throw new SessionError("Session ID contains invalid characters", "SESSION_INVALID");
   }
-
   // The regex permits `.`, so `..` survives the character check; reject explicitly.
   if (sessionId.includes("..")) {
     throw new SessionError(
@@ -175,32 +121,19 @@ export function validateSessionId(sessionId: string): boolean {
   return true;
 }
 
-/**
- * Gets the absolute path to a session file.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @param sessionId - The session ID
- * @returns Absolute path to session JSON file
- * @throws SessionError if session ID is invalid
- */
-export async function getSessionFilePath(vaultPath: string, sessionId: string): Promise<string> {
+export async function getSessionFilePath(
+  vaultPath: string,
+  sessionId: string
+): Promise<string> {
   validateSessionId(sessionId);
   const sessionsDir = await getSessionsDir(vaultPath);
   return join(sessionsDir, `${sessionId}.json`);
 }
 
-/**
- * Saves session metadata to disk.
- * Uses metadata.vaultPath to determine storage location.
- *
- * @param metadata - The session metadata to save
- * @throws SessionError if storage fails
- */
 export async function saveSession(metadata: SessionMetadata): Promise<void> {
   try {
     const filePath = await getSessionFilePath(metadata.vaultPath, metadata.id);
-    const content = JSON.stringify(metadata, null, 2);
-    await writeFile(filePath, content, "utf-8");
+    await writeFile(filePath, JSON.stringify(metadata, null, 2), "utf-8");
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new SessionError(
@@ -210,14 +143,6 @@ export async function saveSession(metadata: SessionMetadata): Promise<void> {
   }
 }
 
-/**
- * Loads session metadata from disk.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @param sessionId - The session ID to load
- * @returns SessionMetadata or null if not found
- * @throws SessionError if the file exists but is invalid
- */
 export async function loadSession(
   vaultPath: string,
   sessionId: string
@@ -225,7 +150,6 @@ export async function loadSession(
   try {
     const filePath = await getSessionFilePath(vaultPath, sessionId);
 
-    // Check if file exists
     if (!(await fileExists(filePath))) {
       return null;
     }
@@ -233,15 +157,11 @@ export async function loadSession(
     const content = await readFile(filePath, "utf-8");
     const metadata = JSON.parse(content) as SessionMetadata;
 
-    // Validate required fields
     if (!metadata.id || !metadata.vaultId || !metadata.vaultPath) {
-      throw new SessionError(
-        `Session file is missing required fields`,
-        "SESSION_INVALID"
-      );
+      throw new SessionError(`Session file is missing required fields`, "SESSION_INVALID");
     }
 
-    // Migration: default messages to empty array for old session files
+    // Older session files predate the `messages` array. Default it so callers don't crash.
     metadata.messages = metadata.messages ?? [];
 
     return metadata;
@@ -250,10 +170,7 @@ export async function loadSession(
       throw error;
     }
     if (error instanceof SyntaxError) {
-      throw new SessionError(
-        `Session file contains invalid JSON`,
-        "SESSION_INVALID"
-      );
+      throw new SessionError(`Session file contains invalid JSON`, "SESSION_INVALID");
     }
     const message = error instanceof Error ? error.message : String(error);
     throw new SessionError(
@@ -263,21 +180,12 @@ export async function loadSession(
   }
 }
 
-/**
- * Deletes session metadata from disk.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @param sessionId - The session ID to delete
- * @returns true if deleted, false if not found
- */
 export async function deleteSession(vaultPath: string, sessionId: string): Promise<boolean> {
   try {
     const filePath = await getSessionFilePath(vaultPath, sessionId);
-
     if (!(await fileExists(filePath))) {
       return false;
     }
-
     await unlink(filePath);
     return true;
   } catch {
@@ -302,7 +210,6 @@ async function readSessionIds(sessionsDir: string): Promise<string[]> {
 /**
  * Loads all sessions for a vault paired with their lastActive Date, sorted
  * most-recent first. Skips files that fail to load or have invalid timestamps.
- * Returns an empty array if anything fails (e.g. sessions dir cannot be read).
  */
 async function loadSessionsSortedByActivity(
   vaultPath: string
@@ -320,7 +227,6 @@ async function loadSessionsSortedByActivity(
         if (Number.isNaN(lastActive.getTime())) continue;
         entries.push({ metadata, lastActive });
       } catch {
-        // Skip corrupted session files
         log.debug(`Skipping corrupted session file: ${sessionId}.json`);
       }
     }
@@ -332,12 +238,6 @@ async function loadSessionsSortedByActivity(
   }
 }
 
-/**
- * Lists all session IDs for a given vault.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @returns Array of session IDs
- */
 export async function listSessionsByVault(vaultPath: string): Promise<string[]> {
   try {
     const sessionsDir = await getSessionsDir(vaultPath);
@@ -347,13 +247,14 @@ export async function listSessionsByVault(vaultPath: string): Promise<string[]> 
   }
 }
 
-/**
- * Gets recent discussion sessions for a vault, sorted by last activity.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @param limit - Maximum number of discussions to return (default 5)
- * @returns Array of RecentDiscussionEntry objects, sorted by most recent first
- */
+function truncatePreview(text: string, maxLength: number): string {
+  const firstLine = text.split("\n")[0].trim();
+  if (firstLine.length <= maxLength) {
+    return firstLine;
+  }
+  return firstLine.slice(0, maxLength - 1) + "…";
+}
+
 export async function getRecentSessions(
   vaultPath: string,
   limit = 5
@@ -379,12 +280,6 @@ export async function getRecentSessions(
     });
 }
 
-/**
- * Prunes old sessions for a vault, keeping only the most recent ones.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @param keepCount - Number of sessions to keep (default: 5)
- */
 export async function pruneOldSessions(
   vaultPath: string,
   keepCount = 5
@@ -407,24 +302,6 @@ export async function pruneOldSessions(
   }
 }
 
-/**
- * Truncates a string to a maximum length, adding ellipsis if truncated.
- */
-function truncatePreview(text: string, maxLength: number): string {
-  // Take first line only
-  const firstLine = text.split("\n")[0].trim();
-  if (firstLine.length <= maxLength) {
-    return firstLine;
-  }
-  return firstLine.slice(0, maxLength - 1) + "…";
-}
-
-/**
- * Updates the lastActiveAt timestamp for a session.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @param sessionId - The session ID to update
- */
 export async function touchSession(vaultPath: string, sessionId: string): Promise<void> {
   const metadata = await loadSession(vaultPath, sessionId);
   if (metadata) {
@@ -433,28 +310,11 @@ export async function touchSession(vaultPath: string, sessionId: string): Promis
   }
 }
 
-/**
- * Gets the most recent session ID for a vault, if one exists.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @returns The most recent session ID, or null if no session exists for this vault
- */
-export async function getSessionForVault(
-  vaultPath: string
-): Promise<string | null> {
+export async function getSessionForVault(vaultPath: string): Promise<string | null> {
   const entries = await loadSessionsSortedByActivity(vaultPath);
   return entries[0]?.metadata.id ?? null;
 }
 
-/**
- * Appends a message to a session's conversation history.
- * Also writes to the transcript file for Obsidian searchability.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @param sessionId - The session ID
- * @param message - The message to append
- * @throws SessionError if session not found
- */
 export async function appendMessage(
   vaultPath: string,
   sessionId: string,
@@ -464,16 +324,13 @@ export async function appendMessage(
   if (!metadata) {
     const filePath = await getSessionFilePath(vaultPath, sessionId);
     log.error(`Session file not found at: ${filePath}`);
-    throw new SessionError(
-      `Session "${sessionId}" not found`,
-      "SESSION_NOT_FOUND"
-    );
+    throw new SessionError(`Session "${sessionId}" not found`, "SESSION_NOT_FOUND");
   }
 
   metadata.messages.push(message);
   metadata.lastActiveAt = new Date().toISOString();
 
-  // Initialize transcript on first user message
+  // Initialize transcript on the first user message of a session.
   if (message.role === "user" && !metadata.transcriptPath) {
     try {
       const vault = await getVaultById(metadata.vaultId);
@@ -490,14 +347,13 @@ export async function appendMessage(
         log.warn(`Vault "${metadata.vaultId}" not found, skipping transcript`);
       }
     } catch (error) {
-      // Log error but don't fail the message append
+      // Transcript is best-effort; never block message append on it.
       log.warn("Failed to initialize transcript:", error);
     }
   }
 
   await saveSession(metadata);
 
-  // Append to transcript if path exists
   if (metadata.transcriptPath) {
     try {
       const timestamp = new Date(message.timestamp);
@@ -507,7 +363,6 @@ export async function appendMessage(
           : formatAssistantMessage(message.content, message.toolInvocations, timestamp);
       await appendToTranscript(metadata.transcriptPath, formatted);
     } catch (error) {
-      // Log error but don't fail the message append
       log.warn("Failed to append to transcript:", error);
     }
   }
@@ -515,32 +370,20 @@ export async function appendMessage(
   log.info(`Appended ${message.role} message to session ${sessionId.slice(0, 8)}...`);
 }
 
-/**
- * Result of a session creation or resume, wrapping the pi-agent session.
- */
 export interface SessionQueryResult {
-  /** The session ID (locally generated UUID) */
   sessionId: string;
-  /** The live pi-agent session for streaming and control */
   piSession: AgentSession;
-  /** Conversation history from prior turns (populated on resume) */
+  /** Conversation history from prior turns (populated on resume). */
   previousMessages?: ConversationMessage[];
 }
 
-/**
- * Callback to request tool permission from the user.
- * Returns true if the user allows the tool, false otherwise.
- */
+/** Returns true to allow the tool, false to block it. */
 export type ToolPermissionCallback = (
   toolUseId: string,
   toolName: string,
   input: unknown
 ) => Promise<boolean>;
 
-/**
- * Schema for a single question in an AskUserQuestion request.
- * Matches the AskUserQuestionItemSchema from the shared protocol.
- */
 export interface AskUserQuestionItem {
   question: string;
   header: string;
@@ -548,20 +391,12 @@ export interface AskUserQuestionItem {
   multiSelect: boolean;
 }
 
-/**
- * Callback to handle AskUserQuestion tool.
- * Receives questions and returns a map of question text to selected answer(s).
- */
+/** Receives questions and returns a map of question text to selected answer(s). */
 export type AskUserQuestionCallback = (
   toolUseId: string,
   questions: AskUserQuestionItem[]
 ) => Promise<Record<string, string>>;
 
-/**
- * Builds a pi-agent ExtensionFactory that gates every tool call through
- * the provided ToolPermissionCallback. When the user denies permission,
- * the factory returns a block result so the tool is not executed.
- */
 function createPermissionExtension(callback: ToolPermissionCallback): ExtensionFactory {
   return (pi) => {
     pi.on("tool_call", async (event) => {
@@ -570,7 +405,6 @@ function createPermissionExtension(callback: ToolPermissionCallback): ExtensionF
         if (!allowed) {
           return { block: true, reason: `User denied permission for ${event.toolName}` };
         }
-        // Returning undefined allows the tool to proceed
         return undefined;
       } catch (err) {
         log.error(`Permission callback threw for ${event.toolName} — blocking tool call`, err);
@@ -580,10 +414,6 @@ function createPermissionExtension(callback: ToolPermissionCallback): ExtensionF
   };
 }
 
-/**
- * Builds the AskUserQuestion custom tool definition, wiring the provided
- * callback so the agent can ask the user structured questions during a turn.
- */
 function createAskUserQuestionTool(callback: AskUserQuestionCallback): ToolDefinition {
   return defineTool({
     name: "AskUserQuestion",
@@ -601,7 +431,9 @@ function createAskUserQuestionTool(callback: AskUserQuestionCallback): ToolDefin
             }),
             { description: "Available options (2-4)" }
           ),
-          multiSelect: Type.Boolean({ description: "Whether multiple options can be selected" }),
+          multiSelect: Type.Boolean({
+            description: "Whether multiple options can be selected",
+          }),
         }),
         { description: "List of questions to ask the user" }
       ),
@@ -616,27 +448,23 @@ function createAskUserQuestionTool(callback: AskUserQuestionCallback): ToolDefin
   });
 }
 
-/**
- * Maps a vault config discussion model name to a pi-agent { provider, modelId } pair.
- * Returns undefined if the model name is not recognised (triggers fallback in the factory).
- */
 function resolveModelForPiAgent(
   vaultPath: string,
   config: Awaited<ReturnType<typeof loadVaultConfig>>
 ): PiAgentModel | undefined {
-  const modelName = resolveDiscussionModel(config);
-  const mapped = DISCUSSION_MODEL_MAP[modelName];
-  if (!mapped) {
-    log.warn(`Unknown discussion model "${modelName}" for vault at ${vaultPath}, using pi-agent fallback`);
+  const modelName = config.discussionModel;
+  if (!modelName) return undefined;
+
+  const entry = getRegistry()[modelName];
+  if (!entry) {
+    log.warn(
+      `Unknown discussion model "${modelName}" for vault at ${vaultPath}, using pi-agent fallback`
+    );
+    return undefined;
   }
-  return mapped;
+  return entry;
 }
 
-/**
- * Builds the discussion extension factories and custom tools shared by
- * createSession() and resumeSession(). Both flows wire the same callbacks
- * (tool permission gating, AskUserQuestion) and the same vault-transfer tools.
- */
 function buildSessionExtensions(
   requestToolPermission: ToolPermissionCallback | undefined,
   askUserQuestion: AskUserQuestionCallback | undefined
@@ -657,13 +485,10 @@ function buildSessionExtensions(
 }
 
 /**
- * Opens a pi-agent session for the given vault using either a fresh `create`
- * or a `resume` SessionManager. Loads vault config, resolves the discussion
- * model, wires extensions, and logs the chosen tooling. Used by both
- * createSession() and resumeSession() so the setup stays in one place.
- *
- * Returns the loaded config alongside the pi-session result so callers don't
- * need a second loadVaultConfig() call (e.g. createSession uses it for pruning).
+ * Opens a pi-agent session for the given vault. Used by createSession() (with a
+ * fresh SessionManager) and resumeSession() (with an open one) so the wiring stays
+ * in one place. Returns the loaded vault config alongside the result so callers
+ * don't need a second loadVaultConfig() call.
  */
 async function openPiSessionForVault(
   vaultPath: string,
@@ -701,9 +526,8 @@ async function openPiSessionForVault(
 }
 
 /**
- * Wraps non-SessionError exceptions in a SessionError(SDK_ERROR). Logs context
- * via the supplied `operation` label. Re-throws SessionError instances as-is so
- * their original codes (e.g. RESUME_FAILED) survive.
+ * Wraps non-SessionError exceptions in a SessionError(SDK_ERROR). Re-throws
+ * existing SessionError instances unchanged so codes like RESUME_FAILED survive.
  */
 function wrapSdkFailure(operation: string, error: unknown): never {
   log.error(`Failed to ${operation}`, error);
@@ -713,14 +537,6 @@ function wrapSdkFailure(operation: string, error: unknown): never {
   throw new SessionError(mapSdkError(error), "SDK_ERROR");
 }
 
-/**
- * Creates a new pi-agent session for a vault.
- *
- * @param vault - The vault to create a session for
- * @param requestToolPermission - Optional callback to request tool permission from user
- * @param askUserQuestion - Optional callback to handle AskUserQuestion tool
- * @returns SessionQueryResult with session ID and pi-agent session
- */
 export async function createSession(
   vault: VaultInfo,
   requestToolPermission?: ToolPermissionCallback,
@@ -737,10 +553,7 @@ export async function createSession(
       askUserQuestion
     );
 
-    // Generate a locally-owned UUID — no longer extracted from the first event.
     const sessionId = crypto.randomUUID();
-
-    // Persist session metadata, including the JSONL path for future resume.
     const now = new Date().toISOString();
     const metadata: SessionMetadata = {
       id: sessionId,
@@ -752,9 +565,11 @@ export async function createSession(
       piSessionPath: result.jsonlPath ?? undefined,
     };
     await saveSession(metadata);
-    log.info(`Session created: ${sessionId}, piSessionPath=${result.jsonlPath ?? "(none)"}`);
+    log.info(
+      `Session created: ${sessionId}, piSessionPath=${result.jsonlPath ?? "(none)"}`
+    );
 
-    // Prune old sessions in background (non-blocking, errors logged internally)
+    // Prune in background; errors are logged inside pruneOldSessions.
     void pruneOldSessions(vault.path, resolveRecentDiscussions(config));
 
     return {
@@ -766,15 +581,6 @@ export async function createSession(
   }
 }
 
-/**
- * Resumes an existing pi-agent session.
- *
- * @param vaultPath - Absolute path to the vault root directory
- * @param sessionId - The session ID to resume
- * @param requestToolPermission - Optional callback to request tool permission from user
- * @param askUserQuestion - Optional callback to handle AskUserQuestion tool
- * @returns SessionQueryResult with session ID and pi-agent session
- */
 export async function resumeSession(
   vaultPath: string,
   sessionId: string,
@@ -783,15 +589,11 @@ export async function resumeSession(
 ): Promise<SessionQueryResult> {
   log.info(`Resuming session: ${sessionId}`);
 
-  // Load existing session metadata
   const metadata = await loadSession(vaultPath, sessionId);
 
   if (!metadata) {
     log.warn(`Session not found: ${sessionId}`);
-    throw new SessionError(
-      `Session "${sessionId}" not found`,
-      "SESSION_NOT_FOUND"
-    );
+    throw new SessionError(`Session "${sessionId}" not found`, "SESSION_NOT_FOUND");
   }
 
   log.info(`Session metadata loaded: vault=${metadata.vaultId}`);
@@ -813,7 +615,6 @@ export async function resumeSession(
       askUserQuestion
     );
 
-    // Update last-active timestamp
     metadata.lastActiveAt = new Date().toISOString();
     await saveSession(metadata);
 

--- a/daemon/src/vault/__tests__/vault-config.test.ts
+++ b/daemon/src/vault/__tests__/vault-config.test.ts
@@ -1,11 +1,6 @@
-/**
- * Vault Configuration Tests
- *
- * Tests for per-vault configuration loading and path resolution.
- */
-
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdir, rm, writeFile, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -24,10 +19,8 @@ import {
   DEFAULT_PROMPTS_PER_GENERATION,
   DEFAULT_MAX_POOL_SIZE,
   DEFAULT_QUOTES_PER_WEEK,
-  DEFAULT_DISCUSSION_MODEL,
   DEFAULT_CARDS_ENABLED,
   DEFAULT_VI_MODE,
-  VALID_DISCUSSION_MODELS,
   resolveMetadataPath,
   resolveGoalsPath,
   resolveContextualPromptsPath,
@@ -39,7 +32,6 @@ import {
   resolveQuotesPerWeek,
   resolveBadges,
   resolvePinnedAssets,
-  resolveDiscussionModel,
   resolveCardsEnabled,
   resolveViMode,
   slashCommandsEqual,
@@ -47,7 +39,6 @@ import {
 import { resolveContentRoot } from "@memory-loop/shared/server";
 import type { VaultConfig, SlashCommand, EditableVaultConfig } from "@memory-loop/shared";
 
-// Test helpers
 async function writeConfig(dir: string, data: unknown): Promise<void> {
   await writeFile(join(dir, CONFIG_FILE_NAME), JSON.stringify(data));
 }
@@ -69,11 +60,7 @@ describe("vault-config", () => {
   });
 
   afterEach(async () => {
-    try {
-      await rm(testDir, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
-    }
+    await rm(testDir, { recursive: true, force: true }).catch(() => {});
   });
 
   describe("exported constants", () => {
@@ -85,10 +72,8 @@ describe("vault-config", () => {
       expect(DEFAULT_PROMPTS_PER_GENERATION).toBe(5);
       expect(DEFAULT_MAX_POOL_SIZE).toBe(50);
       expect(DEFAULT_QUOTES_PER_WEEK).toBe(1);
-      expect(DEFAULT_DISCUSSION_MODEL).toBe("opus");
       expect(DEFAULT_CARDS_ENABLED).toBe(true);
       expect(DEFAULT_VI_MODE).toBe(false);
-      expect(VALID_DISCUSSION_MODELS).toEqual(["opus", "sonnet", "haiku"]);
     });
   });
 
@@ -242,8 +227,8 @@ describe("vault-config", () => {
     });
 
     describe("discussionModel", () => {
-      test.each(["opus", "sonnet", "haiku"] as const)(
-        "loads valid discussionModel %s",
+      test.each(["opus", "sonnet", "haiku", "custom-model", "my-provider/my-model"])(
+        "loads discussionModel %s",
         async (model) => {
           await writeConfig(testDir, { discussionModel: model });
 
@@ -251,13 +236,6 @@ describe("vault-config", () => {
           expect(config.discussionModel).toBe(model);
         }
       );
-
-      test("ignores invalid discussionModel value", async () => {
-        await writeConfig(testDir, { discussionModel: "invalid-model" });
-
-        const config = await loadVaultConfig(testDir);
-        expect(config.discussionModel).toBeUndefined();
-      });
 
       test("ignores non-string discussionModel value", async () => {
         await writeConfig(testDir, { discussionModel: 123 });
@@ -327,9 +305,9 @@ describe("vault-config", () => {
           badges: [
             { text: "Valid", color: "blue" },
             { text: "Invalid Color", color: "pink" },
-            { color: "red" }, // missing text
-            { text: "", color: "green" }, // empty text
-            { text: "No Color" }, // missing color
+            { color: "red" },
+            { text: "", color: "green" },
+            { text: "No Color" },
             null,
             "string",
             42,
@@ -494,17 +472,6 @@ describe("vault-config", () => {
       expect(resolveQuotesPerWeek({})).toBe(DEFAULT_QUOTES_PER_WEEK);
       expect(resolveQuotesPerWeek({ quotesPerWeek: undefined })).toBe(DEFAULT_QUOTES_PER_WEEK);
       expect(resolveQuotesPerWeek({ quotesPerWeek: 3 })).toBe(3);
-    });
-  });
-
-  describe("resolveDiscussionModel", () => {
-    test("returns default when not configured", () => {
-      expect(resolveDiscussionModel({})).toBe(DEFAULT_DISCUSSION_MODEL);
-      expect(resolveDiscussionModel({ discussionModel: undefined })).toBe(DEFAULT_DISCUSSION_MODEL);
-    });
-
-    test.each(["opus", "sonnet", "haiku"] as const)("returns configured model %s", (model) => {
-      expect(resolveDiscussionModel({ discussionModel: model })).toBe(model);
     });
   });
 
@@ -865,30 +832,14 @@ describe("vault-config", () => {
       const result = await saveVaultConfig(testDir, {});
 
       expect(result).toEqual({ success: true });
-
-      const configPath = join(testDir, CONFIG_FILE_NAME);
-      let fileExists = true;
-      try {
-        await readFile(configPath, "utf-8");
-      } catch {
-        fileExists = false;
-      }
-      expect(fileExists).toBe(false);
+      expect(existsSync(join(testDir, CONFIG_FILE_NAME))).toBe(false);
     });
 
     test("does NOT create file if only empty badges array provided", async () => {
       const result = await saveVaultConfig(testDir, { badges: [] });
 
       expect(result).toEqual({ success: true });
-
-      const configPath = join(testDir, CONFIG_FILE_NAME);
-      let fileExists = true;
-      try {
-        await readFile(configPath, "utf-8");
-      } catch {
-        fileExists = false;
-      }
-      expect(fileExists).toBe(false);
+      expect(existsSync(join(testDir, CONFIG_FILE_NAME))).toBe(false);
     });
 
     test("merges only editable fields over existing config", async () => {

--- a/daemon/src/vault/vault-config.ts
+++ b/daemon/src/vault/vault-config.ts
@@ -1,27 +1,64 @@
-/**
- * Vault Configuration I/O (Daemon)
- *
- * Filesystem operations for loading and saving vault configuration.
- * Types and resolver functions are in @memory-loop/shared.
- */
-
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
-import type { SlashCommand, Badge, BadgeColor, EditableVaultConfig, VaultConfig, SaveConfigResult } from "@memory-loop/shared";
+import type {
+  SlashCommand,
+  Badge,
+  BadgeColor,
+  EditableVaultConfig,
+  VaultConfig,
+  SaveConfigResult,
+} from "@memory-loop/shared";
 import {
   createLogger,
   CONFIG_FILE_NAME,
   SLASH_COMMANDS_FILE,
-  VALID_DISCUSSION_MODELS,
   VALID_BADGE_COLORS,
 } from "@memory-loop/shared";
 import { fileExists } from "@memory-loop/shared/server";
 
 const log = createLogger("VaultConfig");
 
+export type { SaveConfigResult };
+
 /**
- * Loads vault configuration from .memory-loop.json if it exists.
+ * Reads a JSON file and returns its parsed object form. Returns an empty object
+ * if the file is missing, unreadable, or doesn't parse to a plain object.
  */
+async function readJsonObject(path: string): Promise<Record<string, unknown>> {
+  if (!(await fileExists(path))) {
+    return {};
+  }
+  try {
+    const content = await readFile(path, "utf-8");
+    const parsed = JSON.parse(content) as unknown;
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Fall through to empty object below.
+  }
+  return {};
+}
+
+async function writeJsonFile(path: string, data: unknown): Promise<void> {
+  await writeFile(path, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}
+
+function isPositiveInt(value: unknown): value is number {
+  return typeof value === "number" && value > 0;
+}
+
+function isBadge(value: unknown): value is Badge {
+  if (typeof value !== "object" || value === null) return false;
+  const badge = value as Record<string, unknown>;
+  return (
+    typeof badge.text === "string" &&
+    badge.text !== "" &&
+    typeof badge.color === "string" &&
+    VALID_BADGE_COLORS.includes(badge.color as BadgeColor)
+  );
+}
+
 export async function loadVaultConfig(vaultPath: string): Promise<VaultConfig> {
   const configPath = join(vaultPath, CONFIG_FILE_NAME);
 
@@ -29,83 +66,72 @@ export async function loadVaultConfig(vaultPath: string): Promise<VaultConfig> {
     return {};
   }
 
+  let obj: Record<string, unknown>;
   try {
     const content = await readFile(configPath, "utf-8");
     const parsed = JSON.parse(content) as unknown;
-
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       log.warn(`Invalid config format in ${configPath}: expected object`);
       return {};
     }
-
-    const config: VaultConfig = {};
-    const obj = parsed as Record<string, unknown>;
-
-    if (typeof obj.title === "string") config.title = obj.title;
-    if (typeof obj.subtitle === "string") config.subtitle = obj.subtitle;
-    if (typeof obj.contentRoot === "string") config.contentRoot = obj.contentRoot;
-    if (typeof obj.inboxPath === "string") config.inboxPath = obj.inboxPath;
-    if (typeof obj.metadataPath === "string") config.metadataPath = obj.metadataPath;
-    if (typeof obj.projectPath === "string") config.projectPath = obj.projectPath;
-    if (typeof obj.areaPath === "string") config.areaPath = obj.areaPath;
-    if (typeof obj.attachmentPath === "string") config.attachmentPath = obj.attachmentPath;
-
-    if (typeof obj.promptsPerGeneration === "number" && obj.promptsPerGeneration > 0) {
-      config.promptsPerGeneration = Math.floor(obj.promptsPerGeneration);
-    }
-    if (typeof obj.maxPoolSize === "number" && obj.maxPoolSize > 0) {
-      config.maxPoolSize = Math.floor(obj.maxPoolSize);
-    }
-    if (typeof obj.quotesPerWeek === "number" && obj.quotesPerWeek > 0) {
-      config.quotesPerWeek = Math.floor(obj.quotesPerWeek);
-    }
-    if (typeof obj.recentCaptures === "number" && obj.recentCaptures > 0) {
-      config.recentCaptures = Math.floor(obj.recentCaptures);
-    }
-    if (typeof obj.recentDiscussions === "number" && obj.recentDiscussions > 0) {
-      config.recentDiscussions = Math.floor(obj.recentDiscussions);
-    }
-
-    if (
-      typeof obj.discussionModel === "string" &&
-      VALID_DISCUSSION_MODELS.includes(obj.discussionModel as typeof VALID_DISCUSSION_MODELS[number])
-    ) {
-      config.discussionModel = obj.discussionModel;
-    }
-
-    if (typeof obj.order === "number" && Number.isFinite(obj.order)) {
-      config.order = obj.order;
-    }
-    if (typeof obj.cardsEnabled === "boolean") config.cardsEnabled = obj.cardsEnabled;
-    if (typeof obj.viMode === "boolean") config.viMode = obj.viMode;
-
-    if (Array.isArray(obj.badges)) {
-      config.badges = obj.badges.filter(
-        (badge): badge is Badge =>
-          typeof badge === "object" &&
-          badge !== null &&
-          typeof (badge as Record<string, unknown>).text === "string" &&
-          (badge as Record<string, unknown>).text !== "" &&
-          typeof (badge as Record<string, unknown>).color === "string" &&
-          VALID_BADGE_COLORS.includes((badge as Record<string, unknown>).color as BadgeColor)
-      );
-    }
-
-    if (Array.isArray(obj.pinnedAssets)) {
-      config.pinnedAssets = obj.pinnedAssets.filter(
-        (path): path is string => typeof path === "string" && path.length > 0
-      );
-    }
-
-    return config;
+    obj = parsed as Record<string, unknown>;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log.warn(`Failed to load config from ${configPath}: ${message}`);
     return {};
   }
-}
 
-export type { SaveConfigResult };
+  const config: VaultConfig = {};
+
+  const stringFields = [
+    "title",
+    "subtitle",
+    "contentRoot",
+    "inboxPath",
+    "metadataPath",
+    "projectPath",
+    "areaPath",
+    "attachmentPath",
+    "discussionModel",
+  ] as const;
+  for (const field of stringFields) {
+    if (typeof obj[field] === "string") {
+      (config as Record<string, unknown>)[field] = obj[field];
+    }
+  }
+
+  const positiveIntFields = [
+    "promptsPerGeneration",
+    "maxPoolSize",
+    "quotesPerWeek",
+    "recentCaptures",
+    "recentDiscussions",
+  ] as const;
+  for (const field of positiveIntFields) {
+    const value = obj[field];
+    if (isPositiveInt(value)) {
+      (config as Record<string, number>)[field] = Math.floor(value);
+    }
+  }
+
+  if (typeof obj.order === "number" && Number.isFinite(obj.order)) {
+    config.order = obj.order;
+  }
+  if (typeof obj.cardsEnabled === "boolean") config.cardsEnabled = obj.cardsEnabled;
+  if (typeof obj.viMode === "boolean") config.viMode = obj.viMode;
+
+  if (Array.isArray(obj.badges)) {
+    config.badges = obj.badges.filter(isBadge);
+  }
+
+  if (Array.isArray(obj.pinnedAssets)) {
+    config.pinnedAssets = obj.pinnedAssets.filter(
+      (path): path is string => typeof path === "string" && path.length > 0
+    );
+  }
+
+  return config;
+}
 
 function isAllDefaults(config: EditableVaultConfig): boolean {
   return (
@@ -138,37 +164,19 @@ export async function saveVaultConfig(
       return { success: true };
     }
 
-    let existingConfig: Record<string, unknown> = {};
+    const mergedConfig: Record<string, unknown> = configExists
+      ? await readJsonObject(configPath)
+      : {};
 
-    if (configExists) {
-      try {
-        const content = await readFile(configPath, "utf-8");
-        const parsed = JSON.parse(content) as unknown;
-        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-          existingConfig = parsed as Record<string, unknown>;
-        }
-      } catch {
-        log.warn(`Could not parse existing config at ${configPath}, will overwrite`);
+    // Copy every defined field from the editable config onto the merged config.
+    // Undefined fields are skipped so existing values survive partial updates.
+    for (const [key, value] of Object.entries(editableConfig)) {
+      if (value !== undefined) {
+        mergedConfig[key] = value;
       }
     }
 
-    const mergedConfig: Record<string, unknown> = { ...existingConfig };
-
-    if (editableConfig.title !== undefined) mergedConfig.title = editableConfig.title;
-    if (editableConfig.subtitle !== undefined) mergedConfig.subtitle = editableConfig.subtitle;
-    if (editableConfig.discussionModel !== undefined) mergedConfig.discussionModel = editableConfig.discussionModel;
-    if (editableConfig.promptsPerGeneration !== undefined) mergedConfig.promptsPerGeneration = editableConfig.promptsPerGeneration;
-    if (editableConfig.maxPoolSize !== undefined) mergedConfig.maxPoolSize = editableConfig.maxPoolSize;
-    if (editableConfig.quotesPerWeek !== undefined) mergedConfig.quotesPerWeek = editableConfig.quotesPerWeek;
-    if (editableConfig.recentCaptures !== undefined) mergedConfig.recentCaptures = editableConfig.recentCaptures;
-    if (editableConfig.recentDiscussions !== undefined) mergedConfig.recentDiscussions = editableConfig.recentDiscussions;
-    if (editableConfig.badges !== undefined) mergedConfig.badges = editableConfig.badges;
-    if (editableConfig.order !== undefined) mergedConfig.order = editableConfig.order;
-    if (editableConfig.cardsEnabled !== undefined) mergedConfig.cardsEnabled = editableConfig.cardsEnabled;
-    if (editableConfig.viMode !== undefined) mergedConfig.viMode = editableConfig.viMode;
-
-    await writeFile(configPath, JSON.stringify(mergedConfig, null, 2) + "\n", "utf-8");
-
+    await writeJsonFile(configPath, mergedConfig);
     log.info(`Saved vault config to ${configPath}`);
     return { success: true };
   } catch (error) {
@@ -178,29 +186,11 @@ export async function saveVaultConfig(
   }
 }
 
-export async function savePinnedAssets(
-  vaultPath: string,
-  paths: string[]
-): Promise<void> {
+export async function savePinnedAssets(vaultPath: string, paths: string[]): Promise<void> {
   const configPath = join(vaultPath, CONFIG_FILE_NAME);
-
-  let existingConfig: Record<string, unknown> = {};
-
-  if (await fileExists(configPath)) {
-    try {
-      const content = await readFile(configPath, "utf-8");
-      const parsed = JSON.parse(content) as unknown;
-      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-        existingConfig = parsed as Record<string, unknown>;
-      }
-    } catch {
-      // If we can't read existing config, start fresh
-    }
-  }
-
+  const existingConfig = await readJsonObject(configPath);
   existingConfig.pinnedAssets = paths;
-
-  await writeFile(configPath, JSON.stringify(existingConfig, null, 2) + "\n", "utf-8");
+  await writeJsonFile(configPath, existingConfig);
   log.info(`Saved ${paths.length} pinned assets to ${configPath}`);
 }
 
@@ -249,9 +239,7 @@ export async function saveSlashCommands(
   commands: SlashCommand[]
 ): Promise<void> {
   const cachePath = join(vaultPath, SLASH_COMMANDS_FILE);
-
   await mkdir(dirname(cachePath), { recursive: true });
-
-  await writeFile(cachePath, JSON.stringify(commands, null, 2) + "\n", "utf-8");
+  await writeJsonFile(cachePath, commands);
   log.info(`Cached ${commands.length} slash commands to ${cachePath}`);
 }

--- a/daemon/src/vault/vault-manager.ts
+++ b/daemon/src/vault/vault-manager.ts
@@ -1,9 +1,4 @@
-/**
- * Vault Manager (Daemon)
- *
- * Vault discovery, creation, and filesystem operations.
- * This is the authoritative implementation per REQ-DAB-1.
- */
+// Vault discovery, creation, and filesystem operations. Authoritative per REQ-DAB-1.
 
 import { readdir, readFile, mkdir, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
@@ -23,7 +18,6 @@ import {
   resolveQuotesPerWeek,
   resolveRecentCaptures,
   resolveRecentDiscussions,
-  resolveDiscussionModel,
   resolveBadges,
   resolveOrder,
   resolveCardsEnabled,
@@ -43,10 +37,6 @@ export class VaultsDirError extends Error {
 
 export const DEFAULT_VAULTS_DIR_NAME = "vaults";
 
-/**
- * Gets the daemon's root directory.
- * Uses DAEMON_ROOT env var or falls back to the daemon package's parent directory.
- */
 function getDaemonRoot(): string {
   if (process.env.DAEMON_ROOT) {
     return process.env.DAEMON_ROOT;
@@ -126,6 +116,7 @@ export async function parseVault(
   const config = await loadVaultConfig(vaultPath);
   const contentRoot = resolveContentRoot(vaultPath, config);
 
+  // Resolution order: vault config > CLAUDE.md extraction > directory name.
   let name = dirName;
   let subtitle: string | undefined;
   try {
@@ -136,7 +127,7 @@ export async function parseVault(
       subtitle = extracted.subtitle;
     }
   } catch {
-    // Failed to read CLAUDE.md, use directory name
+    // Fall through; use directory name.
   }
 
   if (config.title) {
@@ -166,7 +157,7 @@ export async function parseVault(
     goalsPath,
     attachmentPath,
     setupComplete,
-    discussionModel: resolveDiscussionModel(config),
+    discussionModel: config.discussionModel,
     promptsPerGeneration: resolvePromptsPerGeneration(config),
     maxPoolSize: resolveMaxPoolSize(config),
     quotesPerWeek: resolveQuotesPerWeek(config),

--- a/nextjs/app/api/models/route.ts
+++ b/nextjs/app/api/models/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+import { daemonFetch } from "@/lib/daemon/fetch";
+
+export async function GET() {
+  const res = await daemonFetch("/models");
+  return NextResponse.json(await res.json(), { status: res.status });
+}

--- a/nextjs/components/vault/ConfigEditorDialog.tsx
+++ b/nextjs/components/vault/ConfigEditorDialog.tsx
@@ -1,9 +1,6 @@
 /**
- * ConfigEditorDialog Component
- *
- * Portal-based modal dialog for editing vault configuration settings.
- * Displays a form with all editable config fields and handles change detection.
- * Uses ConfirmDialog for unsaved changes confirmation.
+ * Portal-based modal dialog for editing vault configuration. Uses
+ * ConfirmDialog for unsaved-changes confirmation.
  */
 
 import {
@@ -16,11 +13,10 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { ConfirmDialog } from "../shared/ConfirmDialog";
+import type { ModelEntry } from "@/lib/daemon/models";
 import "./ConfigEditorDialog.css";
 
-/**
- * Valid badge colors (matches BadgeColorSchema from protocol.ts)
- */
+// Matches BadgeColorSchema from packages/shared protocol.
 export type BadgeColor =
   | "black"
   | "purple"
@@ -31,31 +27,25 @@ export type BadgeColor =
   | "green"
   | "yellow";
 
-/**
- * Badge configuration
- */
 export interface Badge {
   text: string;
   color: BadgeColor;
 }
 
-/**
- * Editable vault configuration fields.
- * This represents the subset of vault config that users can modify.
- */
+// Subset of vault config users can modify. Bounds enforced by sliders/inputs.
 export interface EditableVaultConfig {
   title?: string;
   subtitle?: string;
-  discussionModel?: "opus" | "sonnet" | "haiku";
+  discussionModel?: string;
   promptsPerGeneration?: number; // 1-20
   maxPoolSize?: number; // 10-200
   quotesPerWeek?: number; // 0-7
   recentCaptures?: number; // 1-20
   recentDiscussions?: number; // 1-20
   badges?: Badge[]; // max 5
-  order?: number; // display order on vault selection screen
-  cardsEnabled?: boolean; // whether spaced repetition card discovery is enabled
-  viMode?: boolean; // whether vi-style editing is enabled in Pair Writing
+  order?: number;
+  cardsEnabled?: boolean;
+  viMode?: boolean;
 }
 
 export interface ConfigEditorDialogProps {
@@ -63,68 +53,41 @@ export interface ConfigEditorDialogProps {
   initialConfig: EditableVaultConfig;
   onSave: (config: EditableVaultConfig) => void | Promise<void>;
   onCancel: () => void;
-  /** Show loading indicator during save (TASK-010) */
   isSaving?: boolean;
-  /** Show inline error message if save failed (TASK-010) */
   saveError?: string | null;
 }
 
-/**
- * Deep comparison of two config objects.
- * Returns true if they differ.
- */
 function hasConfigChanged(
   initial: EditableVaultConfig,
   current: EditableVaultConfig
 ): boolean {
-  // Compare primitive fields
-  if (initial.title !== current.title) return true;
-  if (initial.subtitle !== current.subtitle) return true;
-  if (initial.discussionModel !== current.discussionModel) return true;
-  if (initial.promptsPerGeneration !== current.promptsPerGeneration) return true;
-  if (initial.maxPoolSize !== current.maxPoolSize) return true;
-  if (initial.quotesPerWeek !== current.quotesPerWeek) return true;
-  if (initial.recentCaptures !== current.recentCaptures) return true;
-  if (initial.recentDiscussions !== current.recentDiscussions) return true;
-  if (initial.order !== current.order) return true;
-  if (initial.cardsEnabled !== current.cardsEnabled) return true;
-  if (initial.viMode !== current.viMode) return true;
-
-  // Compare badges array
-  const initialBadges = initial.badges ?? [];
-  const currentBadges = current.badges ?? [];
-
-  if (initialBadges.length !== currentBadges.length) return true;
-
-  for (let i = 0; i < initialBadges.length; i++) {
-    if (
-      initialBadges[i].text !== currentBadges[i].text ||
-      initialBadges[i].color !== currentBadges[i].color
-    ) {
-      return true;
-    }
+  if (
+    initial.title !== current.title ||
+    initial.subtitle !== current.subtitle ||
+    initial.discussionModel !== current.discussionModel ||
+    initial.promptsPerGeneration !== current.promptsPerGeneration ||
+    initial.maxPoolSize !== current.maxPoolSize ||
+    initial.quotesPerWeek !== current.quotesPerWeek ||
+    initial.recentCaptures !== current.recentCaptures ||
+    initial.recentDiscussions !== current.recentDiscussions ||
+    initial.order !== current.order ||
+    initial.cardsEnabled !== current.cardsEnabled ||
+    initial.viMode !== current.viMode
+  ) {
+    return true;
   }
 
-  return false;
+  const initialBadges = initial.badges ?? [];
+  const currentBadges = current.badges ?? [];
+  if (initialBadges.length !== currentBadges.length) return true;
+
+  return initialBadges.some(
+    (badge, i) =>
+      badge.text !== currentBadges[i].text ||
+      badge.color !== currentBadges[i].color
+  );
 }
 
-/**
- * Predefined badge colors available for selection
- */
-const BADGE_COLORS: BadgeColor[] = [
-  "black",
-  "purple",
-  "red",
-  "cyan",
-  "orange",
-  "blue",
-  "green",
-  "yellow",
-];
-
-/**
- * CSS color values for badge backgrounds
- */
 const BADGE_COLOR_VALUES: Record<BadgeColor, string> = {
   black: "var(--color-badge-black, #333)",
   purple: "var(--color-badge-purple, #9b59b6)",
@@ -136,33 +99,24 @@ const BADGE_COLOR_VALUES: Record<BadgeColor, string> = {
   yellow: "var(--color-badge-yellow, #f1c40f)",
 };
 
-/**
- * Maximum character length for badge text (REQ-F-20)
- */
+const BADGE_COLORS = Object.keys(BADGE_COLOR_VALUES) as BadgeColor[];
+
+// REQ-F-20: 20-character cap on badge text.
 const MAX_BADGE_TEXT_LENGTH = 20;
 
-/**
- * Props for the BadgeEditor subcomponent
- */
 interface BadgeEditorProps {
   badges: Badge[];
   onChange: (badges: Badge[]) => void;
+  // REQ-F-21: at most 5 badges.
   maxBadges?: number;
 }
 
-/**
- * BadgeEditor Component
- *
- * Allows users to add, remove, and customize badge chips with color selection.
- * Enforces a maximum of 5 badges (REQ-F-21) and 20-character text limit (REQ-F-20).
- */
 function BadgeEditor({ badges, onChange, maxBadges = 5 }: BadgeEditorProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [newBadgeText, setNewBadgeText] = useState("");
   const [newBadgeColor, setNewBadgeColor] = useState<BadgeColor>("purple");
   const textInputRef = useRef<HTMLInputElement>(null);
 
-  // Focus input when add form opens
   useEffect(() => {
     if (isAdding && textInputRef.current) {
       textInputRef.current.focus();
@@ -209,7 +163,6 @@ function BadgeEditor({ badges, onChange, maxBadges = 5 }: BadgeEditorProps) {
 
   const handleTextChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      // Enforce max length at input level
       const value = e.target.value;
       if (value.length <= MAX_BADGE_TEXT_LENGTH) {
         setNewBadgeText(value);
@@ -233,7 +186,6 @@ function BadgeEditor({ badges, onChange, maxBadges = 5 }: BadgeEditorProps) {
 
   return (
     <div className="badge-editor">
-      {/* Existing badges list */}
       {badges.length > 0 && (
         <div className="badge-editor__list">
           {badges.map((badge, index) => (
@@ -256,10 +208,8 @@ function BadgeEditor({ badges, onChange, maxBadges = 5 }: BadgeEditorProps) {
         </div>
       )}
 
-      {/* Add badge form or button */}
       {isAdding ? (
         <div className="badge-editor__add-form">
-          {/* Color palette */}
           <div className="badge-editor__color-palette">
             {BADGE_COLORS.map((color) => (
               <button
@@ -273,7 +223,6 @@ function BadgeEditor({ badges, onChange, maxBadges = 5 }: BadgeEditorProps) {
             ))}
           </div>
 
-          {/* Text input */}
           <input
             ref={textInputRef}
             type="text"
@@ -285,12 +234,10 @@ function BadgeEditor({ badges, onChange, maxBadges = 5 }: BadgeEditorProps) {
             maxLength={MAX_BADGE_TEXT_LENGTH}
           />
 
-          {/* Character count */}
           <div className="badge-editor__char-count">
             {newBadgeText.length}/{MAX_BADGE_TEXT_LENGTH}
           </div>
 
-          {/* Actions */}
           <div className="badge-editor__add-actions">
             <button
               type="button"
@@ -336,8 +283,6 @@ export function ConfigEditorDialog({
   const subtitleInputId = useId();
   const orderInputId = useId();
   const discussionModelId = useId();
-
-  // Slider field IDs for accessibility
   const promptsPerGenerationId = useId();
   const maxPoolSizeId = useId();
   const quotesPerWeekId = useId();
@@ -346,29 +291,31 @@ export function ConfigEditorDialog({
   const cardsEnabledId = useId();
   const viModeId = useId();
 
-  // Form state - initialized from initialConfig
   const [formState, setFormState] = useState<EditableVaultConfig>(initialConfig);
-
-  // Track if confirm dialog for unsaved changes is shown
+  const [availableModels, setAvailableModels] = useState<ModelEntry[]>([]);
   const [showUnsavedConfirm, setShowUnsavedConfirm] = useState(false);
 
-  // Reset form state when dialog opens with new config
+  useEffect(() => {
+    fetch("/api/models")
+      .then((r) => r.json())
+      .then((data: { models: ModelEntry[] }) => setAvailableModels(data.models))
+      .catch(() => setAvailableModels([]));
+  }, []);
+
+  // Reset to initialConfig each time the dialog opens.
   useEffect(() => {
     if (isOpen) {
       setFormState(initialConfig);
     }
   }, [isOpen, initialConfig]);
 
-  // Compute if form has unsaved changes
   const hasChanges = useMemo(
     () => hasConfigChanged(initialConfig, formState),
     [initialConfig, formState]
   );
 
-  // Cancel attempt - show confirmation if there are changes
-  // Disable cancel while saving (TASK-010)
   const handleCancelAttempt = useCallback(() => {
-    if (isSaving) return; // Prevent cancel during save
+    if (isSaving) return;
     if (hasChanges) {
       setShowUnsavedConfirm(true);
     } else {
@@ -376,7 +323,6 @@ export function ConfigEditorDialog({
     }
   }, [hasChanges, onCancel, isSaving]);
 
-  // Handle backdrop click - trigger cancel behavior
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent) => {
       if (e.target === e.currentTarget) {
@@ -386,7 +332,6 @@ export function ConfigEditorDialog({
     [handleCancelAttempt]
   );
 
-  // Handle Escape key - trigger cancel behavior
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "Escape") {
@@ -397,23 +342,26 @@ export function ConfigEditorDialog({
     [handleCancelAttempt]
   );
 
-  // Confirm discard changes
   const handleConfirmDiscard = useCallback(() => {
     setShowUnsavedConfirm(false);
     onCancel();
   }, [onCancel]);
 
-  // Cancel discard (keep editing)
   const handleCancelDiscard = useCallback(() => {
     setShowUnsavedConfirm(false);
   }, []);
 
-  // Handle save button click
   const handleSave = useCallback(() => {
     void onSave(formState);
   }, [onSave, formState]);
 
   if (!isOpen) return null;
+
+  const selectedModel = formState.discussionModel;
+  const hasUnknownModel =
+    selectedModel !== undefined &&
+    selectedModel !== "" &&
+    !availableModels.some((m) => m.name === selectedModel);
 
   return createPortal(
     <>
@@ -428,7 +376,6 @@ export function ConfigEditorDialog({
           aria-modal="true"
           aria-labelledby={dialogTitleId}
         >
-          {/* Header */}
           <div className="config-editor__header">
             <h2 id={dialogTitleId} className="config-editor__title">
               Vault Settings
@@ -455,9 +402,7 @@ export function ConfigEditorDialog({
             </button>
           </div>
 
-          {/* Scrollable content area */}
           <div className="config-editor__content">
-            {/* Identity Settings Section */}
             <section className="config-editor__section">
               <h3 className="config-editor__section-title">Identity</h3>
               <p className="config-editor__section-description">
@@ -538,7 +483,6 @@ export function ConfigEditorDialog({
               </div>
             </section>
 
-            {/* Discussion Settings Section */}
             <section className="config-editor__section">
               <h3 className="config-editor__section-title">Discussion</h3>
               <p className="config-editor__section-description">
@@ -558,22 +502,30 @@ export function ConfigEditorDialog({
                   onChange={(e) =>
                     setFormState((prev) => ({
                       ...prev,
-                      discussionModel:
-                        (e.target.value as "opus" | "sonnet" | "haiku") ||
-                        undefined,
+                      discussionModel: e.target.value || undefined,
                     }))
                   }
                 >
-                  <option value="" disabled>
-                    Select model
-                  </option>
-                  <option value="opus">Opus (Most capable)</option>
-                  <option value="sonnet">Sonnet (Balanced)</option>
-                  <option value="haiku">Haiku (Fastest)</option>
+                  {availableModels.length === 0 ? (
+                    <option value="" disabled>No models configured.</option>
+                  ) : (
+                    <>
+                      <option value="">— unset —</option>
+                      {hasUnknownModel && (
+                        <option value={selectedModel}>
+                          {selectedModel} (unknown)
+                        </option>
+                      )}
+                      {availableModels.map((m) => (
+                        <option key={m.name} value={m.name}>
+                          {m.name}
+                        </option>
+                      ))}
+                    </>
+                  )}
                 </select>
               </div>
 
-              {/* Recent Discussions slider */}
               <div className="config-editor__slider-field">
                 <label
                   htmlFor={recentDiscussionsId}
@@ -607,14 +559,12 @@ export function ConfigEditorDialog({
               </div>
             </section>
 
-            {/* Inspiration Settings Section */}
             <section className="config-editor__section">
               <h3 className="config-editor__section-title">Inspiration</h3>
               <p className="config-editor__section-description">
                 Control contextual prompts and quotes on the home screen.
               </p>
 
-              {/* Prompts per Generation slider */}
               <div className="config-editor__slider-field">
                 <label
                   htmlFor={promptsPerGenerationId}
@@ -647,7 +597,6 @@ export function ConfigEditorDialog({
                 </div>
               </div>
 
-              {/* Prompt Pool Size slider */}
               <div className="config-editor__slider-field">
                 <label htmlFor={maxPoolSizeId} className="config-editor__label">
                   Prompt Pool Size
@@ -677,7 +626,6 @@ export function ConfigEditorDialog({
                 </div>
               </div>
 
-              {/* Quotes per Week slider */}
               <div className="config-editor__slider-field">
                 <label
                   htmlFor={quotesPerWeekId}
@@ -711,14 +659,12 @@ export function ConfigEditorDialog({
               </div>
             </section>
 
-            {/* Recent Activity Settings Section */}
             <section className="config-editor__section">
               <h3 className="config-editor__section-title">Recent Activity</h3>
               <p className="config-editor__section-description">
                 Configure how many recent captures to display.
               </p>
 
-              {/* Recent Captures slider */}
               <div className="config-editor__slider-field">
                 <label
                   htmlFor={recentCapturesId}
@@ -752,7 +698,6 @@ export function ConfigEditorDialog({
               </div>
             </section>
 
-            {/* Spaced Repetition Settings Section */}
             <section className="config-editor__section">
               <h3 className="config-editor__section-title">Spaced Repetition</h3>
               <p className="config-editor__section-description">
@@ -781,7 +726,6 @@ export function ConfigEditorDialog({
               </div>
             </section>
 
-            {/* Editing Settings Section */}
             <section className="config-editor__section">
               <h3 className="config-editor__section-title">Editing</h3>
               <p className="config-editor__section-description">
@@ -811,9 +755,7 @@ export function ConfigEditorDialog({
             </section>
           </div>
 
-          {/* Footer with actions */}
           <div className="config-editor__footer">
-            {/* Save error display (TASK-010) */}
             {saveError && (
               <div className="config-editor__error" role="alert">
                 {saveError}
@@ -841,7 +783,6 @@ export function ConfigEditorDialog({
         </div>
       </div>
 
-      {/* Unsaved changes confirmation dialog */}
       <ConfirmDialog
         isOpen={showUnsavedConfirm}
         title="Discard Changes?"

--- a/nextjs/components/vault/__tests__/ConfigEditorDialog.test.tsx
+++ b/nextjs/components/vault/__tests__/ConfigEditorDialog.test.tsx
@@ -1,17 +1,28 @@
-/**
- * Tests for ConfigEditorDialog component
- *
- * Tests rendering, field population, slider interactions, badge management,
- * change detection, and save/cancel behavior.
- */
-
-import { describe, it, expect, afterEach, mock, beforeEach } from "bun:test";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach, mock, beforeEach, beforeAll, afterAll } from "bun:test";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import {
   ConfigEditorDialog,
   type EditableVaultConfig,
   type ConfigEditorDialogProps,
 } from "../ConfigEditorDialog";
+
+const MOCK_MODELS = [
+  { name: "opus", provider: "anthropic", modelId: "claude-opus-4-7" },
+  { name: "sonnet", provider: "anthropic", modelId: "claude-sonnet-4-6" },
+  { name: "haiku", provider: "anthropic", modelId: "claude-haiku-4-5" },
+];
+
+const mockFetch = mock(async (url: string) => {
+  if (url === "/api/models") {
+    return new Response(JSON.stringify({ models: MOCK_MODELS }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  throw new Error(`Unexpected fetch: ${url}`);
+});
+
+beforeAll(() => { global.fetch = mockFetch as typeof fetch; });
+afterAll(() => { mockFetch.mockRestore(); });
 
 afterEach(() => {
   cleanup();
@@ -38,7 +49,6 @@ describe("ConfigEditorDialog", () => {
   };
 
   beforeEach(() => {
-    // Reset mocks before each test
     (defaultProps.onSave as ReturnType<typeof mock>).mockClear?.();
     (defaultProps.onCancel as ReturnType<typeof mock>).mockClear?.();
   });
@@ -90,11 +100,13 @@ describe("ConfigEditorDialog", () => {
       expect(subtitleInput.value).toBe("Test subtitle");
     });
 
-    it("discussion model dropdown shows value from initialConfig.discussionModel", () => {
+    it("discussion model dropdown shows value from initialConfig.discussionModel", async () => {
       render(<ConfigEditorDialog {...defaultProps} />);
 
-      const modelSelect = screen.getByLabelText<HTMLSelectElement>("AI Model");
-      expect(modelSelect.value).toBe("sonnet");
+      await waitFor(() => {
+        const modelSelect = screen.getByLabelText<HTMLSelectElement>("AI Model");
+        expect(modelSelect.value).toBe("sonnet");
+      });
     });
 
     it("promptsPerGeneration slider shows value from initialConfig", () => {
@@ -788,30 +800,50 @@ describe("ConfigEditorDialog", () => {
   });
 
   describe("dropdown interactions", () => {
-    it("discussion model can be changed to opus", () => {
+    it("discussion model can be changed to opus", async () => {
       render(<ConfigEditorDialog {...defaultProps} />);
 
-      const modelSelect = screen.getByLabelText<HTMLSelectElement>("AI Model");
-      fireEvent.change(modelSelect, { target: { value: "opus" } });
-
-      expect(modelSelect.value).toBe("opus");
+      await waitFor(() => {
+        const modelSelect = screen.getByLabelText<HTMLSelectElement>("AI Model");
+        fireEvent.change(modelSelect, { target: { value: "opus" } });
+        expect(modelSelect.value).toBe("opus");
+      });
     });
 
-    it("discussion model can be changed to haiku", () => {
+    it("discussion model can be changed to haiku", async () => {
       render(<ConfigEditorDialog {...defaultProps} />);
 
-      const modelSelect = screen.getByLabelText<HTMLSelectElement>("AI Model");
-      fireEvent.change(modelSelect, { target: { value: "haiku" } });
-
-      expect(modelSelect.value).toBe("haiku");
+      await waitFor(() => {
+        const modelSelect = screen.getByLabelText<HTMLSelectElement>("AI Model");
+        fireEvent.change(modelSelect, { target: { value: "haiku" } });
+        expect(modelSelect.value).toBe("haiku");
+      });
     });
 
-    it("displays all model options", () => {
+    it("displays all model options", async () => {
       render(<ConfigEditorDialog {...defaultProps} />);
 
-      expect(screen.getByText("Opus (Most capable)")).toBeDefined();
-      expect(screen.getByText("Sonnet (Balanced)")).toBeDefined();
-      expect(screen.getByText("Haiku (Fastest)")).toBeDefined();
+      await waitFor(() => {
+        expect(screen.getByRole("option", { name: "opus" })).toBeDefined();
+        expect(screen.getByRole("option", { name: "sonnet" })).toBeDefined();
+        expect(screen.getByRole("option", { name: "haiku" })).toBeDefined();
+      });
+    });
+
+    it("shows unknown model option and selects it when initialConfig has an unrecognised model", async () => {
+      render(
+        <ConfigEditorDialog
+          {...defaultProps}
+          initialConfig={{ ...defaultConfig, discussionModel: "unknown-model" }}
+        />
+      );
+
+      await waitFor(() => {
+        const unknownOption = screen.getByRole("option", { name: "unknown-model (unknown)" });
+        expect(unknownOption).toBeDefined();
+        const modelSelect = screen.getByLabelText<HTMLSelectElement>("AI Model");
+        expect(modelSelect.value).toBe("unknown-model");
+      });
     });
   });
 

--- a/nextjs/lib/daemon/index.ts
+++ b/nextjs/lib/daemon/index.ts
@@ -15,3 +15,4 @@ export {
 export * as vaultClient from "./vaults";
 export * as fileClient from "./files";
 export * as sessionClient from "./sessions";
+export * from "./models";

--- a/nextjs/lib/daemon/models.ts
+++ b/nextjs/lib/daemon/models.ts
@@ -1,0 +1,13 @@
+import { daemonFetch } from "./fetch";
+
+export interface ModelEntry {
+  name: string;
+  provider: string;
+  modelId: string;
+}
+
+export async function getModels(): Promise<ModelEntry[]> {
+  const res = await daemonFetch("/models");
+  const json = (await res.json()) as { models: ModelEntry[] };
+  return json.models;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,21 +1,18 @@
 /**
  * @memory-loop/shared
  *
- * Shared types, schemas, and utilities for Memory Loop.
- * Used by both the Next.js web app and the daemon process.
+ * Shared types, schemas, and utilities used by both the Next.js web app
+ * and the daemon process.
  */
 
-// Schemas and types
 export * from "./schemas/index";
 
-// Logger
 export { createLogger, setLogLevel } from "./logger";
 export type { LogLevel } from "./logger";
 
-// Vault configuration types and resolvers
-// NOTE: fileExists/directoryExists and resolveContentRoot are server-only.
-// Import from "@memory-loop/shared/server" for those.
-export type { VaultConfig, DiscussionModelLocal } from "./vault-config";
+// fileExists/directoryExists and resolveContentRoot are server-only.
+// Import them from "@memory-loop/shared/server".
+export type { VaultConfig } from "./vault-config";
 export {
   CONFIG_FILE_NAME,
   SLASH_COMMANDS_FILE,
@@ -28,8 +25,6 @@ export {
   DEFAULT_QUOTES_PER_WEEK,
   DEFAULT_RECENT_CAPTURES,
   DEFAULT_RECENT_DISCUSSIONS,
-  VALID_DISCUSSION_MODELS,
-  DEFAULT_DISCUSSION_MODEL,
   DEFAULT_ORDER,
   DEFAULT_CARDS_ENABLED,
   DEFAULT_VI_MODE,
@@ -48,14 +43,12 @@ export {
   resolvePinnedAssets,
   resolveRecentCaptures,
   resolveRecentDiscussions,
-  resolveDiscussionModel,
   resolveOrder,
   resolveCardsEnabled,
   resolveViMode,
   slashCommandsEqual,
 } from "./vault-config";
 
-// File type utilities
 export {
   IMAGE_EXTENSIONS,
   VIDEO_EXTENSIONS,
@@ -70,14 +63,12 @@ export {
   encodeAssetPath,
 } from "./file-types";
 
-// Date formatting utilities
 export {
   formatDateForFilename,
   formatTimeForTimestamp,
   getDailyNoteFilename,
 } from "./date-utils";
 
-// Session types
 export type {
   SessionEvent,
   PendingPrompt,
@@ -88,7 +79,6 @@ export type {
 } from "./session-types";
 export { AlreadyProcessingError } from "./session-types";
 
-// Pair writing prompts
 export type {
   QuickActionType,
   AdvisoryActionType,
@@ -111,7 +101,6 @@ export {
   buildDiscussPrompt,
 } from "./pair-writing-prompts";
 
-// Vault path helpers
 export type { ExtractedTitle } from "./vault-paths";
 export {
   DEFAULT_INBOX_PATH,

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,51 +1,42 @@
 /**
  * Memory Loop Shared Types and Protocols
  *
- * This package contains:
- * - Zod schemas for WebSocket protocol validation
- * - TypeScript types for Vault, Session, and Message models
- * - Shared utilities for frontend and backend
+ * Zod schemas for protocol validation, TypeScript types for Vault/Session/Message
+ * models, and shared utilities for frontend and backend.
  */
 
 export const VERSION = "0.1.0";
 
-// Core types
-export type { VaultInfo, SessionMetadata, ErrorCode, StoredToolInvocation, ConversationMessage, Badge, BadgeColor, SaveConfigResult } from "./types";
+export type {
+  VaultInfo,
+  SessionMetadata,
+  ErrorCode,
+  StoredToolInvocation,
+  ConversationMessage,
+  Badge,
+  BadgeColor,
+  SaveConfigResult,
+} from "./types";
 
-// Editable vault config types (from protocol)
-export type { EditableVaultConfig, DiscussionModel } from "./protocol";
-export { EditableVaultConfigSchema, DiscussionModelSchema, EditableBadgeSchema } from "./protocol";
+export type { EditableVaultConfig } from "./protocol";
+export { EditableVaultConfigSchema, EditableBadgeSchema } from "./protocol";
 
-// Protocol schemas
 export {
-  // Vault Info
   VaultInfoSchema,
   ErrorCodeSchema,
-  // File browser schemas
   FileEntrySchema,
-  // Task schemas
   TaskCategorySchema,
   TaskEntrySchema,
-  // Recent notes schemas
   RecentNoteEntrySchema,
-  // Recent discussion schemas
   RecentDiscussionEntrySchema,
-  // Tool invocation schema
   ToolInvocationSchema,
-  // Conversation message schema
   ConversationMessageSchema,
-  // Inspiration schemas (used by REST API)
   InspirationItemSchema,
-  // Slash command schemas
   SlashCommandSchema,
-  // Search result schemas
   FileSearchResultSchema,
   ContentSearchResultSchema,
   ContextSnippetSchema,
-
-  // Meeting state schema (used by REST API)
   MeetingStateSchema,
-  // Spaced repetition card schemas (used by REST API)
   ReviewResponseSchema,
   DueCardSchema,
   CardDetailSchema,
@@ -53,7 +44,7 @@ export {
   ReviewResultSchema,
   ArchiveResponseSchema,
   DueCardsResponseSchema,
-  // Client -> Server schemas (WebSocket only)
+  // Client -> Server (WebSocket)
   SelectVaultMessageSchema,
   CreateVaultMessageSchema,
   DiscussionMessageSchema,
@@ -62,7 +53,7 @@ export {
   AbortMessageSchema,
   PingMessageSchema,
   ClientMessageSchema,
-  // Server -> Client schemas (WebSocket only)
+  // Server -> Client (WebSocket)
   VaultListMessageSchema,
   VaultCreatedMessageSchema,
   SessionReadyMessageSchema,
@@ -75,40 +66,26 @@ export {
   ErrorMessageSchema,
   PongMessageSchema,
   ServerMessageSchema,
-  // Validation utilities
   parseClientMessage,
   parseServerMessage,
   safeParseClientMessage,
   safeParseServerMessage,
 } from "./protocol";
 
-// Protocol message types (inferred from Zod schemas)
 export type {
-  // Conversation message type (for session messages)
   ConversationMessageProtocol,
-  // File browser types
   FileEntry,
-  // Task types
   TaskCategory,
   TaskEntry,
-  // Recent notes types
   RecentNoteEntry,
-  // Recent discussion types
   RecentDiscussionEntry,
-  // Tool invocation type
   ToolInvocation,
-  // Inspiration types (used by REST API)
   InspirationItem,
-  // Slash command types
   SlashCommand,
-  // Search result types
   FileSearchResult,
   ContentSearchResult,
   ContextSnippet,
-
-  // Meeting types (used by REST API)
   MeetingState,
-  // Spaced repetition card types (used by REST API)
   ReviewResponse,
   DueCard,
   CardDetail,
@@ -116,17 +93,15 @@ export type {
   ReviewResult,
   ArchiveResponse,
   DueCardsResponse,
-  // AskUserQuestion types
   AskUserQuestionOption,
   AskUserQuestionItem,
   AskUserQuestionResponseMessage,
   AskUserQuestionRequestMessage,
-  // Pair Writing types
   QuickActionType,
   QuickActionRequestMessage,
   AdvisoryActionType,
   AdvisoryActionRequestMessage,
-  // Client message types (WebSocket only)
+  // Client messages (WebSocket)
   SelectVaultMessage,
   CreateVaultMessage,
   DiscussionMessage,
@@ -135,7 +110,7 @@ export type {
   AbortMessage,
   PingMessage,
   ClientMessage,
-  // Server message types (WebSocket only)
+  // Server messages (WebSocket)
   VaultListMessage,
   VaultCreatedMessage,
   SessionReadyMessage,

--- a/packages/shared/src/schemas/protocol.ts
+++ b/packages/shared/src/schemas/protocol.ts
@@ -11,9 +11,6 @@ import { z } from "zod";
 // Badge Schema
 // =============================================================================
 
-/**
- * Schema for badge color enum - valid named colors for badges
- */
 export const BadgeColorSchema = z.enum([
   "black",
   "purple",
@@ -25,18 +22,12 @@ export const BadgeColorSchema = z.enum([
   "yellow",
 ]);
 
-/**
- * Schema for Badge - custom badge configured in .memory-loop.json
- */
 export const BadgeSchema = z.object({
   text: z.string().min(1, "Badge text is required"),
   color: BadgeColorSchema,
 });
 
-/**
- * Schema for Badge with strict validation for editable config.
- * Used when validating user input for badge editing (max 20 chars).
- */
+// Stricter version used when validating user input for badge editing.
 export const EditableBadgeSchema = z.object({
   text: z.string().min(1, "Badge text is required").max(20, "Badge text must be 20 characters or less"),
   color: BadgeColorSchema,
@@ -46,20 +37,11 @@ export const EditableBadgeSchema = z.object({
 // Editable Vault Config Schema
 // =============================================================================
 
-/**
- * Schema for discussion model selection - the three Claude model tiers
- */
-export const DiscussionModelSchema = z.enum(["opus", "sonnet", "haiku"]);
-
-/**
- * Schema for editable vault configuration fields.
- * All fields are optional to support partial updates.
- * Constraints match the spec requirements.
- */
+// All fields optional to support partial updates. Constraints match the spec.
 export const EditableVaultConfigSchema = z.object({
   title: z.string().optional(),
   subtitle: z.string().optional(),
-  discussionModel: DiscussionModelSchema.optional(),
+  discussionModel: z.string().optional(),
   promptsPerGeneration: z.number().int().min(1).max(20).optional(),
   maxPoolSize: z.number().int().min(10).max(200).optional(),
   quotesPerWeek: z.number().int().min(0).max(7).optional(),
@@ -75,9 +57,6 @@ export const EditableVaultConfigSchema = z.object({
 // Vault Info Schema
 // =============================================================================
 
-/**
- * Schema for VaultInfo - used in vault_list messages
- */
 export const VaultInfoSchema = z.object({
   id: z.string().min(1, "Vault ID is required"),
   name: z.string().min(1, "Vault name is required"),
@@ -90,7 +69,7 @@ export const VaultInfoSchema = z.object({
   goalsPath: z.string().optional(),
   attachmentPath: z.string().min(1, "Attachment path is required"),
   setupComplete: z.boolean(),
-  discussionModel: DiscussionModelSchema.optional(),
+  discussionModel: z.string().optional(),
   promptsPerGeneration: z.number().int().positive(),
   maxPoolSize: z.number().int().positive(),
   quotesPerWeek: z.number().int().positive(),
@@ -106,9 +85,6 @@ export const VaultInfoSchema = z.object({
 // Error Code Schema
 // =============================================================================
 
-/**
- * Schema for ErrorCode enum values
- */
 export const ErrorCodeSchema = z.enum([
   "VAULT_NOT_FOUND",
   "VAULT_ACCESS_DENIED",
@@ -128,42 +104,25 @@ export const ErrorCodeSchema = z.enum([
 // File Browser Schemas
 // =============================================================================
 
-/**
- * Schema for a file or directory entry in a vault listing
- */
 export const FileEntrySchema = z.object({
   name: z.string().min(1, "Entry name is required"),
   type: z.enum(["file", "directory"]),
   path: z.string(), // Can be empty string for root entries
 });
 
-/**
- * Schema for task category - indicates which directory the task was found in
- */
 export const TaskCategorySchema = z.enum(["inbox", "projects", "areas"]);
 
-/**
- * Schema for a task entry parsed from markdown files
- * Tasks are lines matching /^\s*- \[(.)\] (.+)$/
- */
+// Tasks are lines matching /^\s*- \[(.)\] (.+)$/
 export const TaskEntrySchema = z.object({
-  /** Task text content (after checkbox) */
   text: z.string(),
-  /** Checkbox state character: ' ', 'x', '/', '?', 'b', 'f' */
+  // Checkbox state character: ' ', 'x', '/', '?', 'b', 'f'
   state: z.string().length(1, "State must be a single character"),
-  /** Relative file path from content root */
   filePath: z.string().min(1, "File path is required"),
-  /** Line number in file (1-indexed) */
   lineNumber: z.number().int().min(1, "Line number must be at least 1"),
-  /** File modification time (Unix timestamp in ms) for sorting */
   fileMtime: z.number().int().min(0),
-  /** Category indicating source directory (inbox, projects, or areas) */
   category: TaskCategorySchema,
 });
 
-/**
- * Schema for a recent note entry in the inbox
- */
 export const RecentNoteEntrySchema = z.object({
   id: z.string().min(1, "Entry ID is required"),
   text: z.string(),
@@ -171,9 +130,6 @@ export const RecentNoteEntrySchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD format"),
 });
 
-/**
- * Schema for a recent discussion entry (session summary)
- */
 export const RecentDiscussionEntrySchema = z.object({
   sessionId: z.string().min(1, "Session ID is required"),
   preview: z.string(),
@@ -186,16 +142,12 @@ export const RecentDiscussionEntrySchema = z.object({
 // Slash Command Schema
 // =============================================================================
 
-/**
- * Schema for a slash command available in the discussion interface
- * Commands are sent from server to client in session_ready message
- */
+// Sent from server to client in session_ready.
 export const SlashCommandSchema = z.object({
-  /** Command name including "/" prefix (e.g., "/commit") */
+  // Includes "/" prefix (e.g., "/commit").
   name: z.string().min(2, "Command name must include / prefix and at least one character"),
-  /** User-facing description of what the command does */
   description: z.string().min(1, "Description is required"),
-  /** Optional hint for expected arguments (e.g., "<message>") */
+  // Optional hint for expected arguments (e.g., "<message>").
   argumentHint: z.string().optional(),
 });
 
@@ -203,9 +155,6 @@ export const SlashCommandSchema = z.object({
 // Tool Invocation Schema
 // =============================================================================
 
-/**
- * Schema for a tool invocation within an assistant message
- */
 export const ToolInvocationSchema = z.object({
   toolUseId: z.string().min(1, "Tool use ID is required"),
   toolName: z.string().min(1, "Tool name is required"),
@@ -214,9 +163,6 @@ export const ToolInvocationSchema = z.object({
   status: z.enum(["running", "complete"]),
 });
 
-/**
- * Schema for a conversation message in session history
- */
 export const ConversationMessageSchema = z.object({
   id: z.string().min(1, "Message ID is required"),
   role: z.enum(["user", "assistant"]),
@@ -231,48 +177,26 @@ export const ConversationMessageSchema = z.object({
 // Search Result Schemas
 // =============================================================================
 
-/**
- * Schema for a file name search result
- * Returned when searching by file name with fuzzy matching
- */
 export const FileSearchResultSchema = z.object({
-  /** Relative path from content root */
   path: z.string(),
-  /** File name only (without path) */
   name: z.string(),
-  /** Match quality score (higher = better match) */
   score: z.number(),
-  /** Character positions in name that matched the query */
   matchPositions: z.array(z.number()),
 });
 
-/**
- * Schema for a content search result
- * Returned when searching within file contents
- */
 export const ContentSearchResultSchema = z.object({
-  /** Relative path from content root */
   path: z.string(),
-  /** File name only (without path) */
   name: z.string(),
-  /** Number of matches found in this file */
   matchCount: z.number().int().min(1),
-  /** Context snippets (populated on demand via get_snippets) */
+  // Populated on demand via get_snippets.
   snippets: z.array(z.lazy(() => ContextSnippetSchema)).optional(),
 });
 
-/**
- * Schema for a context snippet showing a matched line with surrounding context
- * Used for content search result expansion
- */
 export const ContextSnippetSchema = z.object({
-  /** Line number of the match (1-indexed) */
   lineNumber: z.number().int().min(1),
-  /** The matched line content */
   line: z.string(),
-  /** Up to 2 lines before the match */
+  // Up to 2 lines before/after the match.
   contextBefore: z.array(z.string()),
-  /** Up to 2 lines after the match */
   contextAfter: z.array(z.string()),
 });
 
@@ -280,28 +204,16 @@ export const ContextSnippetSchema = z.object({
 // REST API Data Schemas
 // =============================================================================
 
-/**
- * Schema for an inspiration item (used for both contextual prompts and quotes).
- * Used by REST API responses.
- */
+// Used for both contextual prompts and quotes.
 export const InspirationItemSchema = z.object({
   text: z.string().min(1, "Inspiration text is required"),
   attribution: z.string().optional(),
 });
 
-/**
- * Schema for active meeting state.
- * Tracks the current meeting session if one is active.
- * Used by REST API responses.
- */
 export const MeetingStateSchema = z.object({
-  /** Whether a meeting is currently active */
   isActive: z.boolean(),
-  /** Meeting title (set when meeting started) */
   title: z.string().optional(),
-  /** Path to the meeting file (relative to content root) */
   filePath: z.string().optional(),
-  /** ISO 8601 timestamp when meeting started */
   startedAt: z.string().optional(),
 });
 
@@ -309,99 +221,50 @@ export const MeetingStateSchema = z.object({
 // Spaced Repetition Card Schemas
 // =============================================================================
 
-/**
- * Valid review responses for spaced repetition cards.
- * Maps to SM-2 algorithm quality ratings:
- * - again: Complete failure (q=0)
- * - hard: Correct but with difficulty (q=3)
- * - good: Correct with some effort (q=4)
- * - easy: Perfect recall (q=5)
- */
+// Maps to SM-2 algorithm quality ratings:
+//   again (q=0), hard (q=3), good (q=4), easy (q=5).
 export const ReviewResponseSchema = z.enum(["again", "hard", "good", "easy"]);
 
-/**
- * Schema for a due card preview (question only, no answer).
- * Used in GET /cards/due response items.
- */
+// Question-only preview (used in GET /cards/due response items).
 export const DueCardSchema = z.object({
-  /** Unique card identifier (UUID) */
   id: z.string().uuid(),
-  /** The question to display */
   question: z.string().min(1, "Question is required"),
-  /** ISO 8601 date when card is due for review */
   next_review: z.string(),
-  /** Path to the card file (relative to vault, e.g., 06_Metadata/memory-loop/cards/{id}.md) */
   card_file: z.string(),
 });
 
-/**
- * Schema for full card detail with answer.
- * Used in GET /cards/:cardId response after revealing answer.
- */
+// Full card with answer (used in GET /cards/:cardId response).
 export const CardDetailSchema = z.object({
-  /** Unique card identifier (UUID) */
   id: z.string().uuid(),
-  /** The question to display */
   question: z.string().min(1, "Question is required"),
-  /** The answer to reveal */
   answer: z.string().min(1, "Answer is required"),
-  /** SM-2 ease factor (default 2.5, adjusted based on performance) */
+  // SM-2 ease factor (default 2.5, adjusted based on performance).
   ease_factor: z.number().min(1.3),
-  /** Days until next review */
   interval: z.number().int().min(0),
-  /** Number of successful reviews in a row */
   repetitions: z.number().int().min(0),
-  /** ISO 8601 timestamp of last review, null if never reviewed */
   last_reviewed: z.string().nullable(),
-  /** ISO 8601 date when card is due for review */
   next_review: z.string(),
-  /** Source file path if card was extracted from a note */
   source_file: z.string().optional(),
 });
 
-/**
- * Schema for review request body.
- * Used in POST /cards/:cardId/review request.
- */
 export const ReviewRequestSchema = z.object({
-  /** User's self-assessment of recall quality */
   response: ReviewResponseSchema,
 });
 
-/**
- * Schema for review result response.
- * Used in POST /cards/:cardId/review response.
- */
 export const ReviewResultSchema = z.object({
-  /** Card identifier */
   id: z.string().uuid(),
-  /** Updated next review date (ISO 8601) */
   next_review: z.string(),
-  /** Updated interval in days */
   interval: z.number().int().min(0),
-  /** Updated ease factor */
   ease_factor: z.number().min(1.3),
 });
 
-/**
- * Schema for archive response.
- * Used in POST /cards/:cardId/archive response.
- */
 export const ArchiveResponseSchema = z.object({
-  /** Card identifier */
   id: z.string().uuid(),
-  /** Confirmation that card was archived */
   archived: z.literal(true),
 });
 
-/**
- * Schema for due cards list response.
- * Used in GET /cards/due response.
- */
 export const DueCardsResponseSchema = z.object({
-  /** Array of due card previews */
   cards: z.array(DueCardSchema),
-  /** Total count of due cards */
   count: z.number().int().min(0),
 });
 
@@ -409,60 +272,37 @@ export const DueCardsResponseSchema = z.object({
 // Client -> Server Message Schemas
 // =============================================================================
 
-/**
- * Client requests to select a vault and start/resume a session
- */
 export const SelectVaultMessageSchema = z.object({
   type: z.literal("select_vault"),
   vaultId: z.string().min(1, "Vault ID is required"),
 });
 
-/**
- * Client sends a discussion message for the AI to respond to
- */
 export const DiscussionMessageSchema = z.object({
   type: z.literal("discussion_message"),
   text: z.string().min(1, "Message text is required"),
 });
 
-/**
- * Client requests to resume an existing session
- */
 export const ResumeSessionMessageSchema = z.object({
   type: z.literal("resume_session"),
   sessionId: z.string().min(1, "Session ID is required"),
 });
 
-/**
- * Client requests to start a new session (clearing context)
- */
 export const NewSessionMessageSchema = z.object({
   type: z.literal("new_session"),
 });
 
-/**
- * Client requests to abort the current operation
- */
 export const AbortMessageSchema = z.object({
   type: z.literal("abort"),
 });
 
-/**
- * Client sends a ping to keep the connection alive
- */
 export const PingMessageSchema = z.object({
   type: z.literal("ping"),
 });
 
-/**
- * Client responds to a tool permission request
- * Sent in response to tool_permission_request from server
- */
+// Response to tool_permission_request.
 export const ToolPermissionResponseMessageSchema = z.object({
   type: z.literal("tool_permission_response"),
-  /** The tool use ID from the permission request */
   toolUseId: z.string().min(1, "Tool use ID is required"),
-  /** Whether the user allows the tool to run */
   allowed: z.boolean(),
 });
 
@@ -470,49 +310,29 @@ export const ToolPermissionResponseMessageSchema = z.object({
 // AskUserQuestion Schemas
 // =============================================================================
 
-/**
- * Schema for a single option in an AskUserQuestion question
- */
 export const AskUserQuestionOptionSchema = z.object({
-  /** Display text for this option */
   label: z.string().min(1, "Option label is required"),
-  /** Description explaining what this option means */
   description: z.string(),
 });
 
-/**
- * Schema for a single question in an AskUserQuestion request
- */
 export const AskUserQuestionItemSchema = z.object({
-  /** The full question text to display */
   question: z.string().min(1, "Question text is required"),
-  /** Short label for the question */
   header: z.string().min(1, "Header is required"),
-  /** Available choices (2-4 options) */
+  // 2-4 options per question.
   options: z.array(AskUserQuestionOptionSchema).min(2).max(4),
-  /** If true, users can select multiple options */
   multiSelect: z.boolean(),
 });
 
-/**
- * Client responds to an AskUserQuestion request
- * Sent in response to ask_user_question_request from server
- */
+// Response to ask_user_question_request. `answers` maps question text -> answer.
 export const AskUserQuestionResponseMessageSchema = z.object({
   type: z.literal("ask_user_question_response"),
-  /** The tool use ID from the request */
   toolUseId: z.string().min(1, "Tool use ID is required"),
-  /** Map of question text to selected answer(s) */
   answers: z.record(z.string(), z.string()),
 });
 
-/**
- * Client requests to create a new vault.
- * The title will be converted to a safe directory name.
- */
+// Title becomes the CLAUDE.md heading and is converted to a safe directory name.
 export const CreateVaultMessageSchema = z.object({
   type: z.literal("create_vault"),
-  /** User-provided vault title (will become CLAUDE.md heading) */
   title: z.string().min(1, "Vault title is required"),
 });
 
@@ -520,71 +340,46 @@ export const CreateVaultMessageSchema = z.object({
 // Pair Writing Mode Client Messages
 // =============================================================================
 
-/**
- * Action types for Quick Actions (transformative, all platforms)
- * - tighten: Make more concise without losing meaning
- * - embellish: Add detail, nuance, or context
- * - correct: Fix typos and grammar only
- * - polish: Correct + improve prose
- */
+// Quick actions (transformative, all platforms):
+//   tighten   - more concise without losing meaning
+//   embellish - add detail, nuance, or context
+//   correct   - fix typos and grammar only
+//   polish    - correct + improve prose
 export const QuickActionTypeSchema = z.enum(["tighten", "embellish", "correct", "polish"]);
 
-/**
- * Action types for Advisory Actions (Pair Writing Mode, desktop only)
- * - validate: Fact-check the claim
- * - critique: Analyze clarity, voice, structure
- * - compare: Compare current text to snapshot
- * - discuss: Discuss improvements or alternatives
- */
+// Advisory actions (Pair Writing Mode, desktop only):
+//   validate - fact-check the claim
+//   critique - analyze clarity, voice, structure
+//   compare  - compare current text to snapshot
+//   discuss  - discuss improvements or alternatives
 export const AdvisoryActionTypeSchema = z.enum(["validate", "critique", "compare", "discuss"]);
 
-/**
- * Client requests a Quick Action on selected text (all platforms)
- * Claude uses Read/Edit tools to modify the file directly
- */
+// Claude uses Read/Edit tools to modify the file directly.
 export const QuickActionRequestMessageSchema = z.object({
   type: z.literal("quick_action_request"),
-  /** The action to perform */
   action: QuickActionTypeSchema,
-  /** The selected text to transform */
   selection: z.string().min(1, "Selection is required"),
-  /** Paragraph before the selection (for context) */
   contextBefore: z.string(),
-  /** Paragraph after the selection (for context) */
   contextAfter: z.string(),
-  /** Path to the file being edited (relative to content root) */
   filePath: z.string().min(1, "File path is required"),
-  /** 1-indexed line number where selection starts */
   selectionStartLine: z.number().int().min(1, "Selection start line must be at least 1"),
-  /** 1-indexed line number where selection ends */
   selectionEndLine: z.number().int().min(1, "Selection end line must be at least 1"),
-  /** Total lines in the document (for position hint calculation) */
+  // Used for position hint calculation.
   totalLines: z.number().int().min(1, "Total lines must be at least 1"),
 });
 
-/**
- * Client requests an Advisory Action on selected text (Pair Writing Mode, desktop)
- * Response appears in conversation pane; user manually applies changes
- */
+// Response appears in conversation pane; user manually applies changes.
 export const AdvisoryActionRequestMessageSchema = z.object({
   type: z.literal("advisory_action_request"),
-  /** The advisory action to perform */
   action: AdvisoryActionTypeSchema,
-  /** The selected text to analyze */
   selection: z.string().min(1, "Selection is required"),
-  /** Paragraph before the selection (for context) */
   contextBefore: z.string(),
-  /** Paragraph after the selection (for context) */
   contextAfter: z.string(),
-  /** Path to the file being edited (relative to content root) */
   filePath: z.string().min(1, "File path is required"),
-  /** 1-indexed line number where selection starts */
   selectionStartLine: z.number().int().min(1, "Selection start line must be at least 1"),
-  /** 1-indexed line number where selection ends */
   selectionEndLine: z.number().int().min(1, "Selection end line must be at least 1"),
-  /** Total lines in the document (for position hint calculation) */
   totalLines: z.number().int().min(1, "Total lines must be at least 1"),
-  /** For compare action: the corresponding text from the snapshot */
+  // For compare action: the corresponding text from the snapshot.
   snapshotSelection: z.string().optional(),
 });
 
@@ -592,38 +387,25 @@ export const AdvisoryActionRequestMessageSchema = z.object({
 // Memory Extraction Client Messages
 // =============================================================================
 
-/**
- * Client requests current extraction prompt with override status (REQ-F-15)
- * Response: extraction_prompt_content message
- */
+// REQ-F-15: response is extraction_prompt_content.
 export const GetExtractionPromptMessageSchema = z.object({
   type: z.literal("get_extraction_prompt"),
 });
 
-/**
- * Client requests to save extraction prompt (REQ-F-16)
- * Creates user override at ~/.config/memory-loop/extraction-prompt.md if needed
- * Response: extraction_prompt_saved message
- */
+// REQ-F-16: creates user override at ~/.config/memory-loop/extraction-prompt.md
+// if needed. Response is extraction_prompt_saved.
 export const SaveExtractionPromptMessageSchema = z.object({
   type: z.literal("save_extraction_prompt"),
-  /** Updated extraction prompt content */
   content: z.string(),
 });
 
-/**
- * Client requests to reset extraction prompt to default (REQ-F-16)
- * Removes user override at ~/.config/memory-loop/extraction-prompt.md
- * Response: extraction_prompt_reset message
- */
+// REQ-F-16: removes the user override file. Response is extraction_prompt_reset.
 export const ResetExtractionPromptMessageSchema = z.object({
   type: z.literal("reset_extraction_prompt"),
 });
 
-/**
- * Client requests to manually trigger extraction (for testing/debug)
- * Response: extraction_status messages with progress updates
- */
+// Manually triggers extraction (for testing/debug). Response stream is
+// extraction_status messages with progress updates.
 export const TriggerExtractionMessageSchema = z.object({
   type: z.literal("trigger_extraction"),
 });
@@ -632,63 +414,35 @@ export const TriggerExtractionMessageSchema = z.object({
 // Card Generator Client Messages
 // =============================================================================
 
-/**
- * Client requests current card generator config with requirements override status
- * Response: card_generator_config_content message
- */
 export const GetCardGeneratorConfigMessageSchema = z.object({
   type: z.literal("get_card_generator_config"),
 });
 
-/**
- * Client requests to save card generator requirements (creates user override)
- * Response: card_generator_requirements_saved message
- */
 export const SaveCardGeneratorRequirementsMessageSchema = z.object({
   type: z.literal("save_card_generator_requirements"),
-  /** Updated requirements content */
   content: z.string(),
 });
 
-/**
- * Client requests to save card generator config (byte limit)
- * Response: card_generator_config_saved message
- */
 export const SaveCardGeneratorConfigMessageSchema = z.object({
   type: z.literal("save_card_generator_config"),
-  /** Weekly byte limit for card generation */
-  weeklyByteLimit: z.number().int().min(102400).max(10485760), // 100KB - 10MB
+  // 100KB - 10MB.
+  weeklyByteLimit: z.number().int().min(102400).max(10485760),
 });
 
-/**
- * Client requests to reset card generator requirements to default
- * Removes user override at ~/.config/memory-loop/card-generator-requirements.md
- * Response: card_generator_requirements_reset message
- */
+// Removes user override at ~/.config/memory-loop/card-generator-requirements.md.
 export const ResetCardGeneratorRequirementsMessageSchema = z.object({
   type: z.literal("reset_card_generator_requirements"),
 });
 
-/**
- * Client requests to manually trigger card generation
- * Bypasses "already ran this week" check, uses remaining weekly budget
- * Response: card_generation_status messages with progress updates
- */
+// Bypasses "already ran this week" check, uses remaining weekly budget.
 export const TriggerCardGenerationMessageSchema = z.object({
   type: z.literal("trigger_card_generation"),
 });
 
-/**
- * Client requests current card generation status
- * Response: card_generation_status message
- */
 export const GetCardGenerationStatusMessageSchema = z.object({
   type: z.literal("get_card_generation_status"),
 });
 
-/**
- * Discriminated union of all client message types
- */
 export const ClientMessageSchema = z.discriminatedUnion("type", [
   SelectVaultMessageSchema,
   CreateVaultMessageSchema,
@@ -699,7 +453,6 @@ export const ClientMessageSchema = z.discriminatedUnion("type", [
   PingMessageSchema,
   ToolPermissionResponseMessageSchema,
   AskUserQuestionResponseMessageSchema,
-
   // Pair Writing Mode
   QuickActionRequestMessageSchema,
   AdvisoryActionRequestMessageSchema,
@@ -721,48 +474,34 @@ export const ClientMessageSchema = z.discriminatedUnion("type", [
 // Server -> Client Message Schemas
 // =============================================================================
 
-/**
- * Server sends the list of available vaults
- */
 export const VaultListMessageSchema = z.object({
   type: z.literal("vault_list"),
   vaults: z.array(VaultInfoSchema),
 });
 
-/**
- * Server confirms session is ready
- * Note: sessionId can be empty when vault is first selected (session created lazily)
- * When resuming a session, messages contains the conversation history.
- */
+// `sessionId` may be empty when a vault is first selected; the session is
+// created on the first discussion_message. On resume, `messages` carries
+// the conversation history.
 export const SessionReadyMessageSchema = z.object({
   type: z.literal("session_ready"),
-  sessionId: z.string(), // Can be empty - session created on first discussion_message
+  sessionId: z.string(),
   vaultId: z.string().min(1),
-  messages: z.array(ConversationMessageSchema).optional(), // Sent on resume
-  createdAt: z.string().optional(), // ISO 8601 timestamp of session creation
-  slashCommands: z.array(SlashCommandSchema).optional(), // Available slash commands
+  messages: z.array(ConversationMessageSchema).optional(),
+  createdAt: z.string().optional(),
+  slashCommands: z.array(SlashCommandSchema).optional(),
 });
 
-/**
- * Server signals start of AI response
- */
 export const ResponseStartMessageSchema = z.object({
   type: z.literal("response_start"),
   messageId: z.string().min(1),
 });
 
-/**
- * Server sends a chunk of the AI response
- */
 export const ResponseChunkMessageSchema = z.object({
   type: z.literal("response_chunk"),
   messageId: z.string().min(1),
   content: z.string(), // Can be empty for whitespace-only chunks
 });
 
-/**
- * Server signals end of AI response
- */
 export const ResponseEndMessageSchema = z.object({
   type: z.literal("response_end"),
   messageId: z.string().min(1),
@@ -770,82 +509,54 @@ export const ResponseEndMessageSchema = z.object({
   durationMs: z.number().int().min(0).optional(),
 });
 
-/**
- * Server signals start of tool invocation
- */
 export const ToolStartMessageSchema = z.object({
   type: z.literal("tool_start"),
   toolName: z.string().min(1),
   toolUseId: z.string().min(1),
 });
 
-/**
- * Server sends tool input parameters
- */
 export const ToolInputMessageSchema = z.object({
   type: z.literal("tool_input"),
   toolUseId: z.string().min(1),
   input: z.unknown(),
 });
 
-/**
- * Server signals end of tool invocation with output
- */
 export const ToolEndMessageSchema = z.object({
   type: z.literal("tool_end"),
   toolUseId: z.string().min(1),
   output: z.unknown(),
 });
 
-/**
- * Server sends an error message
- */
 export const ErrorMessageSchema = z.object({
   type: z.literal("error"),
   code: ErrorCodeSchema,
   message: z.string().min(1, "Error message is required"),
 });
 
-/**
- * Server responds to ping
- */
 export const PongMessageSchema = z.object({
   type: z.literal("pong"),
 });
 
-/**
- * Server requests permission from the user before running a tool
- * The client should display a dialog and respond with tool_permission_response
- */
+// Client should display a dialog and respond with tool_permission_response.
 export const ToolPermissionRequestMessageSchema = z.object({
   type: z.literal("tool_permission_request"),
-  /** Unique identifier for this tool invocation */
   toolUseId: z.string().min(1, "Tool use ID is required"),
-  /** Name of the tool being requested */
   toolName: z.string().min(1, "Tool name is required"),
-  /** Tool input parameters for user review */
   input: z.unknown(),
 });
 
-/**
- * Server requests user input via AskUserQuestion tool
- * The client should display a multi-question dialog and respond with ask_user_question_response
- */
+// Client should display a multi-question dialog and respond with
+// ask_user_question_response.
 export const AskUserQuestionRequestMessageSchema = z.object({
   type: z.literal("ask_user_question_request"),
-  /** Unique identifier for this tool invocation */
   toolUseId: z.string().min(1, "Tool use ID is required"),
-  /** Array of questions to present to the user (1-4 questions) */
+  // 1-4 questions.
   questions: z.array(AskUserQuestionItemSchema).min(1).max(4),
 });
 
-/**
- * Server confirms vault was created successfully.
- * Response to create_vault request.
- */
+// Response to create_vault.
 export const VaultCreatedMessageSchema = z.object({
   type: z.literal("vault_created"),
-  /** The newly created vault info */
   vault: VaultInfoSchema,
 });
 
@@ -853,72 +564,41 @@ export const VaultCreatedMessageSchema = z.object({
 // Memory Extraction Schemas
 // =============================================================================
 
-/**
- * Schema for extraction status enum values
- * - idle: No extraction running
- * - running: Extraction in progress
- * - complete: Extraction finished successfully
- * - error: Extraction failed
- */
 export const ExtractionStatusValueSchema = z.enum(["idle", "running", "complete", "error"]);
 
-/**
- * Server sends extraction prompt content (REQ-F-15)
- * Response to get_extraction_prompt request
- */
+// REQ-F-15: response to get_extraction_prompt.
+// `isOverride` is true when reading from ~/.config/memory-loop/extraction-prompt.md.
 export const ExtractionPromptContentMessageSchema = z.object({
   type: z.literal("extraction_prompt_content"),
-  /** Extraction prompt content */
   content: z.string(),
-  /** True if using user override at ~/.config/memory-loop/extraction-prompt.md */
   isOverride: z.boolean(),
 });
 
-/**
- * Server confirms extraction prompt was saved (REQ-F-16)
- * Response to save_extraction_prompt request
- */
+// REQ-F-16: response to save_extraction_prompt.
 export const ExtractionPromptSavedMessageSchema = z.object({
   type: z.literal("extraction_prompt_saved"),
-  /** Whether the save was successful */
   success: z.boolean(),
-  /** True if this created/updated user override */
   isOverride: z.boolean(),
-  /** Error message if success is false */
   error: z.string().optional(),
 });
 
-/**
- * Server confirms extraction prompt was reset to default (REQ-F-16)
- * Response to reset_extraction_prompt request
- */
+// REQ-F-16: response to reset_extraction_prompt.
+// `content` carries the default prompt so the UI can update without refetching.
 export const ExtractionPromptResetMessageSchema = z.object({
   type: z.literal("extraction_prompt_reset"),
-  /** Whether the reset was successful */
   success: z.boolean(),
-  /** The default prompt content (sent so UI can update without fetching again) */
   content: z.string(),
-  /** Error message if success is false */
   error: z.string().optional(),
 });
 
-/**
- * Server sends extraction status updates
- * Sent during extraction run (triggered manually or scheduled)
- */
+// Sent during extraction run (triggered manually or scheduled).
 export const ExtractionStatusMessageSchema = z.object({
   type: z.literal("extraction_status"),
-  /** Current extraction status */
   status: ExtractionStatusValueSchema,
-  /** Progress percentage (0-100) when status is "running" */
   progress: z.number().min(0).max(100).optional(),
-  /** Human-readable status message */
   message: z.string().optional(),
-  /** Error details when status is "error" */
   error: z.string().optional(),
-  /** Number of transcripts processed (on completion) */
   transcriptsProcessed: z.number().int().min(0).optional(),
-  /** Number of facts extracted (on completion) */
   factsExtracted: z.number().int().min(0).optional(),
 });
 
@@ -926,94 +606,46 @@ export const ExtractionStatusMessageSchema = z.object({
 // Card Generator Server Messages
 // =============================================================================
 
-/**
- * Schema for card generation status enum values
- * - idle: No generation running
- * - running: Generation in progress
- * - complete: Generation finished successfully
- * - error: Generation failed
- */
 export const CardGenerationStatusValueSchema = z.enum(["idle", "running", "complete", "error"]);
 
-/**
- * Server sends card generator config content
- * Response to get_card_generator_config request
- */
 export const CardGeneratorConfigContentMessageSchema = z.object({
   type: z.literal("card_generator_config_content"),
-  /** Requirements prompt content */
   requirements: z.string(),
-  /** True if using user override for requirements */
   isOverride: z.boolean(),
-  /** Weekly byte limit for card generation */
   weeklyByteLimit: z.number().int().min(0),
-  /** Bytes used this week */
   weeklyBytesUsed: z.number().int().min(0),
 });
 
-/**
- * Server confirms card generator requirements were saved
- * Response to save_card_generator_requirements request
- */
 export const CardGeneratorRequirementsSavedMessageSchema = z.object({
   type: z.literal("card_generator_requirements_saved"),
-  /** Whether the save was successful */
   success: z.boolean(),
-  /** True if this created/updated user override */
   isOverride: z.boolean(),
-  /** Error message if success is false */
   error: z.string().optional(),
 });
 
-/**
- * Server confirms card generator config was saved
- * Response to save_card_generator_config request
- */
 export const CardGeneratorConfigSavedMessageSchema = z.object({
   type: z.literal("card_generator_config_saved"),
-  /** Whether the save was successful */
   success: z.boolean(),
-  /** Error message if success is false */
   error: z.string().optional(),
 });
 
-/**
- * Server confirms card generator requirements were reset to default
- * Response to reset_card_generator_requirements request
- */
 export const CardGeneratorRequirementsResetMessageSchema = z.object({
   type: z.literal("card_generator_requirements_reset"),
-  /** Whether the reset was successful */
   success: z.boolean(),
-  /** The default requirements content */
   content: z.string(),
-  /** Error message if success is false */
   error: z.string().optional(),
 });
 
-/**
- * Server sends card generation status updates
- * Sent during generation run (triggered manually or scheduled)
- */
 export const CardGenerationStatusMessageSchema = z.object({
   type: z.literal("card_generation_status"),
-  /** Current generation status */
   status: CardGenerationStatusValueSchema,
-  /** Human-readable status message */
   message: z.string().optional(),
-  /** Error details when status is "error" */
   error: z.string().optional(),
-  /** Number of files processed (on completion) */
   filesProcessed: z.number().int().min(0).optional(),
-  /** Number of cards created (on completion) */
   cardsCreated: z.number().int().min(0).optional(),
-  /** Bytes processed (on completion) */
   bytesProcessed: z.number().int().min(0).optional(),
 });
 
-/**
- * Discriminated union of all server message types
- */
 export const ServerMessageSchema = z.discriminatedUnion("type", [
   VaultListMessageSchema,
   VaultCreatedMessageSchema,
@@ -1028,7 +660,6 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
   PongMessageSchema,
   ToolPermissionRequestMessageSchema,
   AskUserQuestionRequestMessageSchema,
-
   // Memory Extraction
   ExtractionPromptContentMessageSchema,
   ExtractionPromptSavedMessageSchema,
@@ -1046,49 +677,33 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
 // Inferred TypeScript Types
 // =============================================================================
 
-// File browser types
 export type FileEntry = z.infer<typeof FileEntrySchema>;
 
-// Task types
 export type TaskCategory = z.infer<typeof TaskCategorySchema>;
 export type TaskEntry = z.infer<typeof TaskEntrySchema>;
 
-// Recent notes types
 export type RecentNoteEntry = z.infer<typeof RecentNoteEntrySchema>;
-
-// Recent discussion types
 export type RecentDiscussionEntry = z.infer<typeof RecentDiscussionEntrySchema>;
 
-// Slash command type
 export type SlashCommand = z.infer<typeof SlashCommandSchema>;
 
-// Tool invocation type
 export type ToolInvocation = z.infer<typeof ToolInvocationSchema>;
-
-// Conversation message type
 export type ConversationMessageProtocol = z.infer<typeof ConversationMessageSchema>;
 
-// Search result types
 export type FileSearchResult = z.infer<typeof FileSearchResultSchema>;
 export type ContentSearchResult = z.infer<typeof ContentSearchResultSchema>;
 export type ContextSnippet = z.infer<typeof ContextSnippetSchema>;
 
-// Badge types
 export type Badge = z.infer<typeof BadgeSchema>;
 export type BadgeColor = z.infer<typeof BadgeColorSchema>;
 export type EditableBadge = z.infer<typeof EditableBadgeSchema>;
 
-// Vault config types
-export type DiscussionModel = z.infer<typeof DiscussionModelSchema>;
 export type EditableVaultConfig = z.infer<typeof EditableVaultConfigSchema>;
 
-// Meeting types
 export type MeetingState = z.infer<typeof MeetingStateSchema>;
 
-// Inspiration types (used by REST API)
 export type InspirationItem = z.infer<typeof InspirationItemSchema>;
 
-// Spaced repetition card types (used by REST API)
 export type ReviewResponse = z.infer<typeof ReviewResponseSchema>;
 export type DueCard = z.infer<typeof DueCardSchema>;
 export type CardDetail = z.infer<typeof CardDetailSchema>;
@@ -1115,10 +730,13 @@ export type QuickActionType = z.infer<typeof QuickActionTypeSchema>;
 export type AdvisoryActionType = z.infer<typeof AdvisoryActionTypeSchema>;
 export type QuickActionRequestMessage = z.infer<typeof QuickActionRequestMessageSchema>;
 export type AdvisoryActionRequestMessage = z.infer<typeof AdvisoryActionRequestMessageSchema>;
+
+// Memory Extraction client message types
 export type GetExtractionPromptMessage = z.infer<typeof GetExtractionPromptMessageSchema>;
 export type SaveExtractionPromptMessage = z.infer<typeof SaveExtractionPromptMessageSchema>;
 export type ResetExtractionPromptMessage = z.infer<typeof ResetExtractionPromptMessageSchema>;
 export type TriggerExtractionMessage = z.infer<typeof TriggerExtractionMessageSchema>;
+
 // Card Generator client message types
 export type GetCardGeneratorConfigMessage = z.infer<typeof GetCardGeneratorConfigMessageSchema>;
 export type SaveCardGeneratorRequirementsMessage = z.infer<typeof SaveCardGeneratorRequirementsMessageSchema>;
@@ -1142,11 +760,14 @@ export type ErrorMessage = z.infer<typeof ErrorMessageSchema>;
 export type PongMessage = z.infer<typeof PongMessageSchema>;
 export type ToolPermissionRequestMessage = z.infer<typeof ToolPermissionRequestMessageSchema>;
 export type AskUserQuestionRequestMessage = z.infer<typeof AskUserQuestionRequestMessageSchema>;
+
+// Memory Extraction server message types
 export type ExtractionStatusValue = z.infer<typeof ExtractionStatusValueSchema>;
 export type ExtractionPromptContentMessage = z.infer<typeof ExtractionPromptContentMessageSchema>;
 export type ExtractionPromptSavedMessage = z.infer<typeof ExtractionPromptSavedMessageSchema>;
 export type ExtractionPromptResetMessage = z.infer<typeof ExtractionPromptResetMessageSchema>;
 export type ExtractionStatusMessage = z.infer<typeof ExtractionStatusMessageSchema>;
+
 // Card Generator server message types
 export type CardGenerationStatusValue = z.infer<typeof CardGenerationStatusValueSchema>;
 export type CardGeneratorConfigContentMessage = z.infer<typeof CardGeneratorConfigContentMessageSchema>;
@@ -1160,32 +781,20 @@ export type ServerMessage = z.infer<typeof ServerMessageSchema>;
 // Validation Utilities
 // =============================================================================
 
-/**
- * Parse and validate a client message from JSON
- * @throws ZodError if validation fails
- */
+/** Parse a client message. Throws ZodError if validation fails. */
 export function parseClientMessage(data: unknown): ClientMessage {
   return ClientMessageSchema.parse(data);
 }
 
-/**
- * Parse and validate a server message from JSON
- * @throws ZodError if validation fails
- */
+/** Parse a server message. Throws ZodError if validation fails. */
 export function parseServerMessage(data: unknown): ServerMessage {
   return ServerMessageSchema.parse(data);
 }
 
-/**
- * Safely parse a client message, returning success/error result
- */
 export function safeParseClientMessage(data: unknown) {
   return ClientMessageSchema.safeParse(data);
 }
 
-/**
- * Safely parse a server message, returning success/error result
- */
 export function safeParseServerMessage(data: unknown) {
   return ServerMessageSchema.safeParse(data);
 }

--- a/packages/shared/src/schemas/types.ts
+++ b/packages/shared/src/schemas/types.ts
@@ -1,13 +1,12 @@
 /**
  * Memory Loop Shared Types
  *
- * Core type definitions for Vault and Session models.
- * These types are used by both frontend and backend.
+ * Core type definitions for Vault, Session, and Message models.
+ * Used by both frontend and backend.
  */
 
 /**
- * Named colors for custom badges.
- * These map to theme CSS variables for consistent styling.
+ * Named colors for custom badges. Map to theme CSS variables.
  */
 export type BadgeColor =
   | "black"
@@ -19,12 +18,6 @@ export type BadgeColor =
   | "green"
   | "yellow";
 
-/**
- * A custom badge configured in .memory-loop.json.
- *
- * @property text - The badge label text
- * @property color - Named color from the theme palette
- */
 export interface Badge {
   text: string;
   color: BadgeColor;
@@ -33,24 +26,10 @@ export interface Badge {
 /**
  * Information about an Obsidian vault discovered by the backend.
  *
- * @property id - Directory name (unique identifier)
- * @property name - Human-readable name (title portion before " - " or full heading)
- * @property subtitle - Optional subtitle (portion after " - " in heading)
- * @property path - Absolute path to the vault root directory
- * @property hasClaudeMd - Whether the vault has a CLAUDE.md file
- * @property contentRoot - Absolute path to content root (may differ from path if configured)
- * @property inboxPath - Resolved inbox location for daily notes (relative to contentRoot)
- * @property metadataPath - Path to metadata directory (relative to contentRoot)
- * @property goalsPath - Path to goals.md if it exists (relative to contentRoot)
- * @property attachmentPath - Path to attachments directory for uploads (relative to contentRoot)
- * @property setupComplete - Whether vault setup has been completed (marker file exists)
- * @property promptsPerGeneration - Number of prompts to generate per cycle (default: 5)
- * @property maxPoolSize - Maximum items to keep in inspiration pools (default: 50)
- * @property quotesPerWeek - Number of quotes to generate per week (default: 1)
- * @property badges - Custom badges configured in .memory-loop.json
- * @property order - Display order for vault selection (lower values first, Infinity for unset)
- * @property cardsEnabled - Whether spaced repetition card discovery is enabled (default: true)
- * @property viMode - Whether vi mode is enabled for Pair Writing editor (default: false)
+ * `path` is the vault root; `contentRoot` is the content directory (may differ
+ * if configured). All sub-paths (inboxPath, metadataPath, etc.) are relative
+ * to `contentRoot`. `order` may be `Infinity` for vaults without an explicit
+ * order, sorting them last.
  */
 export interface VaultInfo {
   id: string;
@@ -64,7 +43,7 @@ export interface VaultInfo {
   goalsPath?: string;
   attachmentPath: string;
   setupComplete: boolean;
-  discussionModel?: "opus" | "sonnet" | "haiku";
+  discussionModel?: string;
   promptsPerGeneration: number;
   maxPoolSize: number;
   quotesPerWeek: number;
@@ -76,15 +55,6 @@ export interface VaultInfo {
   viMode: boolean;
 }
 
-/**
- * A tool invocation within an assistant message.
- *
- * @property toolUseId - Unique ID for this tool invocation
- * @property toolName - Name of the tool that was invoked
- * @property input - Tool input parameters (optional)
- * @property output - Tool output/result (optional)
- * @property status - Whether the tool is running or complete
- */
 export interface StoredToolInvocation {
   toolUseId: string;
   toolName: string;
@@ -96,15 +66,8 @@ export interface StoredToolInvocation {
 /**
  * A message in the conversation history.
  *
- * Stored server-side in session files and sent to frontend on resume.
- *
- * @property id - Unique message ID
- * @property role - Who sent the message
- * @property content - Message text content
- * @property timestamp - ISO 8601 timestamp
- * @property toolInvocations - Tool invocations for assistant messages (optional)
- * @property contextUsage - Percentage of context window used (0-100, assistant messages only)
- * @property durationMs - Turn duration in milliseconds (assistant messages only)
+ * Stored server-side in session files and sent to the frontend on resume.
+ * `contextUsage` and `durationMs` are only set for assistant messages.
  */
 export interface ConversationMessage {
   id: string;
@@ -119,18 +82,8 @@ export interface ConversationMessage {
 /**
  * Metadata for a Claude Agent SDK session.
  *
- * Session data is stored in `.memory-loop/sessions/` as JSON files.
- * The actual conversation state is managed by the Claude Agent SDK.
- *
- * @property id - Claude Agent SDK session ID
- * @property vaultId - Vault directory name
- * @property vaultPath - Absolute path to the vault
- * @property createdAt - ISO 8601 timestamp of session creation
- * @property lastActiveAt - ISO 8601 timestamp of last activity
- * @property messages - Conversation history for this session
- * @property activeModel - Model identifier captured from SDK (optional)
- * @property transcriptPath - Path to transcript markdown file in vault (optional)
- * @property piSessionPath - Absolute path to the pi-agent JSONL session file (optional)
+ * Stored as JSON in `.memory-loop/sessions/`. Conversation state lives in
+ * the SDK; we persist enough to resume and render history.
  */
 export interface SessionMetadata {
   id: string;
@@ -144,19 +97,10 @@ export interface SessionMetadata {
   piSessionPath?: string;
 }
 
-/**
- * Result type for vault config save operations.
- */
 export type SaveConfigResult =
   | { success: true }
   | { success: false; error: string };
 
-/**
- * Error codes for the WebSocket protocol.
- *
- * These codes provide structured error information for clients
- * to handle specific error conditions appropriately.
- */
 export type ErrorCode =
   | "VAULT_NOT_FOUND"
   | "VAULT_ACCESS_DENIED"

--- a/packages/shared/src/vault-config.ts
+++ b/packages/shared/src/vault-config.ts
@@ -1,15 +1,18 @@
 /**
  * Vault Configuration Types and Resolvers
  *
- * Pure types and derivation functions for vault configuration.
- * No I/O operations. Used by both daemon and nextjs.
+ * Pure types and derivation functions for vault configuration. No I/O.
+ * Used by both daemon and nextjs.
+ *
+ * NOTE: resolveContentRoot uses node:path for security (normalize/join) and
+ * lives in vault-config-server.ts, exported from "@memory-loop/shared/server".
  */
 
 import type { Badge, BadgeColor } from "./schemas/types";
+import type { SlashCommand } from "./schemas/protocol";
 
 /**
- * Per-vault configuration options.
- * All paths are relative to the vault root directory.
+ * Per-vault configuration. All paths are relative to the vault root.
  */
 export interface VaultConfig {
   title?: string;
@@ -33,8 +36,6 @@ export interface VaultConfig {
   viMode?: boolean;
 }
 
-// --- Constants ---
-
 export const CONFIG_FILE_NAME = ".memory-loop.json";
 export const SLASH_COMMANDS_FILE = ".memory-loop/slash-commands.json";
 export const DEFAULT_METADATA_PATH = "06_Metadata/memory-loop";
@@ -46,9 +47,6 @@ export const DEFAULT_MAX_POOL_SIZE = 50;
 export const DEFAULT_QUOTES_PER_WEEK = 1;
 export const DEFAULT_RECENT_CAPTURES = 5;
 export const DEFAULT_RECENT_DISCUSSIONS = 5;
-export const VALID_DISCUSSION_MODELS = ["opus", "sonnet", "haiku"] as const;
-export type DiscussionModelLocal = (typeof VALID_DISCUSSION_MODELS)[number];
-export const DEFAULT_DISCUSSION_MODEL: DiscussionModelLocal = "opus";
 export const DEFAULT_ORDER = 999999;
 export const DEFAULT_CARDS_ENABLED = true;
 export const DEFAULT_VI_MODE = false;
@@ -63,10 +61,6 @@ export const VALID_BADGE_COLORS: BadgeColor[] = [
   "green",
   "yellow",
 ];
-
-// --- Resolver functions ---
-// NOTE: resolveContentRoot uses node:path for security (normalize/join).
-// It lives in vault-config-server.ts and is exported from @memory-loop/shared/server.
 
 export function resolveMetadataPath(config: VaultConfig): string {
   return config.metadataPath ?? DEFAULT_METADATA_PATH;
@@ -124,10 +118,6 @@ export function resolveRecentDiscussions(config: VaultConfig): number {
   return config.recentDiscussions ?? DEFAULT_RECENT_DISCUSSIONS;
 }
 
-export function resolveDiscussionModel(config: VaultConfig): DiscussionModelLocal {
-  return (config.discussionModel as DiscussionModelLocal | undefined) ?? DEFAULT_DISCUSSION_MODEL;
-}
-
 export function resolveOrder(config: VaultConfig): number {
   return config.order ?? DEFAULT_ORDER;
 }
@@ -139,10 +129,6 @@ export function resolveCardsEnabled(config: VaultConfig): boolean {
 export function resolveViMode(config: VaultConfig): boolean {
   return config.viMode ?? DEFAULT_VI_MODE;
 }
-
-// --- Utility functions ---
-
-import type { SlashCommand } from "./schemas/protocol";
 
 export function slashCommandsEqual(
   a: SlashCommand[] | undefined,


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `DiscussionModel` enum and `DISCUSSION_MODEL_MAP` with a runtime registry loaded from `memory-loop-config.json` at daemon startup
- Vaults store a plain model name string resolved against the registry at session-creation time; unset vaults fall through to pi-agent's own default instead of always using opus
- Model dropdown in vault settings is now dynamic: fetches from the daemon, shows "No models configured." when empty, and renders `<name> (unknown)` for stale/unknown values

## What changed

**New:**
- `daemon/src/global-config.ts` — registry module; reads from `MEMORY_LOOP_CONFIG` env var or `${VAULTS_DIR}/memory-loop-config.json`; missing/malformed config is non-fatal
- `GET /models` route in daemon + Next.js proxy at `/api/models`
- `nextjs/lib/daemon/models.ts` — `ModelEntry` type + `getModels()` client

**Removed from shared:**
- `DiscussionModelSchema` (Zod enum), `VALID_DISCUSSION_MODELS`, `DEFAULT_DISCUSSION_MODEL`, `resolveDiscussionModel()`
- `discussionModel` is now `string | undefined` everywhere

**Updated:**
- `session-manager.ts` — `resolveModelForPiAgent()` looks up `getRegistry()` instead of a local map; unknown names log a warning and return `undefined`
- `ConfigEditorDialog.tsx` — dynamic dropdown replacing hardcoded opus/sonnet/haiku options
- All dependent tests updated; test injection via `configureRegistryForTesting` / `_resetRegistryForTesting`

## Test plan

- [ ] `bun run test` — 2042 tests, 0 failures
- [ ] `bun run typecheck` — clean across all packages
- [ ] Start daemon with no config file → `GET /api/models` returns `{ "models": [] }`, no fatal errors
- [ ] Write `${VAULTS_DIR}/memory-loop-config.json` with model entries, restart daemon → dropdown shows them
- [ ] Set vault `discussionModel` to a name not in registry → session starts, warning logged, no crash
- [ ] Leave `discussionModel` unset → session starts with pi-agent default, no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)